### PR TITLE
[v2] Fix non-ASCII escaping in cloudformation package

### DIFF
--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -68,6 +68,7 @@ def yaml_dump(dict_to_dump):
     return yaml.dump(
         dict_to_dump,
         default_flow_style=False,
+        allow_unicode=False,
         Dumper=FlattenAliasDumper,
     )
 

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -157,6 +157,16 @@ class TestYaml(unittest.TestCase):
         self.assertTrue(isinstance(output, OrderedDict))
         self.assertEqual(output.get('test').get('property'), 'value')
 
+    def test_yaml_dump_escapes_non_ascii_characters(self):
+        # PyYAML defaults write raw UTF-8; CloudFormation shows '?' for non-ASCII
+        data = {'Value': '\U0001F6A8 firing \U0001F7E2 resolved'}
+        dumped = yaml_dump(data)
+        self.assertNotIn('\U0001F6A8', dumped)
+        self.assertNotIn('\U0001F7E2', dumped)
+        self.assertIn('\\U0001F6A8', dumped)
+        self.assertIn('\\U0001F7E2', dumped)
+        self.assertEqual(yaml_parse(dumped), data)
+
     def test_unroll_yaml_anchors(self):
         properties = {
             "Foo": "bar",


### PR DESCRIPTION
`cloudformation package` started writing emoji and other non-ASCII characters as raw UTF-8 bytes in output templates in v2.34.13, when `yamlhelper.py` switched from ruamel.yaml to PyYAML (PR #10164). PyYAML defaults to `allow_unicode=True`, which writes characters like 🚨 directly rather than as YAML unicode escapes like `\U0001F6A8`. CloudFormation displays these raw bytes as `?` in the console and in `get-template` output.

The fix is `allow_unicode=False` on the `yaml.dump()` call. This restores the pre-regression behavior with no other changes to serialization.

The regression test verifies that emoji characters are serialized as YAML escape sequences rather than raw bytes, and that the escaped output round-trips correctly through `yaml_parse`.

Fixes #10185

Credit: @rkamach-smtc for the reproduction steps in #10185, and @RyanFitzSimmonsAK for confirming the regression on EC2.

*This change was generated with AI assistance and reviewed by me.*