### PR TITLE
Fix symlinks and protect non-aws skills

### DIFF
--- a/awscli/customizations/agenttoolkit/update_skill.py
+++ b/awscli/customizations/agenttoolkit/update_skill.py
@@ -100,5 +100,6 @@ class UpdateSkillCommand(BasicCommand):
             outdated,
             self._stream,
             action='Updated',
+            overwrite_existing=True,
         )
         return 0

--- a/awscli/customizations/agenttoolkit/utils.py
+++ b/awscli/customizations/agenttoolkit/utils.py
@@ -189,9 +189,10 @@ def install_skill(
                         version_note = f' ({installed})' if installed else ''
                         stream.write(
                             f'  {skill_name} is already installed'
-                            f'{version_note}. Run "aws agent-toolkit '
-                            f'update-skill --skill-name {skill_name}" to '
-                            f'update, or remove it first to reinstall.\n'
+                            f'{version_note} at {real_dir}. Run '
+                            f'"aws agent-toolkit update-skill '
+                            f'--skill-name {skill_name}" to update, '
+                            f'or remove it first to reinstall.\n'
                         )
                     continue
                 shutil.rmtree(real_dir)

--- a/awscli/customizations/agenttoolkit/utils.py
+++ b/awscli/customizations/agenttoolkit/utils.py
@@ -142,6 +142,7 @@ def install_skill(
     agents,
     stream=None,
     action='Installed',
+    overwrite_existing=False,
 ):
     expected = checksum.strip().lower().split()[0]
     actual = hashlib.sha256(zip_bytes).hexdigest()
@@ -169,14 +170,34 @@ def install_skill(
         extracted_paths = set()
         for agent in universal_first(agents):
             skill_dir = os.path.join(agent.skills_path, skill_name)
-            if skill_dir in extracted_paths:
+            real_dir = os.path.realpath(skill_dir)
+            if real_dir in extracted_paths:
                 continue
-            if os.path.isdir(skill_dir):
-                shutil.rmtree(skill_dir)
-            os.makedirs(skill_dir, exist_ok=True)
-            zf.extractall(skill_dir)
-            write_skill_metadata(skill_dir, version)
-            extracted_paths.add(skill_dir)
+            extracted_paths.add(real_dir)
+            if os.path.isdir(real_dir):
+                marker = os.path.join(real_dir, SKILL_METADATA_FILENAME)
+                if not os.path.exists(marker):
+                    if stream:
+                        stream.write(
+                            f'  Skipped {skill_name} at {real_dir}: '
+                            f'directory was not installed by the AWS CLI.\n'
+                        )
+                    continue
+                if not overwrite_existing:
+                    if stream:
+                        installed = read_installed_version(real_dir)
+                        version_note = f' ({installed})' if installed else ''
+                        stream.write(
+                            f'  {skill_name} is already installed'
+                            f'{version_note}. Run "aws agent-toolkit '
+                            f'update-skill --skill-name {skill_name}" to '
+                            f'update, or remove it first to reinstall.\n'
+                        )
+                    continue
+                shutil.rmtree(real_dir)
+            os.makedirs(real_dir, exist_ok=True)
+            zf.extractall(real_dir)
+            write_skill_metadata(real_dir, version)
             if stream:
                 stream.write(
                     f'  {action} {skill_name} ({version})'

--- a/tests/unit/customizations/agenttoolkit/test_add_skill.py
+++ b/tests/unit/customizations/agenttoolkit/test_add_skill.py
@@ -313,6 +313,7 @@ def test_add_skill_skips_symlinked_existing_install(tmp_path):
     rc, output = _run_add(configs, ['--skill-name', 'aws-s3'])
     assert rc == 0
     assert 'aws-s3 is already installed (v1)' in output
+    assert 'update-skill --skill-name aws-s3' in output
     assert link.is_symlink()
     assert (target / 'SKILL.md').read_text() == 'old'
 

--- a/tests/unit/customizations/agenttoolkit/test_add_skill.py
+++ b/tests/unit/customizations/agenttoolkit/test_add_skill.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from awscli.customizations.agenttoolkit.add_skill import AddSkillCommand
+from awscli.customizations.agenttoolkit.agents import SKILL_METADATA_FILENAME
 from awscli.customizations.agenttoolkit.utils import AgentToolkitServiceError
 from awscli.customizations.exceptions import ParamValidationError
 from tests.unit.customizations.agenttoolkit.utils import (
@@ -226,6 +227,111 @@ def test_add_skill_universal_row_coexists_with_override_agent(tmp_path):
     # Codex shares the skills path; the universal row owns the print line.
     assert output.count('Installed aws-cdk') == 1
     assert (shared / 'aws-cdk' / 'SKILL.md').exists()
+
+
+def test_add_skill_already_installed_message_not_duplicated(tmp_path):
+    (tmp_path / '.codex').mkdir()
+    universal_base = tmp_path / '.agents'
+    shared = universal_base / 'skills'
+    skill_dir = shared / 'aws-cdk'
+    skill_dir.mkdir(parents=True)
+    (skill_dir / 'SKILL.md').write_text('old')
+    (skill_dir / SKILL_METADATA_FILENAME).write_text('{"version": "v1"}')
+    configs = [
+        make_config(
+            tmp_path,
+            id='codex',
+            display_name='Codex',
+            detection_path=str(tmp_path / '.codex'),
+            skills_path_override=str(shared),
+        ),
+        make_config(
+            tmp_path,
+            id='universal',
+            display_name='Universal (Codex)',
+            detection_path=str(universal_base),
+        ),
+    ]
+    rc, output = _run_add(configs, ['--skill-name', 'aws-cdk'])
+    assert rc == 0
+    assert output.count('already installed') == 1
+
+
+def test_add_skill_into_symlinked_skills_dir(tmp_path):
+    # User symlinks an agent's skills dir into a shared location so every
+    # agent reads one source of truth. We follow the link and write into
+    # its target, preserving the link (shutil.rmtree would otherwise refuse
+    # to operate on the symlink).
+    shared = tmp_path / 'shared-skills'
+    shared.mkdir()
+    agent_dir = tmp_path / '.test-agent'
+    agent_dir.mkdir()
+    skills_link = agent_dir / 'skills'
+    skills_link.symlink_to(shared, target_is_directory=True)
+
+    configs = [make_config(tmp_path)]
+    rc, output = _run_add(configs, ['--skill-name', 'aws-s3'])
+    assert rc == 0
+    assert 'Installed aws-s3 (v1) to Test Agent' in output
+    # The symlink is preserved and the skill landed in its target.
+    assert skills_link.is_symlink()
+    assert (shared / 'aws-s3' / 'SKILL.md').exists()
+
+
+def test_add_skill_already_installed_recommends_update(tmp_path):
+    # add-skill leaves an existing AWS-CLI install alone and points the
+    # user at the version-aware update-skill command rather than silently
+    # overwriting it.
+    skill_dir = tmp_path / '.test-agent' / 'skills' / 'aws-s3'
+    skill_dir.mkdir(parents=True)
+    (skill_dir / 'SKILL.md').write_text('old')
+    (skill_dir / SKILL_METADATA_FILENAME).write_text('{"version": "v1"}')
+
+    configs = [make_config(tmp_path)]
+    rc, output = _run_add(configs, ['--skill-name', 'aws-s3'])
+    assert rc == 0
+    assert 'aws-s3 is already installed (v1)' in output
+    assert 'update-skill --skill-name aws-s3' in output
+    assert 'Installed aws-s3' not in output
+    # Existing content is untouched.
+    assert (skill_dir / 'SKILL.md').read_text() == 'old'
+
+
+def test_add_skill_skips_symlinked_existing_install(tmp_path):
+    # The per-skill dir is a symlink to a previously-installed location.
+    # We resolve it, see our marker, and skip (recommend update) without
+    # touching the link or its target.
+    (tmp_path / '.test-agent' / 'skills').mkdir(parents=True)
+    target = tmp_path / 'real-aws-s3'
+    target.mkdir()
+    (target / 'SKILL.md').write_text('old')
+    (target / SKILL_METADATA_FILENAME).write_text('{"version": "v1"}')
+    link = tmp_path / '.test-agent' / 'skills' / 'aws-s3'
+    link.symlink_to(target, target_is_directory=True)
+
+    configs = [make_config(tmp_path)]
+    rc, output = _run_add(configs, ['--skill-name', 'aws-s3'])
+    assert rc == 0
+    assert 'aws-s3 is already installed (v1)' in output
+    assert link.is_symlink()
+    assert (target / 'SKILL.md').read_text() == 'old'
+
+
+def test_add_skill_skips_unmarked_existing_dir(tmp_path):
+    # User has a hand-written skill (no AWS CLI metadata marker). Install
+    # must skip it rather than destroy the user's content.
+    skill_dir = tmp_path / '.test-agent' / 'skills' / 'aws-s3'
+    skill_dir.mkdir(parents=True)
+    (skill_dir / 'SKILL.md').write_text('hand-written content')
+
+    configs = [make_config(tmp_path)]
+    rc, output = _run_add(configs, ['--skill-name', 'aws-s3'])
+    assert rc == 0
+    assert 'was not installed by the AWS CLI' in output
+    assert 'Installed aws-s3' not in output
+    assert (skill_dir / 'SKILL.md').read_text() == 'hand-written content'
+    # No marker written, so we did not adopt the directory.
+    assert not (skill_dir / SKILL_METADATA_FILENAME).exists()
 
 
 def test_add_skill_zip_slip_rejected(tmp_path):

--- a/tests/unit/customizations/agenttoolkit/test_update_skill.py
+++ b/tests/unit/customizations/agenttoolkit/test_update_skill.py
@@ -140,6 +140,39 @@ def test_update_skill_missing_marker_skipped(tmp_path):
         _run_update(configs, ['--skill-name', 'aws-s3'], remote_version='v2')
 
 
+def test_update_skill_through_symlinked_dir(tmp_path):
+    # A user symlinks the per-skill dir into a shared location. update-skill
+    # must follow the link and overwrite the target in place (shutil.rmtree
+    # refuses to operate on the symlink itself), leaving the link intact.
+    (tmp_path / '.test-agent' / 'skills').mkdir(parents=True)
+    target = tmp_path / 'shared' / 'aws-s3'
+    target.mkdir(parents=True)
+    (target / 'SKILL.md').write_text('old')
+    (target / 'old.md').write_text('removed in v2')
+    (target / SKILL_METADATA_FILENAME).write_text(
+        json.dumps({'version': 'v1'})
+    )
+    link = tmp_path / '.test-agent' / 'skills' / 'aws-s3'
+    link.symlink_to(target, target_is_directory=True)
+
+    configs = [make_config(tmp_path)]
+    new_zip = make_skill_zip({'SKILL.md': 'new'})[0]
+    rc, output = _run_update(
+        configs,
+        ['--skill-name', 'aws-s3'],
+        remote_version='v2',
+        zip_bytes=new_zip,
+    )
+    assert rc == 0
+    assert 'Updated aws-s3 (v2)' in output
+    assert link.is_symlink()
+    assert (target / 'SKILL.md').read_text() == 'new'
+    assert not (target / 'old.md').exists()
+    assert json.loads((target / SKILL_METADATA_FILENAME).read_text()) == {
+        'version': 'v2'
+    }
+
+
 def test_update_skill_removes_orphaned_files(tmp_path):
     skill_dir = tmp_path / '.test-agent' / 'skills' / 'aws-s3'
     skill_dir.mkdir(parents=True)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
  
- Fix crash when an agent's skill dir is a symlink (shutil.rmtree refuses to operate on symlinks)
- Update add-skill to skip and point at update-skill when a skill is already installed, instead of silently overwriting
- Update both add-skill and update-skill to skip non aws directories instead of clobbering user content
- Dedup the "already installed" / "skipped" messages so they print once per canonical path

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
