### PR TITLE
[v2] Fix parent reference warning

### DIFF
--- a/.changes/next-release/bugfix-s3-52243.json
+++ b/.changes/next-release/bugfix-s3-52243.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Fix false negative in parent-directory escape detection that allowed keys like ``/../foo`` to bypass warning during downloads"
+}

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -335,9 +335,10 @@ class BaseTransferRequestSubmitter:
         # normpath() will use the OS path separator so we
         # need to take that into account when checking for a parent prefix.
         parent_prefix = '..' + os.path.sep
-        escapes_cwd = os.path.normpath(fileinfo.compare_key).startswith(
-            parent_prefix
-        )
+        # Anchor compare_key against '.' (the destination directory root)
+        # to avoid false negatives on paths like '/../foo'
+        normalized = os.path.normpath('.' + os.path.sep + fileinfo.compare_key)
+        escapes_cwd = normalized.startswith(parent_prefix)
         if escapes_cwd:
             warning = create_warning(
                 fileinfo.compare_key, "File references a parent directory."

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -646,6 +646,27 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         future = self.transfer_request_submitter.submit(fileinfo)
         self.assertIsInstance(self.result_queue.get(), DryRunResult)
 
+    def test_warn_and_ignore_on_leading_slash_parent_reference(self):
+        fileinfo = self.create_file_info('/../foo.txt')
+        future = self.transfer_request_submitter.submit(fileinfo)
+        warning_result = self.result_queue.get()
+        self.assertIsInstance(warning_result, WarningResult)
+        self.assert_no_downloads_happened()
+
+    def test_warn_and_ignore_on_leading_slash_stacked_parent_reference(self):
+        fileinfo = self.create_file_info('/../../../foo/bar.txt')
+        future = self.transfer_request_submitter.submit(fileinfo)
+        warning_result = self.result_queue.get()
+        self.assertIsInstance(warning_result, WarningResult)
+        self.assert_no_downloads_happened()
+
+    def test_warn_and_ignore_on_double_leading_slash_parent_reference(self):
+        fileinfo = self.create_file_info('//../foo')
+        future = self.transfer_request_submitter.submit(fileinfo)
+        warning_result = self.result_queue.get()
+        self.assertIsInstance(warning_result, WarningResult)
+        self.assert_no_downloads_happened()
+
     def test_dry_run(self):
         self.cli_params['dryrun'] = True
         self.transfer_request_submitter = DownloadRequestSubmitter(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Improves the parent-directory reference check in the S3 download path so that compare keys with a leading slash (e.g. `/../foo`) are correctly flagged. 

The compare key is now anchored against the destination directory root before `os.path.normpath()` is applied, preventing the leading slash from collapsing the `..` segment away.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.