### PR TITLE
[v2] feat: Add account and role filtering in aws configure sso

### DIFF
--- a/awscli/customizations/configure/sso_commands.py
+++ b/awscli/customizations/configure/sso_commands.py
@@ -208,11 +208,16 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
     def _handle_multiple_accounts(self, accounts):
         available_accounts_msg = (
             'There are {} AWS accounts available to you.\n'
+            'Use arrow keys to navigate, type to filter, '
+            'and press Enter to select.\n'
         )
         uni_print(available_accounts_msg.format(len(accounts)))
         sorted_accounts = sorted(accounts, key=get_account_sorting_key)
         selected_account = self._selector(
-            sorted_accounts, display_format=display_account
+            sorted_accounts,
+            display_format=display_account,
+            enable_filter=True,
+            no_results_message='No matching accounts found',
         )
         sso_account_id = selected_account['accountId']
         return sso_account_id
@@ -241,11 +246,19 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
         return sso_role_name
 
     def _handle_multiple_roles(self, roles):
-        available_roles_msg = 'There are {} roles available to you.\n'
+        available_roles_msg = (
+            'There are {} roles available to you.\n'
+            'Use arrow keys to navigate, type to filter, '
+            'and press Enter to select.\n'
+        )
         uni_print(available_roles_msg.format(len(roles)))
         sorted_roles = sorted(roles, key=lambda x: x['roleName'].lower())
         role_names = [r['roleName'] for r in sorted_roles]
-        sso_role_name = self._selector(role_names)
+        sso_role_name = self._selector(
+            role_names,
+            enable_filter=True,
+            no_results_message='No matching roles found',
+        )
         return sso_role_name
 
     def _get_all_roles(self, sso, sso_token, sso_account_id):

--- a/awscli/customizations/wizard/ui/selectmenu.py
+++ b/awscli/customizations/wizard/ui/selectmenu.py
@@ -13,17 +13,28 @@
 from prompt_toolkit import Application
 from prompt_toolkit.application import get_app
 from prompt_toolkit.buffer import Buffer
-from prompt_toolkit.key_binding.key_bindings import KeyBindings
+from prompt_toolkit.key_binding.key_bindings import (
+    KeyBindings,
+    merge_key_bindings,
+)
 from prompt_toolkit.layout import Float, FloatContainer, Layout
-from prompt_toolkit.layout.containers import ScrollOffsets, Window
-from prompt_toolkit.layout.controls import UIContent, UIControl
+from prompt_toolkit.layout.containers import HSplit, ScrollOffsets, Window
+from prompt_toolkit.layout.controls import BufferControl, UIContent, UIControl
 from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.margins import ScrollbarMargin
 from prompt_toolkit.layout.screen import Point
 from prompt_toolkit.utils import get_cwidth
 
+SEARCH_PROMPT = 'Search: '
 
-def select_menu(items, display_format=None, max_height=10):
+
+def select_menu(
+    items,
+    display_format=None,
+    max_height=10,
+    enable_filter=False,
+    no_results_message=None,
+):
     """Presents a list of options and allows the user to select one.
 
     This presents a static list of options and prompts the user to select one.
@@ -42,32 +53,79 @@ def select_menu(items, display_format=None, max_height=10):
     :type max_height: int
     :param max_height: The max number of items to show in the list at a time.
 
+    :type enable_filter: bool
+    :param enable_filter: Show a search bar above the menu that lets the user
+    narrow the list down by typing.
+
+    :type no_results_message: str
+    :param no_results_message: Message to show when the filter matches no
+    items. Only used when ``enable_filter`` is set.
+
     :returns: The selected element from the items list.
     """
+    if callable(items):
+        items = items()
+
     app_bindings = KeyBindings()
 
     @app_bindings.add('c-c')
     def exit_app(event):
         event.app.exit(exception=KeyboardInterrupt, style='class:aborting')
 
-    min_height = min(max_height, len(items))
+    if enable_filter:
+        menu_control = FilterableSelectionMenuControl(
+            items,
+            display_format=display_format,
+            no_results_message=no_results_message,
+        )
+    else:
+        menu_control = SelectionMenuControl(
+            items,
+            display_format=display_format,
+        )
+
+    menu_height = min(max_height, len(items))
     menu_window = Window(
-        SelectionMenuControl(items, display_format=display_format),
-        always_hide_cursor=False,
-        height=Dimension(min=min_height, max=min_height),
+        menu_control,
+        # The cursor belongs in the search bar when filtering is enabled.
+        always_hide_cursor=enable_filter,
+        height=Dimension(min=menu_height, max=menu_height),
         scroll_offsets=ScrollOffsets(),
         right_margins=[ScrollbarMargin()],
     )
+
+    if enable_filter:
+        # The search bar takes up an extra line above the menu. Menu
+        # navigation is bound at the application level because the search
+        # buffer, not the menu, holds the focus.
+        search_window = Window(
+            BufferControl(buffer=menu_control.filter_buffer),
+            height=Dimension.exact(1),
+            get_line_prefix=lambda line_number, wrap_count: [
+                ('class:filter', SEARCH_PROMPT)
+            ],
+        )
+        float_content = HSplit([search_window, menu_window])
+        focused_element = search_window
+        min_height = menu_height + 1
+        key_bindings = merge_key_bindings(
+            [app_bindings, menu_control.get_key_bindings()]
+        )
+    else:
+        float_content = menu_window
+        focused_element = None
+        min_height = menu_height
+        key_bindings = app_bindings
 
     # Using a FloatContainer was the only way I was able to succesfully
     # limit the height and width of the window.
     content = FloatContainer(
         Window(height=Dimension(min=min_height, max=min_height)),
-        [Float(menu_window, top=0, left=0)],
+        [Float(float_content, top=0, left=0)],
     )
     app = Application(
-        layout=Layout(content),
-        key_bindings=app_bindings,
+        layout=Layout(content, focused_element=focused_element),
+        key_bindings=key_bindings,
         erase_when_done=True,
     )
     return app.run()
@@ -120,11 +178,15 @@ class SelectionMenuControl(UIControl):
     def is_focusable(self):
         return True
 
+    def _display_text(self, item):
+        if self._display_format:
+            return self._display_format(item)
+        return item
+
     def preferred_width(self, max_width):
         items = self._get_items()
-        if self._display_format:
-            items = (self._display_format(i) for i in items)
-        max_item_width = max(get_cwidth(i) for i in items)
+        widths = [get_cwidth(self._display_text(i)) for i in items]
+        max_item_width = max(widths, default=0)
         max_item_width += self._format_overhead
         if max_item_width < self.MIN_WIDTH:
             max_item_width = self.MIN_WIDTH
@@ -146,7 +208,7 @@ class SelectionMenuControl(UIControl):
 
         text, tw = _trim_text(item, menu_width - self._format_overhead)
         padding = ' ' * (menu_width - self._format_overhead - tw)
-        return [(style_str, '%s %s%s  ' % (cursor, text, padding))]
+        return [(style_str, f'{cursor} {text}{padding}  ')]
 
     def create_content(self, width, height):
         def get_line(i):
@@ -184,6 +246,132 @@ class SelectionMenuControl(UIControl):
         def app_result(event):
             result = self._get_items()[self._selection]
             event.app.exit(result=result)
+
+        return kb
+
+
+class FilterableSelectionMenuControl(SelectionMenuControl):
+    """Menu that supports filtering its items with a search buffer.
+
+    The search text is stored in a ``prompt_toolkit`` ``Buffer``. This means
+    all text editing behavior (unicode input, bracketed pastes, cursor
+    movement and the standard readline shortcuts such as ``Ctrl-U`` and
+    ``Ctrl-W``) is handled by ``prompt_toolkit`` instead of being
+    reimplemented here.
+    """
+
+    DEFAULT_NO_RESULTS_MESSAGE = 'No matching items found'
+
+    def __init__(
+        self,
+        items,
+        display_format=None,
+        cursor='>',
+        no_results_message=None,
+        filter_buffer=None,
+    ):
+        super().__init__(items, display_format=display_format, cursor=cursor)
+        self._no_results_message = (
+            no_results_message or self.DEFAULT_NO_RESULTS_MESSAGE
+        )
+        self._filtered_items = None
+        if filter_buffer is None:
+            filter_buffer = Buffer(multiline=False)
+        self.filter_buffer = filter_buffer
+        self.filter_buffer.on_text_changed += self._on_filter_text_changed
+
+    @property
+    def filter_text(self):
+        return self.filter_buffer.text
+
+    def _get_items(self):
+        """Return the items matching the current filter text."""
+        if self._filtered_items is None:
+            self._filtered_items = self._filter_items(super()._get_items())
+        return self._filtered_items
+
+    def _filter_items(self, items):
+        filter_text = self.filter_text.strip().lower()
+        if not filter_text:
+            return list(items)
+        return [
+            item
+            for item in items
+            if filter_text in str(self._display_text(item)).lower()
+        ]
+
+    def _on_filter_text_changed(self, buffer=None):
+        # Keep the previously highlighted item selected when it survives the
+        # new filter, otherwise fall back to the first match. The previous
+        # selection is read from the cached list because it still reflects
+        # the filter text from before this change.
+        previously_selected = None
+        if self._filtered_items and self._selection < len(
+            self._filtered_items
+        ):
+            previously_selected = self._filtered_items[self._selection]
+        self._filtered_items = None
+        self._selection = 0
+        if previously_selected is not None:
+            for i, item in enumerate(self._get_items()):
+                if item == previously_selected:
+                    self._selection = i
+                    break
+
+    def selected_item(self):
+        """The highlighted item, or ``None`` when nothing matches the filter."""
+        items = self._get_items()
+        if not items:
+            return None
+        if self._selection >= len(items):
+            self._selection = 0
+        return items[self._selection]
+
+    def move_selection(self, delta):
+        if self._get_items():
+            self._move_cursor(delta)
+
+    def preferred_width(self, max_width):
+        width = max(
+            super().preferred_width(max_width),
+            get_cwidth(self._no_results_message) + self._format_overhead,
+        )
+        return min(max_width, width)
+
+    def preferred_height(self, width, max_height, wrap_lines, get_line_prefix):
+        return min(max_height, max(1, len(self._get_items())))
+
+    def create_content(self, width, height):
+        if self._get_items():
+            return super().create_content(width, height)
+
+        def get_line(i):
+            if i == 0:
+                return [('class:no-results', f' {self._no_results_message}')]
+            return [('', '')]
+
+        return UIContent(
+            get_line=get_line,
+            cursor_position=Point(x=0, y=0),
+            line_count=1,
+        )
+
+    def get_key_bindings(self):
+        kb = KeyBindings()
+
+        @kb.add('up')
+        def move_up(event):
+            self.move_selection(-1)
+
+        @kb.add('down')
+        def move_down(event):
+            self.move_selection(1)
+
+        @kb.add('enter')
+        def app_result(event):
+            selected = self.selected_item()
+            if selected is not None:
+                event.app.exit(result=selected)
 
         return kb
 

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -793,12 +793,15 @@ class PTKStubber:
     _ALLOWED_SELECT_MENU_KWARGS = {
         "display_format",
         "max_height",
+        "enable_filter",
+        "no_results_message",
     }
 
     def __init__(self, user_inputs=None):
         if user_inputs is None:
             user_inputs = UserInputs()
         self.user_inputs = user_inputs
+        self.select_menu_calls = []
         self._expected_inputs = None
 
     def prompt(self, message, **kwargs):
@@ -833,6 +836,7 @@ class PTKStubber:
     def select_menu(self, items, **kwargs):
         self._initialize_expected_inputs_if_needed()
         self._validate_kwargs(kwargs, self._ALLOWED_SELECT_MENU_KWARGS)
+        self.select_menu_calls.append(kwargs)
         if not self._expected_inputs:
             raise AssertionError(
                 f'Received select_menu with no stubbed answer: "{items}"'
@@ -1529,6 +1533,104 @@ class TestConfigureSSOCommand:
         )
         sso_cmd = sso_cmd_factory(session=session)
         assert sso_cmd(args, parsed_globals) == 0
+
+    def test_multiple_accounts_uses_filterable_menu(
+        self,
+        sso_cmd,
+        ptk_stubber,
+        aws_config,
+        stub_sso_list_roles,
+        stub_sso_list_accounts,
+        mock_do_sso_login,
+        botocore_session,
+        args,
+        parsed_globals,
+        configure_sso_legacy_inputs,
+        capsys,
+    ):
+        """Test that multiple accounts selection shows filter instructions"""
+        inputs = configure_sso_legacy_inputs
+        selected_account_id = inputs.account_id_select.answer["accountId"]
+        ptk_stubber.user_inputs = inputs
+
+        stub_sso_list_accounts(inputs.account_id_select.expected_choices)
+        stub_sso_list_roles(
+            inputs.role_name_select.expected_choices,
+            expected_account_id=selected_account_id,
+        )
+
+        sso_cmd(args, parsed_globals)
+
+        stdout = capsys.readouterr().out
+        assert "Use arrow keys to navigate, type to filter" in stdout
+        assert "There are 2 AWS accounts available to you" in stdout
+        assert ptk_stubber.select_menu_calls[0]["enable_filter"] is True
+        assert (
+            ptk_stubber.select_menu_calls[0]["no_results_message"]
+            == "No matching accounts found"
+        )
+
+    def test_multiple_roles_uses_filterable_menu(
+        self,
+        sso_cmd,
+        ptk_stubber,
+        aws_config,
+        stub_sso_list_roles,
+        stub_sso_list_accounts,
+        mock_do_sso_login,
+        botocore_session,
+        args,
+        parsed_globals,
+        configure_sso_legacy_inputs,
+        capsys,
+    ):
+        """Test that multiple roles selection is filterable as well"""
+        inputs = configure_sso_legacy_inputs
+        selected_account_id = inputs.account_id_select.answer["accountId"]
+        ptk_stubber.user_inputs = inputs
+
+        stub_sso_list_accounts(inputs.account_id_select.expected_choices)
+        stub_sso_list_roles(
+            inputs.role_name_select.expected_choices,
+            expected_account_id=selected_account_id,
+        )
+
+        sso_cmd(args, parsed_globals)
+
+        stdout = capsys.readouterr().out
+        assert "There are 2 roles available to you" in stdout
+        role_menu_kwargs = ptk_stubber.select_menu_calls[1]
+        assert role_menu_kwargs["enable_filter"] is True
+        assert (
+            role_menu_kwargs["no_results_message"] == "No matching roles found"
+        )
+
+    def test_single_account_does_not_use_filterable_menu(
+        self,
+        sso_cmd,
+        ptk_stubber,
+        aws_config,
+        stub_simple_single_item_sso_responses,
+        mock_do_sso_login,
+        botocore_session,
+        args,
+        parsed_globals,
+        configure_sso_legacy_inputs,
+        account_id,
+        role_name,
+        capsys,
+    ):
+        """Test that single account does not show filter instructions"""
+        inputs = configure_sso_legacy_inputs
+        inputs.skip_account_and_role_selection()
+        ptk_stubber.user_inputs = inputs
+        stub_simple_single_item_sso_responses(account_id, role_name)
+
+        sso_cmd(args, parsed_globals)
+
+        stdout = capsys.readouterr().out
+        assert "Use arrow keys to navigate, type to filter" not in stdout
+        assert "The only AWS account available to you is" in stdout
 
     def test_single_account_single_role_device_code_fallback(
         self,

--- a/tests/unit/customizations/wizard/ui/test_filterable_menu.py
+++ b/tests/unit/customizations/wizard/ui/test_filterable_menu.py
@@ -1,0 +1,399 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.layout.containers import Window, to_container
+from prompt_toolkit.layout.controls import BufferControl
+
+from awscli.customizations.wizard.ui.selectmenu import (
+    FilterableSelectionMenuControl,
+    SelectionMenuControl,
+    select_menu,
+)
+
+UP = '\x1b[A'
+DOWN = '\x1b[B'
+ENTER = '\r'
+BACKSPACE = '\x7f'
+CTRL_U = '\x15'
+
+
+def _walk_windows(container):
+    container = to_container(container)
+    yield container
+    for child in container.get_children():
+        yield from _walk_windows(child)
+
+
+def _find_controls(container, control_type):
+    return [
+        window.content
+        for window in _walk_windows(container)
+        if isinstance(window, Window)
+        and isinstance(window.content, control_type)
+    ]
+
+
+class TestFilterableSelectionMenuControl(unittest.TestCase):
+    def setUp(self):
+        self.items = [
+            {'id': '1', 'name': 'Production', 'env': 'prod'},
+            {'id': '2', 'name': 'Development', 'env': 'dev'},
+            {'id': '3', 'name': 'Staging', 'env': 'stage'},
+            {'id': '4', 'name': 'Testing', 'env': 'test'},
+        ]
+        self.display_format = lambda item: f"{item['name']} ({item['env']})"
+        self.control = FilterableSelectionMenuControl(
+            self.items, display_format=self.display_format
+        )
+
+    def _filter(self, text):
+        self.control.filter_buffer.text = text
+
+    def _names(self):
+        return [item['name'] for item in self.control._get_items()]
+
+    def test_no_filter_shows_all_items(self):
+        self.assertEqual(self.control.filter_text, '')
+        self.assertEqual(self.control._get_items(), self.items)
+        self.assertEqual(self.control._selection, 0)
+
+    def test_default_no_results_message(self):
+        self.assertEqual(
+            self.control._no_results_message,
+            FilterableSelectionMenuControl.DEFAULT_NO_RESULTS_MESSAGE,
+        )
+
+    def test_filter_matching(self):
+        self._filter('prod')
+        self.assertEqual(self._names(), ['Production'])
+
+    def test_filter_no_match(self):
+        self._filter('xyz')
+        self.assertEqual(self.control._get_items(), [])
+        self.assertIsNone(self.control.selected_item())
+
+    def test_filter_is_case_insensitive(self):
+        self._filter('DEV')
+        self.assertEqual(self._names(), ['Development'])
+
+    def test_filter_partial_match(self):
+        self._filter('ing')
+        self.assertEqual(self._names(), ['Staging', 'Testing'])
+
+    def test_filter_uses_display_format(self):
+        # 'stage' only appears in the formatted text, not in the name.
+        self._filter('stage')
+        self.assertEqual(self._names(), ['Staging'])
+
+    def test_clearing_filter_restores_all_items(self):
+        self._filter('prod')
+        self._filter('')
+        self.assertEqual(self.control._get_items(), self.items)
+
+    def test_surrounding_whitespace_is_ignored(self):
+        self._filter('  prod  ')
+        self.assertEqual(self._names(), ['Production'])
+
+    def test_filter_supports_non_ascii_text(self):
+        items = ['東京アカウント', 'osaka-account', 'café-account']
+        control = FilterableSelectionMenuControl(items)
+        control.filter_buffer.text = '東京'
+        self.assertEqual(control._get_items(), ['東京アカウント'])
+        control.filter_buffer.text = 'café'
+        self.assertEqual(control._get_items(), ['café-account'])
+
+    def test_filter_supports_pasted_text(self):
+        # A bracketed paste arrives as a single insert_text call.
+        self.control.filter_buffer.insert_text('Development')
+        self.assertEqual(self._names(), ['Development'])
+
+    def test_selection_is_preserved_when_item_still_matches(self):
+        self.control._selection = 2  # Staging
+        self._filter('ing')
+        self.assertEqual(
+            self.control.selected_item()['name'],
+            'Staging',
+        )
+
+    def test_selection_resets_when_item_filtered_out(self):
+        self.control._selection = 3  # Testing
+        self._filter('prod')
+        self.assertEqual(self.control._selection, 0)
+        self.assertEqual(self.control.selected_item()['name'], 'Production')
+
+    def test_move_selection_wraps_within_filtered_items(self):
+        self._filter('ing')
+        self.control.move_selection(1)
+        self.assertEqual(self.control.selected_item()['name'], 'Testing')
+        self.control.move_selection(1)
+        self.assertEqual(self.control.selected_item()['name'], 'Staging')
+        self.control.move_selection(-1)
+        self.assertEqual(self.control.selected_item()['name'], 'Testing')
+
+    def test_move_selection_is_a_noop_without_matches(self):
+        self._filter('xyz')
+        self.control.move_selection(1)
+        self.assertIsNone(self.control.selected_item())
+
+    def test_accepts_callable_items(self):
+        control = FilterableSelectionMenuControl(lambda: ['alpha', 'beta'])
+        self.assertEqual(control._get_items(), ['alpha', 'beta'])
+        control.filter_buffer.text = 'al'
+        self.assertEqual(control._get_items(), ['alpha'])
+        self.assertGreater(control.preferred_width(80), 0)
+
+    def test_accepts_external_filter_buffer(self):
+        buffer = Buffer(multiline=False)
+        control = FilterableSelectionMenuControl(
+            self.items,
+            display_format=self.display_format,
+            filter_buffer=buffer,
+        )
+        buffer.text = 'dev'
+        self.assertEqual(
+            [item['name'] for item in control._get_items()], ['Development']
+        )
+
+    def test_content_renders_items_without_a_search_line(self):
+        content = self.control.create_content(50, 10)
+        self.assertEqual(content.line_count, len(self.items))
+        self.assertIn('Production', content.get_line(0)[0][1])
+
+    def test_content_renders_no_results_message(self):
+        self._filter('xyz')
+        content = self.control.create_content(50, 10)
+        self.assertEqual(content.line_count, 1)
+        style, text = content.get_line(0)[0]
+        self.assertEqual(style, 'class:no-results')
+        self.assertIn(
+            FilterableSelectionMenuControl.DEFAULT_NO_RESULTS_MESSAGE, text
+        )
+
+    def test_custom_no_results_message(self):
+        message = 'No AWS accounts match your search'
+        control = FilterableSelectionMenuControl(
+            self.items, no_results_message=message
+        )
+        control.filter_buffer.text = 'xyz'
+        content = control.create_content(50, 10)
+        self.assertIn(message, content.get_line(0)[0][1])
+
+    def test_preferred_height_reserves_a_line_for_no_results(self):
+        self._filter('xyz')
+        self.assertEqual(self.control.preferred_height(50, 10, False, None), 1)
+
+    def test_preferred_height_tracks_filtered_items(self):
+        self._filter('ing')
+        self.assertEqual(self.control.preferred_height(50, 10, False, None), 2)
+
+    def test_preferred_width_fits_no_results_message(self):
+        message = 'a much longer no results message than any item'
+        control = FilterableSelectionMenuControl(
+            ['a', 'b'], no_results_message=message
+        )
+        control.filter_buffer.text = 'xyz'
+        self.assertGreaterEqual(control.preferred_width(200), len(message))
+
+    def test_empty_items(self):
+        control = FilterableSelectionMenuControl([])
+        self.assertEqual(control._get_items(), [])
+        self.assertIsNone(control.selected_item())
+        self.assertGreater(control.preferred_width(100), 0)
+
+    def test_key_bindings_only_handle_navigation(self):
+        kb = self.control.get_key_bindings()
+        bound = {str(key) for binding in kb.bindings for key in binding.keys}
+        self.assertEqual(bound, {'Keys.Up', 'Keys.Down', 'Keys.ControlM'})
+
+    def test_enter_exits_with_selected_item(self):
+        kb = self.control.get_key_bindings()
+        enter = next(
+            b for b in kb.bindings if str(b.keys[0]) == 'Keys.ControlM'
+        )
+        self._filter('dev')
+        event = MagicMock()
+        enter.handler(event)
+        event.app.exit.assert_called_once_with(
+            result=self.items[1],
+        )
+
+    def test_enter_does_nothing_without_matches(self):
+        kb = self.control.get_key_bindings()
+        enter = next(
+            b for b in kb.bindings if str(b.keys[0]) == 'Keys.ControlM'
+        )
+        self._filter('xyz')
+        event = MagicMock()
+        enter.handler(event)
+        event.app.exit.assert_not_called()
+
+
+class TestBaseSelectionMenuControlUnchanged(unittest.TestCase):
+    def test_no_filter_buffer_on_base_control(self):
+        control = SelectionMenuControl(['a', 'b'])
+        self.assertFalse(hasattr(control, 'filter_buffer'))
+
+    def test_preferred_width_handles_empty_items(self):
+        control = SelectionMenuControl([])
+        self.assertEqual(control.preferred_width(100), control.MIN_WIDTH)
+
+
+class TestSelectMenuLayout(unittest.TestCase):
+    def _run_select_menu(self, **kwargs):
+        with patch(
+            'awscli.customizations.wizard.ui.selectmenu.Application'
+        ) as mock_app_class:
+            mock_app_class.return_value.run.return_value = 'result'
+            result = select_menu(['item1', 'item2'], **kwargs)
+        _, app_kwargs = mock_app_class.call_args
+        return result, app_kwargs['layout']
+
+    def test_filter_enabled_adds_search_buffer_bound_to_the_menu(self):
+        result, layout = self._run_select_menu(enable_filter=True)
+        self.assertEqual(result, 'result')
+        buffer_controls = _find_controls(layout.container, BufferControl)
+        menu_controls = _find_controls(
+            layout.container, FilterableSelectionMenuControl
+        )
+        self.assertEqual(len(buffer_controls), 1)
+        self.assertEqual(len(menu_controls), 1)
+        self.assertIs(
+            buffer_controls[0].buffer, menu_controls[0].filter_buffer
+        )
+
+    def test_filter_enabled_focuses_the_search_buffer(self):
+        _, layout = self._run_select_menu(enable_filter=True)
+        self.assertIsInstance(layout.current_control, BufferControl)
+
+    def test_filter_disabled_has_no_search_buffer(self):
+        result, layout = self._run_select_menu(enable_filter=False)
+        self.assertEqual(result, 'result')
+        self.assertEqual(_find_controls(layout.container, BufferControl), [])
+        self.assertEqual(
+            len(_find_controls(layout.container, SelectionMenuControl)), 1
+        )
+
+    def test_filter_enabled_reserves_an_extra_line(self):
+        _, filtered_layout = self._run_select_menu(enable_filter=True)
+        _, plain_layout = self._run_select_menu(enable_filter=False)
+        filtered_height = to_container(
+            filtered_layout.container
+        ).content.height
+        plain_height = to_container(plain_layout.container).content.height
+        self.assertEqual(filtered_height.max, plain_height.max + 1)
+
+    def test_callable_items_are_resolved(self):
+        with patch(
+            'awscli.customizations.wizard.ui.selectmenu.Application'
+        ) as mock_app_class:
+            mock_app_class.return_value.run.return_value = 'result'
+            select_menu(lambda: ['item1', 'item2'], enable_filter=True)
+        _, app_kwargs = mock_app_class.call_args
+        menu_control = _find_controls(
+            app_kwargs['layout'].container, FilterableSelectionMenuControl
+        )[0]
+        self.assertEqual(menu_control._get_items(), ['item1', 'item2'])
+
+
+class TestSelectMenuFilteringEndToEnd:
+    """Drive the real application with key presses from a pipe input."""
+
+    ACCOUNTS = [
+        {'accountId': '111111111111', 'accountName': 'Production'},
+        {'accountId': '222222222222', 'accountName': 'Development'},
+        {'accountId': '333333333333', 'accountName': '東京アカウント'},
+        {'accountId': '444444444444', 'accountName': 'Staging'},
+    ]
+
+    @staticmethod
+    def _display(account):
+        return f"{account['accountName']} ({account['accountId']})"
+
+    def _select_account(self, app_session, keys, **kwargs):
+        app_session.input.send_text(keys)
+        return select_menu(
+            self.ACCOUNTS,
+            display_format=self._display,
+            enable_filter=True,
+            **kwargs,
+        )
+
+    @pytest.mark.parametrize(
+        'keys,expected_name',
+        [
+            # Enter with no filter selects the first item.
+            (ENTER, 'Production'),
+            # Typing narrows the list down to a single match.
+            ('Devel' + ENTER, 'Development'),
+            # Filtering is case insensitive.
+            ('devel' + ENTER, 'Development'),
+            # The account id is searchable through the display format.
+            ('4444' + ENTER, 'Staging'),
+            # Non-ascii filter text is supported.
+            ('東京' + ENTER, '東京アカウント'),
+            # Backspace widens the filter again.
+            ('Devxx' + BACKSPACE + BACKSPACE + ENTER, 'Development'),
+            # Ctrl-U discards the filter text.
+            ('Devel' + CTRL_U + '東京' + ENTER, '東京アカウント'),
+            # A space is filter text rather than a selection key.
+            ('Production (1111' + ENTER, 'Production'),
+            # Arrow keys move within the filtered list.
+            ('ing' + DOWN + ENTER, 'Staging'),
+            # Arrow keys wrap around the unfiltered list.
+            (UP + ENTER, 'Staging'),
+        ],
+    )
+    def test_filtering_selects_expected_account(
+        self, ptk_app_session, keys, expected_name
+    ):
+        selected = self._select_account(ptk_app_session, keys)
+        assert selected['accountName'] == expected_name
+
+    def test_pasted_text_filters_the_list(self, ptk_app_session):
+        # A bracketed paste is delivered as a single key press.
+        paste = '\x1b[200~Development\x1b[201~'
+        selected = self._select_account(ptk_app_session, paste + ENTER)
+        assert selected['accountName'] == 'Development'
+
+    def test_enter_is_ignored_while_nothing_matches(self, ptk_app_session):
+        keys = 'zzzz' + ENTER + BACKSPACE * 4 + 'Staging' + ENTER
+        selected = self._select_account(
+            ptk_app_session,
+            keys,
+            no_results_message='No matching accounts found',
+        )
+        assert selected['accountName'] == 'Staging'
+
+    def test_selection_is_kept_when_filter_is_cleared(self, ptk_app_session):
+        selected = self._select_account(
+            ptk_app_session, 'Devel' + CTRL_U + ENTER
+        )
+        assert selected['accountName'] == 'Development'
+
+    def test_menu_without_filter_ignores_typed_characters(
+        self, ptk_app_session
+    ):
+        ptk_app_session.input.send_text('Staging' + DOWN + ENTER)
+        selected = select_menu(self.ACCOUNTS, display_format=self._display)
+        assert selected['accountName'] == 'Development'
+
+    def test_callable_items_are_filterable(self, ptk_app_session):
+        ptk_app_session.input.send_text('beta' + ENTER)
+        assert (
+            select_menu(lambda: ['alpha', 'beta'], enable_filter=True)
+            == 'beta'
+        )


### PR DESCRIPTION
## Summary

Add keyboard filtering to the account and role selection menus in `aws configure sso`. When multiple accounts or roles are available, users can type to narrow the list down in real time.

Fixes #8867

## Changes

**`awscli/customizations/wizard/ui/selectmenu.py`**

- Add `FilterableSelectionMenuControl` (subclass of `SelectionMenuControl`). The search text is held in a `prompt_toolkit` `Buffer` rendered in its own window above the menu, so unicode input, bracketed pastes, cursor movement and the standard readline shortcuts (`Ctrl-U`, `Ctrl-W`, `Home`/`End`) are handled by `prompt_toolkit` rather than reimplemented here.
- Add `enable_filter` and `no_results_message` parameters to `select_menu()`. Menu navigation is bound at the application level because the search buffer, not the menu, holds the focus.
- Resolve callable `items` in `select_menu()`, and keep honoring callables in the filterable control so the inherited behavior of `SelectionMenuControl` is preserved.
- Fix `SelectionMenuControl.preferred_width()` raising `ValueError` on an empty item list, which is reachable once a filter matches nothing.
- Keep the previously highlighted item selected when the filter changes and that item still matches.

**`awscli/customizations/configure/sso_commands.py`**

- Enable filtering in `_handle_multiple_accounts()` and `_handle_multiple_roles()`, and mention the filter in both prompts.

**Tests**

- `tests/unit/customizations/wizard/ui/test_filterable_menu.py` (new): 49 tests. 32 unit tests cover filtering, selection handling, layout wiring and rendering. 17 end-to-end tests drive the real `Application` with key presses through a pipe input, covering typing, non-ASCII filter text, bracketed paste, backspace, `Ctrl-U`, arrow keys and recovery from a filter with no matches.
- `tests/unit/customizations/configure/test_sso.py`: record `select_menu` kwargs in `PTKStubber` and assert that both the account and role menus enable filtering.

## Notes

- The non-filtering code path is unchanged, so the rest of the wizard UI keeps its current behavior.
- Filtering is applied to role selection as well as account selection for consistency. Happy to drop the role part if you would rather keep this scoped to accounts.

## Testing

```
pytest tests/unit/customizations/wizard/ tests/unit/customizations/configure/   # 501 passed
```

`pre-commit` (ruff + ruff-format) is clean on the changed files.

Manually verified the interactive flow against a live IAM Identity Center instance on macOS (iTerm2, Terminal.app): typing to filter, non-ASCII filter text, pasting, backspace, `Ctrl-U`, arrow keys and `Enter` to select, plus the no-match message and recovery.

Also verified on Windows 10 (AMD64) with Python 3.10.11: the interactive filtering works correctly — typing to narrow the list, backspace, Ctrl-U, arrow keys, and Ctrl-V paste all behave as expected. All 49 filterable-menu tests and 80 SSO configuration tests pass.

Also verified on Linux via Docker container (`python:3.11-slim`, Debian 13, aarch64 and x86_64): the interactive flow against a live IAM Identity Center instance works correctly, including paste. All unit and E2E tests pass on both architectures.

## AI tooling disclosure

Generated by AI tools, and reviewed by masamaru0513, per the Automated Tools section of `CONTRIBUTING.rst`.

Related #9692


