### PR TITLE
feat(emr): Improve SSH host key verification with accept-new

### DIFF
--- a/.changes/next-release/enhancement-emr-34686.json
+++ b/.changes/next-release/enhancement-emr-34686.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "emr",
+  "description": "EMR SSH/SCP helper commands (``aws emr ssh``, ``socks``, ``put``, ``get``) now default to ``StrictHostKeyChecking=accept-new`` for improved host key verification security. A new ``--ssh-options`` parameter allows passing arbitrary SSH options to override defaults. On systems with OpenSSH < 7.6, the CLI automatically falls back to the previous behavior with a warning."
+}

--- a/awscli/customizations/emr/ssh.py
+++ b/awscli/customizations/emr/ssh.py
@@ -13,6 +13,7 @@
 
 import os
 import subprocess
+import sys
 import tempfile
 
 from awscli.customizations.emr import constants, emrutils, sshutils
@@ -23,6 +24,67 @@ KEY_PAIR_FILE_HELP_TEXT = (
     'can be set in the AWS CLI config file using the '
     '"aws configure set emr.key_pair_file <value>" command.\n'
 )
+
+SSH_OPTIONS_HELP_TEXT = (
+    'Additional SSH options passed directly to the ssh/scp command. '
+    'Multiple options can be specified space-separated. Example: '
+    '--ssh-options StrictHostKeyChecking=no ConnectTimeout=30'
+)
+
+DEFAULT_STRICT_HOST_KEY_CHECKING = 'StrictHostKeyChecking=accept-new'
+
+UNSUPPORTED_OPTION_MSG = (
+    'WARNING: Your OpenSSH version does not support '
+    'StrictHostKeyChecking=accept-new (requires OpenSSH 7.6+). '
+    'Falling back to StrictHostKeyChecking=no. '
+    'Upgrade to OpenSSH 7.6+ for improved security.\n'
+)
+
+PUTTY_SSH_OPTIONS_MSG = (
+    'WARNING: --ssh-options is only supported with OpenSSH. '
+    'Options are ignored when using PuTTY/pscp.\n'
+)
+
+
+def _supports_accept_new():
+    """Check if OpenSSH supports StrictHostKeyChecking=accept-new."""
+    try:
+        result = subprocess.run(
+            ['ssh', '-G', '-o', 'StrictHostKeyChecking=accept-new',
+             'localhost'],
+            capture_output=True, text=True,
+        )
+        return result.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _has_strict_host_key_override(extra_options):
+    """Check if user provided a StrictHostKeyChecking override."""
+    if not extra_options:
+        return False
+    for opt in extra_options:
+        if opt.lower().startswith('stricthostkeychecking='):
+            return True
+    return False
+
+
+def _build_ssh_options(extra_options):
+    """Build the -o flags list for ssh/scp commands."""
+    options = []
+    if _has_strict_host_key_override(extra_options):
+        for opt in extra_options:
+            options.extend(['-o', opt])
+    else:
+        if _supports_accept_new():
+            options.extend(['-o', DEFAULT_STRICT_HOST_KEY_CHECKING])
+        else:
+            sys.stderr.write(UNSUPPORTED_OPTION_MSG)
+            options.extend(['-o', 'StrictHostKeyChecking=no'])
+        if extra_options:
+            for opt in extra_options:
+                options.extend(['-o', opt])
+    return options
 
 
 class Socks(Command):
@@ -42,6 +104,11 @@ class Socks(Command):
             'required': True,
             'help_text': 'Private key file to use for login',
         },
+        {
+            'name': 'ssh-options',
+            'nargs': '+',
+            'help_text': SSH_OPTIONS_HELP_TEXT,
+        },
     ]
 
     def _run_main_command(self, parsed_args, parsed_globals):
@@ -56,28 +123,20 @@ class Socks(Command):
             sshutils.validate_ssh_with_key_file(key_file)
             f = tempfile.NamedTemporaryFile(delete=False)
             if emrutils.which('ssh') or emrutils.which('ssh.exe'):
-                command = [
-                    'ssh',
-                    '-o',
-                    'StrictHostKeyChecking=no',
-                    '-o',
-                    'ServerAliveInterval=10',
-                    '-ND',
-                    '8157',
-                    '-i',
-                    parsed_args.key_pair_file,
+                ssh_options = _build_ssh_options(parsed_args.ssh_options)
+                command = ['ssh'] + ssh_options + [
+                    '-o', 'ServerAliveInterval=10',
+                    '-ND', '8157',
+                    '-i', parsed_args.key_pair_file,
                     constants.SSH_USER + '@' + master_dns,
                 ]
             else:
+                if parsed_args.ssh_options:
+                    sys.stderr.write(PUTTY_SSH_OPTIONS_MSG)
                 command = [
-                    'putty',
-                    '-ssh',
-                    '-i',
-                    parsed_args.key_pair_file,
+                    'putty', '-ssh', '-i', parsed_args.key_pair_file,
                     constants.SSH_USER + '@' + master_dns,
-                    '-N',
-                    '-D',
-                    '8157',
+                    '-N', '-D', '8157',
                 ]
 
             print(' '.join(command))
@@ -105,6 +164,11 @@ class SSH(Command):
             'help_text': 'Private key file to use for login',
         },
         {'name': 'command', 'help_text': 'Command to execute on Master Node'},
+        {
+            'name': 'ssh-options',
+            'nargs': '+',
+            'help_text': SSH_OPTIONS_HELP_TEXT,
+        },
     ]
 
     def _run_main_command(self, parsed_args, parsed_globals):
@@ -118,27 +182,21 @@ class SSH(Command):
         sshutils.validate_ssh_with_key_file(key_file)
         f = tempfile.NamedTemporaryFile(delete=False)
         if emrutils.which('ssh') or emrutils.which('ssh.exe'):
-            command = [
-                'ssh',
-                '-o',
-                'StrictHostKeyChecking=no',
-                '-o',
-                'ServerAliveInterval=10',
-                '-i',
-                parsed_args.key_pair_file,
+            ssh_options = _build_ssh_options(parsed_args.ssh_options)
+            command = ['ssh'] + ssh_options + [
+                '-o', 'ServerAliveInterval=10',
+                '-i', parsed_args.key_pair_file,
                 constants.SSH_USER + '@' + master_dns,
                 '-t',
             ]
             if parsed_args.command:
                 command.append(parsed_args.command)
         else:
+            if parsed_args.ssh_options:
+                sys.stderr.write(PUTTY_SSH_OPTIONS_MSG)
             command = [
-                'putty',
-                '-ssh',
-                '-i',
-                parsed_args.key_pair_file,
-                constants.SSH_USER + '@' + master_dns,
-                '-t',
+                'putty', '-ssh', '-i', parsed_args.key_pair_file,
+                constants.SSH_USER + '@' + master_dns, '-t',
             ]
             if parsed_args.command:
                 f.write(parsed_args.command)
@@ -175,6 +233,11 @@ class Put(Command):
             'help_text': 'Source file path on local machine',
         },
         {'name': 'dest', 'help_text': 'Destination file path on remote host'},
+        {
+            'name': 'ssh-options',
+            'nargs': '+',
+            'help_text': SSH_OPTIONS_HELP_TEXT,
+        },
     ]
 
     def _run_main_command(self, parsed_args, parsed_globals):
@@ -187,27 +250,20 @@ class Put(Command):
         key_file = parsed_args.key_pair_file
         sshutils.validate_scp_with_key_file(key_file)
         if emrutils.which('scp') or emrutils.which('scp.exe'):
-            command = [
-                'scp',
-                '-r',
-                '-o StrictHostKeyChecking=no',
-                '-i',
-                parsed_args.key_pair_file,
+            ssh_options = _build_ssh_options(parsed_args.ssh_options)
+            command = ['scp', '-r'] + ssh_options + [
+                '-i', parsed_args.key_pair_file,
                 parsed_args.src,
                 constants.SSH_USER + '@' + master_dns,
             ]
         else:
+            if parsed_args.ssh_options:
+                sys.stderr.write(PUTTY_SSH_OPTIONS_MSG)
             command = [
-                'pscp',
-                '-scp',
-                '-r',
-                '-i',
-                parsed_args.key_pair_file,
-                parsed_args.src,
-                constants.SSH_USER + '@' + master_dns,
+                'pscp', '-scp', '-r', '-i', parsed_args.key_pair_file,
+                parsed_args.src, constants.SSH_USER + '@' + master_dns,
             ]
 
-        # if the instance is not terminated
         if parsed_args.dest:
             command[-1] = command[-1] + ":" + parsed_args.dest
         else:
@@ -237,6 +293,11 @@ class Get(Command):
             'help_text': 'Source file path on remote host',
         },
         {'name': 'dest', 'help_text': 'Destination file path on your machine'},
+        {
+            'name': 'ssh-options',
+            'nargs': '+',
+            'help_text': SSH_OPTIONS_HELP_TEXT,
+        },
     ]
 
     def _run_main_command(self, parsed_args, parsed_globals):
@@ -249,21 +310,16 @@ class Get(Command):
         key_file = parsed_args.key_pair_file
         sshutils.validate_scp_with_key_file(key_file)
         if emrutils.which('scp') or emrutils.which('scp.exe'):
-            command = [
-                'scp',
-                '-r',
-                '-o StrictHostKeyChecking=no',
-                '-i',
-                parsed_args.key_pair_file,
+            ssh_options = _build_ssh_options(parsed_args.ssh_options)
+            command = ['scp', '-r'] + ssh_options + [
+                '-i', parsed_args.key_pair_file,
                 constants.SSH_USER + '@' + master_dns + ':' + parsed_args.src,
             ]
         else:
+            if parsed_args.ssh_options:
+                sys.stderr.write(PUTTY_SSH_OPTIONS_MSG)
             command = [
-                'pscp',
-                '-scp',
-                '-r',
-                '-i',
-                parsed_args.key_pair_file,
+                'pscp', '-scp', '-r', '-i', parsed_args.key_pair_file,
                 constants.SSH_USER + '@' + master_dns + ':' + parsed_args.src,
             ]
 

--- a/tests/unit/customizations/emr/test_ssh_host_key.py
+++ b/tests/unit/customizations/emr/test_ssh_host_key.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from awscli.customizations.emr.ssh import SSH, Get, Put, Socks
+from awscli.testutils import mock
+from tests.unit.customizations.emr import (
+    EMRBaseAWSCommandParamsTest as BaseAWSCommandParamsTest,
+)
+
+CLUSTER_ID = "j-TESTCLUSTER123"
+KEY_PAIR_FILE = "/tmp/test_key.pem"
+MASTER_DNS = "ec2-1-2-3-4.us-west-2.compute.amazonaws.com"
+
+
+class TestSSHHostKeyVerification(BaseAWSCommandParamsTest):
+    """Verify all EMR SSH commands use StrictHostKeyChecking=accept-new
+    when OpenSSH supports it."""
+
+    def _get_ssh_command(self, mock_call):
+        self.assertTrue(mock_call.called)
+        return mock_call.call_args[0][0]
+
+    def _assert_accept_new(self, command):
+        joined = ' '.join(command)
+        self.assertIn('StrictHostKeyChecking=accept-new', joined)
+        self.assertNotIn('StrictHostKeyChecking=no', joined)
+
+    @mock.patch('subprocess.call', return_value=0)
+    @mock.patch('awscli.customizations.emr.ssh._supports_accept_new',
+                return_value=True)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_and_find_master_dns',
+                return_value=MASTER_DNS)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_ssh_with_key_file')
+    @mock.patch('awscli.customizations.emr.emrutils.which', return_value='/usr/bin/ssh')
+    def test_socks_uses_accept_new(self, mock_which, mock_validate,
+                                   mock_dns, mock_probe, mock_call):
+        self.run_cmd(
+            f'emr socks --cluster-id {CLUSTER_ID} '
+            f'--key-pair-file {KEY_PAIR_FILE}', 0)
+        command = self._get_ssh_command(mock_call)
+        self._assert_accept_new(command)
+
+    @mock.patch('subprocess.call', return_value=0)
+    @mock.patch('awscli.customizations.emr.ssh._supports_accept_new',
+                return_value=True)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_and_find_master_dns',
+                return_value=MASTER_DNS)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_ssh_with_key_file')
+    @mock.patch('awscli.customizations.emr.emrutils.which', return_value='/usr/bin/ssh')
+    def test_ssh_uses_accept_new(self, mock_which, mock_validate,
+                                 mock_dns, mock_probe, mock_call):
+        self.run_cmd(
+            f'emr ssh --cluster-id {CLUSTER_ID} '
+            f'--key-pair-file {KEY_PAIR_FILE}', 0)
+        command = self._get_ssh_command(mock_call)
+        self._assert_accept_new(command)
+
+    @mock.patch('subprocess.call', return_value=0)
+    @mock.patch('awscli.customizations.emr.ssh._supports_accept_new',
+                return_value=True)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_and_find_master_dns',
+                return_value=MASTER_DNS)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_scp_with_key_file')
+    @mock.patch('awscli.customizations.emr.emrutils.which', return_value='/usr/bin/scp')
+    def test_put_uses_accept_new(self, mock_which, mock_validate,
+                                 mock_dns, mock_probe, mock_call):
+        self.run_cmd(
+            f'emr put --cluster-id {CLUSTER_ID} '
+            f'--key-pair-file {KEY_PAIR_FILE} --src /tmp/local.txt', 0)
+        command = self._get_ssh_command(mock_call)
+        self._assert_accept_new(command)
+
+    @mock.patch('subprocess.call', return_value=0)
+    @mock.patch('awscli.customizations.emr.ssh._supports_accept_new',
+                return_value=True)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_and_find_master_dns',
+                return_value=MASTER_DNS)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_scp_with_key_file')
+    @mock.patch('awscli.customizations.emr.emrutils.which', return_value='/usr/bin/scp')
+    def test_get_uses_accept_new(self, mock_which, mock_validate,
+                                 mock_dns, mock_probe, mock_call):
+        self.run_cmd(
+            f'emr get --cluster-id {CLUSTER_ID} '
+            f'--key-pair-file {KEY_PAIR_FILE} --src /remote/file.txt', 0)
+        command = self._get_ssh_command(mock_call)
+        self._assert_accept_new(command)
+
+
+class TestSSHFallbackOnOldOpenSSH(BaseAWSCommandParamsTest):
+    """Verify fallback to StrictHostKeyChecking=no when accept-new
+    is not supported, with a warning."""
+
+    def _get_ssh_command(self, mock_call):
+        self.assertTrue(mock_call.called)
+        return mock_call.call_args[0][0]
+
+    @mock.patch('subprocess.call', return_value=0)
+    @mock.patch('awscli.customizations.emr.ssh._supports_accept_new',
+                return_value=False)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_and_find_master_dns',
+                return_value=MASTER_DNS)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_ssh_with_key_file')
+    @mock.patch('awscli.customizations.emr.emrutils.which', return_value='/usr/bin/ssh')
+    def test_falls_back_to_no_with_warning(self, mock_which, mock_validate,
+                                           mock_dns, mock_probe, mock_call):
+        _, stderr, _ = self.run_cmd(
+            f'emr ssh --cluster-id {CLUSTER_ID} '
+            f'--key-pair-file {KEY_PAIR_FILE}', 0)
+        command = self._get_ssh_command(mock_call)
+        joined = ' '.join(command)
+        self.assertIn('StrictHostKeyChecking=no', joined)
+        self.assertNotIn('StrictHostKeyChecking=accept-new', joined)
+        self.assertIn('Upgrade to OpenSSH 7.6+', stderr)
+
+
+class TestSSHOptionsPassthrough(BaseAWSCommandParamsTest):
+    """Verify --ssh-options are passed through and can override defaults."""
+
+    def _get_ssh_command(self, mock_call):
+        self.assertTrue(mock_call.called)
+        return mock_call.call_args[0][0]
+
+    @mock.patch('subprocess.call', return_value=0)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_and_find_master_dns',
+                return_value=MASTER_DNS)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_ssh_with_key_file')
+    @mock.patch('awscli.customizations.emr.emrutils.which', return_value='/usr/bin/ssh')
+    def test_ssh_options_override_strict_host_key(self, mock_which,
+                                                  mock_validate,
+                                                  mock_dns, mock_call):
+        self.run_cmd(
+            f'emr ssh --cluster-id {CLUSTER_ID} --key-pair-file {KEY_PAIR_FILE} '
+            '--ssh-options StrictHostKeyChecking=no', 0)
+        command = self._get_ssh_command(mock_call)
+        joined = ' '.join(command)
+        self.assertIn('StrictHostKeyChecking=no', joined)
+        self.assertNotIn('StrictHostKeyChecking=accept-new', joined)
+
+    @mock.patch('subprocess.call', return_value=0)
+    @mock.patch('awscli.customizations.emr.ssh._supports_accept_new',
+                return_value=True)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_and_find_master_dns',
+                return_value=MASTER_DNS)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_ssh_with_key_file')
+    @mock.patch('awscli.customizations.emr.emrutils.which', return_value='/usr/bin/ssh')
+    def test_ssh_options_additional_options(self, mock_which, mock_validate,
+                                           mock_dns, mock_probe, mock_call):
+        self.run_cmd(
+            f'emr ssh --cluster-id {CLUSTER_ID} --key-pair-file {KEY_PAIR_FILE} '
+            '--ssh-options ConnectTimeout=30', 0)
+        command = self._get_ssh_command(mock_call)
+        joined = ' '.join(command)
+        self.assertIn('StrictHostKeyChecking=accept-new', joined)
+        self.assertIn('ConnectTimeout=30', joined)
+
+    @mock.patch('subprocess.call', return_value=0)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_and_find_master_dns',
+                return_value=MASTER_DNS)
+    @mock.patch('awscli.customizations.emr.sshutils.validate_scp_with_key_file')
+    @mock.patch('awscli.customizations.emr.emrutils.which', return_value='/usr/bin/scp')
+    def test_put_options_override(self, mock_which, mock_validate,
+                                  mock_dns, mock_call):
+        self.run_cmd(
+            f'emr put --cluster-id {CLUSTER_ID} --key-pair-file {KEY_PAIR_FILE} '
+            '--src /tmp/f.txt '
+            '--ssh-options StrictHostKeyChecking=no', 0)
+        command = self._get_ssh_command(mock_call)
+        joined = ' '.join(command)
+        self.assertIn('StrictHostKeyChecking=no', joined)
+        self.assertNotIn('StrictHostKeyChecking=accept-new', joined)


### PR DESCRIPTION
EMR SSH/SCP helper commands (ssh, socks, put, get) now default to StrictHostKeyChecking=accept-new for improved host key verification. Uses ssh -G probe to detect support; falls back to =no with warning on OpenSSH < 7.6.

New --ssh-options parameter allows passing arbitrary SSH options (space-separated) to override defaults. This provides an escape hatch for legacy clients and addresses #1799.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
