### PR TITLE
Harden GameLift build archives against symlinks

### DIFF
--- a/awscli/customizations/gamelift/uploadbuild.py
+++ b/awscli/customizations/gamelift/uploadbuild.py
@@ -136,8 +136,14 @@ def zip_directory(zipfile_name, source_root):
         zip_file = zipfile.ZipFile(f, 'w', zipfile.ZIP_DEFLATED, True)
         with contextlib.closing(zip_file) as zf:
             for root, dirs, files in os.walk(source_root):
+                dirs[:] = [
+                    dirname for dirname in dirs
+                    if not os.path.islink(os.path.join(root, dirname))
+                ]
                 for filename in files:
                     full_path = os.path.join(root, filename)
+                    if os.path.islink(full_path):
+                        continue
                     relative_path = os.path.relpath(
                         full_path, source_root)
                     zf.write(full_path, relative_path)

--- a/tests/unit/customizations/gamelift/test_uploadbuild.py
+++ b/tests/unit/customizations/gamelift/test_uploadbuild.py
@@ -304,6 +304,38 @@ class TestZipDirectory(unittest.TestCase):
         zip_directory(self.zip_file, self.dir_root)
         self.assert_contents_of_zip_file([filename])
 
+    def test_symlinked_files_are_not_archived(self):
+        self.add_to_directory('foo')
+        outside_file = self.file_creator.create_file(
+            'outside-secret', 'secret contents')
+        linked_file = os.path.join(self.dir_root, 'linked-secret')
+        try:
+            os.symlink(outside_file, linked_file)
+        except OSError as e:
+            raise unittest.SkipTest(
+                f'Unable to create symlink on this platform: {e}')
+
+        zip_directory(self.zip_file, self.dir_root)
+
+        self.assert_contents_of_zip_file(['foo'])
+
+    def test_symlinked_directories_are_not_archived(self):
+        self.add_to_directory('foo')
+        outside_dir = os.path.join(self.file_creator.rootdir, 'outside')
+        os.makedirs(outside_dir)
+        with open(os.path.join(outside_dir, 'secret'), 'w') as f:
+            f.write('secret contents')
+        linked_dir = os.path.join(self.dir_root, 'linked-dir')
+        try:
+            os.symlink(outside_dir, linked_dir, target_is_directory=True)
+        except OSError as e:
+            raise unittest.SkipTest(
+                f'Unable to create symlink on this platform: {e}')
+
+        zip_directory(self.zip_file, self.dir_root)
+
+        self.assert_contents_of_zip_file(['foo'])
+
 
 class TestValidateDirectory(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- skip symlinked files when creating GameLift upload-build archives
- prune symlinked directories before walking build roots
- add regression coverage for symlinked file and directory entries

## Why
The GameLift upload-build helper packages a local build root and uploads the generated archive. Symlink entries can cause archive contents to come from outside the selected build root, so this keeps the archive bounded to regular files under the requested directory.

## Testing
- python -m pytest tests\\unit\\customizations\\gamelift\\test_uploadbuild.py -q
- python -m py_compile awscli\\customizations\\gamelift\\uploadbuild.py tests\\unit\\customizations\\gamelift\\test_uploadbuild.py
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check