### PR TITLE
Fix nested config updates across non-option lines

### DIFF
--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -215,30 +215,37 @@ class ConfigFileWriter(object):
 
     def _update_subattributes(self, index, contents, values, starting_indent):
         index += 1
+        insert_at = index - 1
         for i in range(index, len(contents)):
             line = contents[i]
+            if self.SECTION_REGEX.search(line) is not None:
+                # We've arrived at a new section so we can just write out all
+                # the values now.
+                self._insert_new_values(i - 1, contents, values, '    ')
+                return i
             match = self.OPTION_REGEX.search(line)
-            if match is not None:
-                current_indent = len(
-                    match.group(1)) - len(match.group(1).lstrip())
-                key_name = match.group(1).strip()
-                if key_name in values:
-                    option_value = values[key_name]
-                    new_line = '%s%s = %s\n' % (' ' * current_indent,
-                                                key_name, option_value)
-                    contents[i] = new_line
-                    del values[key_name]
-            if starting_indent == current_indent or \
-                    self.SECTION_REGEX.search(line) is not None:
+            if match is None:
+                insert_at = i
+                continue
+            current_indent = len(
+                match.group(1)) - len(match.group(1).lstrip())
+            if starting_indent == current_indent:
                 # We've arrived at the starting indent level so we can just
                 # write out all the values now.
                 self._insert_new_values(i - 1, contents, values, '    ')
-                break
+                return i
+            insert_at = i
+            key_name = match.group(1).strip()
+            if key_name in values:
+                option_value = values[key_name]
+                new_line = '%s%s = %s\n' % (' ' * current_indent,
+                                            key_name, option_value)
+                contents[i] = new_line
+                del values[key_name]
         else:
-            if starting_indent != current_indent:
-                # The option is the last option in the file
-                self._insert_new_values(i, contents, values, '    ')
-        return i
+            # The option is the last option in the file.
+            self._insert_new_values(insert_at, contents, values, '    ')
+        return insert_at
 
     def _insert_new_values(self, line_number, contents, new_values, indent=''):
         new_contents = []

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -295,6 +295,50 @@ class TestConfigFileWriter(unittest.TestCase):
             '    other = foo\n'
             '    signature_version = newval\n')
 
+    def test_add_to_empty_nested_block(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '    signature_version = newval\n')
+
+    def test_add_to_nested_block_with_comment(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+            '# comment\n'
+            '    other = foo\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '# comment\n'
+            '    other = foo\n'
+            '    signature_version = newval\n')
+
+    def test_add_to_nested_block_before_next_section(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+            '[profile foo]\n'
+            'foo = bar\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '    signature_version = newval\n'
+            '[profile foo]\n'
+            'foo = bar\n')
+
     def test_update_nested_attribute(self):
         original = (
             '[default]\n'


### PR DESCRIPTION
Fixes #10348.

`ConfigFileWriter._update_subattributes()` assumed every line inside a nested config block matched `OPTION_REGEX`, so `current_indent` could be read before assignment when the block was empty or when a comment/section header followed the parent key.

This makes the loop handle section headers before option parsing, skip non-option lines safely, and keep the insertion point at the last line that still belongs to the nested block. The regressions cover empty nested blocks, comments between the parent key and child option, and a next section immediately after the parent key.

Validation:
- `python -m pytest tests/unit/customizations/configure/test_writer.py -q`
- `git diff --check`