### PR TITLE
[v2] Refactor to standalone source HeadObject for copies

### DIFF
--- a/awscli/customizations/s3/subscribers.py
+++ b/awscli/customizations/s3/subscribers.py
@@ -242,6 +242,35 @@ class DirectoryCreatorSubscriber(BaseSubscriber):
                 )
 
 
+_SOURCE_HEAD_OBJECT_CONTEXT_KEY = 'source_head_object_response'
+
+
+def get_copy_source_head_object(
+    future, source_client, cli_params, cached_response=None
+):
+    user_context = future.meta.user_context
+    if _SOURCE_HEAD_OBJECT_CONTEXT_KEY not in user_context:
+        if cached_response is None:
+            cached_response = _head_copy_source(
+                future, source_client, cli_params
+            )
+        user_context[_SOURCE_HEAD_OBJECT_CONTEXT_KEY] = cached_response
+    return user_context[_SOURCE_HEAD_OBJECT_CONTEXT_KEY]
+
+
+def _head_copy_source(future, source_client, cli_params):
+    copy_source = future.meta.call_args.copy_source
+    head_object_params = {
+        'Bucket': copy_source['Bucket'],
+        'Key': copy_source['Key'],
+    }
+    utils.RequestParamsMapper.map_head_object_params_with_copy_source_sse(
+        head_object_params,
+        cli_params,
+    )
+    return source_client.head_object(**head_object_params)
+
+
 class CopyPropsSubscriberFactory:
     def __init__(self, client, transfer_config, cli_params):
         self._client = client
@@ -278,16 +307,17 @@ class CopyPropsSubscriberFactory:
         ]
 
     def _create_metadata_directive_props_subscriber(self, fileinfo):
-        subscriber_kwargs = {
-            'client': fileinfo.source_client,
-            'transfer_config': self._transfer_config,
-            'cli_params': self._cli_params,
-        }
-        if not self._cli_params.get('dir_op'):
-            subscriber_kwargs['head_object_response'] = (
-                fileinfo.associated_response_data
-            )
-        return SetMetadataDirectivePropsSubscriber(**subscriber_kwargs)
+        return SetMetadataDirectivePropsSubscriber(
+            client=fileinfo.source_client,
+            transfer_config=self._transfer_config,
+            cli_params=self._cli_params,
+            head_object_response=self._cached_head_object_response(fileinfo),
+        )
+
+    def _cached_head_object_response(self, fileinfo):
+        if self._cli_params.get('dir_op'):
+            return None
+        return fileinfo.associated_response_data
 
 
 class ReplaceDirectiveSubscriber(BaseSubscriber):
@@ -342,18 +372,12 @@ class SetMetadataDirectivePropsSubscriber(BaseSubscriber):
         return False
 
     def _get_head_object_response(self, future):
-        if self._head_object_response is not None:
-            return self._head_object_response
-        copy_source = future.meta.call_args.copy_source
-        head_object_params = {
-            'Bucket': copy_source['Bucket'],
-            'Key': copy_source['Key'],
-        }
-        utils.RequestParamsMapper.map_head_object_params_with_copy_source_sse(
-            head_object_params,
+        return get_copy_source_head_object(
+            future,
+            self._client,
             self._cli_params,
+            cached_response=self._head_object_response,
         )
-        return self._client.head_object(**head_object_params)
 
     def _inject_metadata_props(self, future, head_object_response):
         request_args = future.meta.call_args.extra_args

--- a/tests/unit/customizations/s3/test_subscribers.py
+++ b/tests/unit/customizations/s3/test_subscribers.py
@@ -46,6 +46,7 @@ from awscli.customizations.s3.subscribers import (
     ReplaceTaggingDirectiveSubscriber,
     SetMetadataDirectivePropsSubscriber,
     SetTagsSubscriber,
+    get_copy_source_head_object,
 )
 from awscli.testutils import FileCreator, mock, unittest
 from tests.unit.customizations.s3 import (
@@ -414,6 +415,66 @@ class BaseCopyPropsSubscriberTest(unittest.TestCase):
 
     def set_cli_params_to_recursive_copy(self):
         self.cli_params['dir_op'] = True
+
+
+class TestGetCopySourceHeadObject(BaseCopyPropsSubscriberTest):
+    def setUp(self):
+        super(TestGetCopySourceHeadObject, self).setUp()
+        self.source_client = mock.Mock()
+
+    def test_returns_cached_response_without_calling_head_object(self):
+        cached_response = {'ContentType': 'from-cache'}
+        response = get_copy_source_head_object(
+            self.future,
+            self.source_client,
+            self.cli_params,
+            cached_response=cached_response,
+        )
+        self.assertEqual(response, cached_response)
+        self.assertFalse(self.source_client.head_object.called)
+
+    def test_fetches_head_object_when_not_cached(self):
+        self.source_client.head_object.return_value = {'TagCount': 1}
+        response = get_copy_source_head_object(
+            self.future, self.source_client, self.cli_params
+        )
+        self.assertEqual(response, {'TagCount': 1})
+        self.source_client.head_object.assert_called_once_with(
+            Bucket=self.source_bucket, Key=self.source_key
+        )
+
+    def test_memoizes_fetched_response_on_user_context(self):
+        self.source_client.head_object.return_value = {'TagCount': 1}
+        first = get_copy_source_head_object(
+            self.future, self.source_client, self.cli_params
+        )
+        second = get_copy_source_head_object(
+            self.future, self.source_client, self.cli_params
+        )
+        self.assertIs(first, second)
+        self.source_client.head_object.assert_called_once_with(
+            Bucket=self.source_bucket, Key=self.source_key
+        )
+
+    def test_maps_copy_source_sse_params_to_head_object(self):
+        self.cli_params.update(
+            {
+                'sse_c_copy_source': 'AES256',
+                'sse_c_copy_source_key': 'source-key',
+                'sse_c': 'AES256',
+                'sse_c_key': 'destination-key',
+            }
+        )
+        self.source_client.head_object.return_value = {}
+        get_copy_source_head_object(
+            self.future, self.source_client, self.cli_params
+        )
+        self.source_client.head_object.assert_called_once_with(
+            Bucket=self.source_bucket,
+            Key=self.source_key,
+            SSECustomerAlgorithm='AES256',
+            SSECustomerKey='source-key',
+        )
 
 
 class TestCopyPropsSubscriberFactory(BaseCopyPropsSubscriberTest):


### PR DESCRIPTION
This PR refactors `HeadObject` calls during S3 to S3 multipart copies. Currently, the `HeadObject` request is called in `SetMetadataDirectivePropsSubscriber`. This isn't ideal since it couples `HeadObject` invocations to a specific subscriber. We want to open it up so that other subscribers can consume the `HeadObject` response, even if `SetMetadataDirectivePropsSubscriber` never fires.

Specifically, this refactor unblocks the following future changes:
* Update `SetTagsSubscriber` so it only fires if `TagCount` in `HeadObject` response is greater than 0.
* Hypothetical, but if we wanted to support more options for `--copy-props` (eg `tagging`) in the future, then these values can be fetched and copied independently from metadata.