### PR TITLE
Fix TypeError in s3 error handler when Error.Message is None

### DIFF
--- a/.changes/next-release/s3-bugfix-10161.json
+++ b/.changes/next-release/s3-bugfix-10161.json
@@ -1,0 +1,7 @@
+[
+  {
+    "category": "``s3``",
+    "description": "Fix ``TypeError`` in S3 error message handler when the error response contains a ``None`` ``Message`` value, which can occur with S3-compatible endpoints that return empty ``<Message>`` XML elements.",
+    "type": "bugfix"
+  }
+]

--- a/awscli/customizations/s3errormsg.py
+++ b/awscli/customizations/s3errormsg.py
@@ -44,24 +44,26 @@ def enhance_error_msg(parsed, **kwargs):
         message += REGION_ERROR_MSG
         parsed['Error']['Message'] = message
     elif _is_permanent_redirect_message(parsed):
-        endpoint = parsed['Error']['Endpoint']
-        message = parsed['Error']['Message']
+        endpoint = parsed['Error'].get('Endpoint', '')
+        message = parsed['Error'].get('Message') or ''
         new_message = message[:-1] + ': %s\n' % endpoint
         new_message += REGION_ERROR_MSG
         parsed['Error']['Message'] = new_message
     elif _is_kms_sigv4_error_message(parsed):
-        parsed['Error']['Message'] += ENABLE_SIGV4_MSG
+        current_msg = parsed['Error'].get('Message') or ''
+        parsed['Error']['Message'] = current_msg + ENABLE_SIGV4_MSG
 
 
 def _is_sigv4_error_message(parsed):
-    return ('Please use AWS4-HMAC-SHA256' in
-            parsed.get('Error', {}).get('Message', ''))
+    error_message = parsed.get('Error', {}).get('Message') or ''
+    return 'Please use AWS4-HMAC-SHA256' in error_message
 
 
 def _is_permanent_redirect_message(parsed):
-    return parsed.get('Error', {}).get('Code', '') == 'PermanentRedirect'
+    error_code = parsed.get('Error', {}).get('Code') or ''
+    return error_code == 'PermanentRedirect'
 
 
 def _is_kms_sigv4_error_message(parsed):
-    return ('AWS KMS managed keys require AWS Signature Version 4' in
-            parsed.get('Error', {}).get('Message', ''))
+    error_message = parsed.get('Error', {}).get('Message') or ''
+    return 'AWS KMS managed keys require AWS Signature Version 4' in error_message

--- a/tests/unit/customizations/test_s3errormsg.py
+++ b/tests/unit/customizations/test_s3errormsg.py
@@ -84,3 +84,77 @@ class TestGetRegionFromEndpoint(unittest.TestCase):
         s3errormsg.enhance_error_msg(parsed)
         # Nothing should have changed
         self.assertEqual(parsed, expected)
+
+    def test_none_message_does_not_crash(self):
+        # Empty <Message></Message> parsed as None must not raise TypeError.
+        parsed = {
+            'Error': {
+                'Code': 'AccessDenied',
+                'Message': None,
+            }
+        }
+        # Should not raise TypeError
+        s3errormsg.enhance_error_msg(parsed)
+        # Message should remain None since no error pattern matched
+        self.assertIsNone(parsed['Error']['Message'])
+
+    def test_none_message_with_sigv4_code(self):
+        # None Message should not match sigv4 pattern.
+        parsed = {
+            'Error': {
+                'Code': 'AuthorizationHeaderMalformed',
+                'Message': None,
+            }
+        }
+        s3errormsg.enhance_error_msg(parsed)
+        # Should not have been enhanced (no match)
+        self.assertIsNone(parsed['Error']['Message'])
+
+    def test_none_message_with_kms_context(self):
+        # None Message should not match KMS sigv4 pattern.
+        parsed = {
+            'Error': {
+                'Code': 'InvalidArgument',
+                'Message': None,
+            }
+        }
+        s3errormsg.enhance_error_msg(parsed)
+        self.assertIsNone(parsed['Error']['Message'])
+
+    def test_none_code_does_not_crash(self):
+        # None Code should not crash PermanentRedirect check.
+        parsed = {
+            'Error': {
+                'Code': None,
+                'Message': 'Some error message.',
+            }
+        }
+        expected = copy.deepcopy(parsed)
+        s3errormsg.enhance_error_msg(parsed)
+        # Nothing should have changed
+        self.assertEqual(parsed, expected)
+
+    def test_empty_string_message_does_not_crash(self):
+        # Empty string Message should be handled without crashing.
+        parsed = {
+            'Error': {
+                'Code': 'AccessDenied',
+                'Message': '',
+            }
+        }
+        expected = copy.deepcopy(parsed)
+        s3errormsg.enhance_error_msg(parsed)
+        self.assertEqual(parsed, expected)
+
+    def test_permanent_redirect_with_none_message(self):
+        # PermanentRedirect with None Message should not crash.
+        parsed = {
+            'Error': {
+                'Code': 'PermanentRedirect',
+                'Message': None,
+                'Endpoint': 'myendpoint',
+            }
+        }
+        s3errormsg.enhance_error_msg(parsed)
+        # Should have enhanced the message despite None original
+        self.assertIn('myendpoint', parsed['Error']['Message'])


### PR DESCRIPTION
## Description

Fix `TypeError: argument of type 'NoneType' is not iterable` in `awscli/customizations/s3errormsg.py` when S3-compatible endpoints return error responses with empty `<Message></Message>` XML elements.

Fixes #10161

## Root Cause

S3-compatible endpoints (Ceph RadosGW, Hetzner, MinIO) may return valid XML error responses with empty `<Message>` elements. Python's `ElementTree` parses empty elements as `None` (i.e., `.text = None`), and botocore's error parsing path in `_replace_nodes()` does not normalize `None` to `""`. This causes the parsed response dict to contain `{'Error': {'Message': None}}`.

The `_is_sigv4_error_message()` and `_is_kms_sigv4_error_message()` functions then perform `'substring' in None`, which raises:

TypeError: argument of type 'NoneType' is not iterable

**Key Python gotcha:** `.get('Message', '')` returns the default `''` only when the key is *absent*. When the key *exists* with value `None`, `.get()` returns `None`.

## Changes

- Use `or ''` coalescing in `_is_sigv4_error_message()`, `_is_permanent_redirect_message()`, and `_is_kms_sigv4_error_message()` to handle `None` values safely
- Guard `enhance_error_msg()` body against `None` Message and missing `Endpoint` in the `PermanentRedirect` code path
- Add 6 unit tests covering `None` Message, `None` Code, empty string Message, and `PermanentRedirect` with `None` Message

## Testing

- All 5 existing tests pass without modification **zero regressions**
- 6 new tests validate the fix across all vulnerable code paths
- `pytest tests/unit/customizations/test_s3errormsg.py -v` **11 passed**
- No behavioral change for AWS S3 (AWS always returns non-empty `Message` content)

## Credit

Root cause analysis by @sfwester in #10161.