### PR TITLE
Add security considerations note to cfn package docs

### DIFF
--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -54,3 +54,23 @@ command doesn't upload the artifacts. Use the ``--force-upload flag`` to skip th
 check and always upload the artifacts. The command uses MD5 checksums to compare
 files by default. If MD5 is not available in the environment, a SHA256 checksum is used.
 
+.. warning::
+
+   **Security considerations**
+
+   The ``package`` command treats the supplied CloudFormation template as
+   trusted build input. The properties listed above (for example,
+   ``CodeUri``, ``ContentUri``, ``TemplateURL``, and the ``Location`` parameter
+   for the ``AWS::Include`` transform) cause the CLI to read files from the
+   local filesystem at the paths the template specifies and upload them to the
+   S3 bucket you provide, using your own AWS credentials and operating-system
+   identity. Paths in the template are not constrained to the template's
+   directory; relative paths that traverse above the template directory (for
+   example, ``CodeUri: ../src/my-function``) are supported by design to enable
+   monorepo, shared-fragment, and nested-stack layouts.
+
+   Do not run ``aws cloudformation package`` against templates from sources
+   you do not trust. A malicious template author can cause arbitrary readable
+   files on your machine, such as credentials or other sensitive files, to be
+   uploaded to the configured S3 bucket.
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a security-considerations warning to the `aws cloudformation package` reference documentation (rendered at https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html, sourced from `awscli/examples/cloudformation/_package_description.rst`).

The note clarifies that the command treats the supplied CloudFormation template as trusted build input: properties such as `CodeUri`, `ContentUri`, `TemplateURL`, and the `AWS::Include` `Location` parameter cause the CLI to read files from the local filesystem at the paths the template specifies and upload them to the user-provided S3 bucket under the invoking user's AWS credentials and OS identity. Paths in the template are not constrained to the template's directory — relative paths that traverse above it (e.g. `CodeUri: ../src/my-function`) are supported by design for monorepo, shared-fragment, and nested-stack layouts. The note advises users not to run the command against templates from untrusted sources.

This is a documentation-only change; no behavior changes and no changelog entry is required (matching the precedent of #9316).

Generated by AI tools, and reviewed by Roger Zhang.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.