### PR TITLE
Replaced "CPU" with "Cpu" in Apprunner examples

### DIFF
--- a/awscli/examples/apprunner/create-service.rst
+++ b/awscli/examples/apprunner/create-service.rst
@@ -37,7 +37,7 @@ Contents of ``input.json``::
             }
         },
         "InstanceConfiguration": {
-            "CPU": "1 vCPU",
+            "Cpu": "1 vCPU",
             "Memory": "3 GB"
         }
     }
@@ -82,7 +82,7 @@ Output::
             },
             "Status": "OPERATION_IN_PROGRESS",
             "InstanceConfiguration": {
-                "CPU": "1 vCPU",
+                "Cpu": "1 vCPU",
                 "Memory": "3 GB"
             }
         }
@@ -127,7 +127,7 @@ Contents of ``input.json``::
             }
         },
         "InstanceConfiguration": {
-            "CPU": "1 vCPU",
+            "Cpu": "1 vCPU",
             "Memory": "3 GB"
         }
     }
@@ -172,7 +172,7 @@ Output::
             },
             "Status": "OPERATION_IN_PROGRESS",
             "InstanceConfiguration": {
-                "CPU": "1 vCPU",
+                "Cpu": "1 vCPU",
                 "Memory": "3 GB"
             }
         }
@@ -208,7 +208,7 @@ Contents of ``input.json``::
             }
         },
         "InstanceConfiguration": {
-            "CPU": "1 vCPU",
+            "Cpu": "1 vCPU",
             "Memory": "3 GB"
         }
     }
@@ -244,7 +244,7 @@ Output::
             },
             "Status": "OPERATION_IN_PROGRESS",
             "InstanceConfiguration": {
-                "CPU": "1 vCPU",
+                "Cpu": "1 vCPU",
                 "Memory": "3 GB"
             }
         }

--- a/awscli/examples/apprunner/delete-service.rst
+++ b/awscli/examples/apprunner/delete-service.rst
@@ -51,7 +51,7 @@ Output::
             },
             "Status": "OPERATION_IN_PROGRESS",
             "InstanceConfiguration": {
-                "CPU": "1 vCPU",
+                "Cpu": "1 vCPU",
                 "Memory": "3 GB"
             }
         }

--- a/awscli/examples/apprunner/describe-service.rst
+++ b/awscli/examples/apprunner/describe-service.rst
@@ -50,7 +50,7 @@ Output::
             },
             "Status": "RUNNING",
             "InstanceConfiguration": {
-                "CPU": "1 vCPU",
+                "Cpu": "1 vCPU",
                 "Memory": "3 GB"
             }
         }

--- a/awscli/examples/apprunner/pause-service.rst
+++ b/awscli/examples/apprunner/pause-service.rst
@@ -51,7 +51,7 @@ Output::
             },
             "Status": "OPERATION_IN_PROGRESS",
             "InstanceConfiguration": {
-                "CPU": "1 vCPU",
+                "Cpu": "1 vCPU",
                 "Memory": "3 GB"
             }
         }

--- a/awscli/examples/apprunner/resume-service.rst
+++ b/awscli/examples/apprunner/resume-service.rst
@@ -51,7 +51,7 @@ Output::
             },
             "Status": "OPERATION_IN_PROGRESS",
             "InstanceConfiguration": {
-                "CPU": "1 vCPU",
+                "Cpu": "1 vCPU",
                 "Memory": "3 GB"
             }
         }

--- a/awscli/examples/apprunner/update-service.rst
+++ b/awscli/examples/apprunner/update-service.rst
@@ -57,7 +57,7 @@ Output::
             },
             "Status": "OPERATION_IN_PROGRESS",
             "InstanceConfiguration": {
-                "CPU": "1 vCPU",
+                "Cpu": "1 vCPU",
                 "Memory": "4 GB"
             }
         }


### PR DESCRIPTION
*Issue #, if available:* Internal documentation feedback ticket (P424226904)

*Description of changes:* Apprunner models the "Cpu" parameter with title case, but our existing examples have the whole parameter capitalized.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
