### PR TITLE
Fix None injection for hoisted binary arguments

### DIFF
--- a/.changes/next-release/bugfix-binaryhoist-None.json
+++ b/.changes/next-release/bugfix-binaryhoist-None.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "translate",
+  "description": "Fixed a bug where omitting an optional hoisted binary argument (such as ``--data-file`` for ``aws translate import-terminology`` or ``--document-content`` for ``aws translate translate-document``) would inject a ``None`` member into the request parameters instead of leaving them empty."
+}

--- a/awscli/customizations/binaryhoist.py
+++ b/awscli/customizations/binaryhoist.py
@@ -33,7 +33,7 @@ class InjectingArgument(CustomArgument):
 
     def add_to_params(self, parameters, value):
         if value is None:
-            pass
+            return
         wrapped_value = {self._original_member_name: value}
         if parameters.get(self._serialized_name):
             parameters[self._serialized_name].update(wrapped_value)

--- a/tests/unit/customizations/test_binaryhoist.py
+++ b/tests/unit/customizations/test_binaryhoist.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest
+from awscli.customizations.binaryhoist import InjectingArgument
+
+
+class TestInjectingArgument(unittest.TestCase):
+    def setUp(self):
+        self.argument = InjectingArgument(
+            'TerminologyData',
+            'File',
+            name='data-file',
+            cli_type_name='blob',
+            required=False,
+        )
+
+    def test_none_value_does_not_add_to_params(self):
+        parameters = {}
+        self.argument.add_to_params(parameters, None)
+        self.assertEqual(parameters, {})
+
+    def test_value_is_wrapped_in_serialized_member(self):
+        parameters = {}
+        self.argument.add_to_params(parameters, b'data')
+        self.assertEqual(parameters, {'TerminologyData': {'File': b'data'}})
+
+    def test_value_merges_with_existing_serialized_arg(self):
+        parameters = {'TerminologyData': {'Format': 'CSV'}}
+        self.argument.add_to_params(parameters, b'data')
+        self.assertEqual(
+            parameters,
+            {'TerminologyData': {'Format': 'CSV', 'File': b'data'}},
+        )


### PR DESCRIPTION
## Summary

`InjectingArgument.add_to_params` in `awscli/customizations/binaryhoist.py` used `pass` instead of `return` in its `None` guard. When an optional hoisted binary argument is omitted, the method falls through and still injects the wrapped member with a `None` value.

The sibling class `OriginalArgument.add_to_params` (same file) correctly `return`s on `None`, which confirms the intended behavior.

## Impact

This affects the hoisted binary blob arguments:
- `aws translate import-terminology` (`--data-file`)
- `aws translate translate-document` (`--document-content`)

When the optional argument is omitted, the serialized parameters get polluted, e.g. `{'TerminologyData': {'File': None}}` instead of staying empty.

## Reproduction

```python
from awscli.customizations.binaryhoist import InjectingArgument
arg = InjectingArgument('TerminologyData', 'File', name='data-file', cli_type_name='blob', required=False)
params = {}
arg.add_to_params(params, None)
# before: {'TerminologyData': {'File': None}}
# after:  {}
```

## Fix

```diff
     def add_to_params(self, parameters, value):
         if value is None:
-            pass
+            return
```

## Tests

Added `tests/unit/customizations/test_binaryhoist.py` with three cases (None, wrapping, merge-with-existing). The None case fails before the change and passes after. Verified locally:

```
$ python -m pytest tests/unit/customizations/test_binaryhoist.py -q
3 passed
```

---
Developed with AI assistance and verified locally as described above.