### PR TITLE
Fix add-skill limbo when SKILL.md is manually deleted

### DIFF
--- a/.changes/next-release/bugfix-agenttoolkit-24712.json
+++ b/.changes/next-release/bugfix-agenttoolkit-24712.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``agent-toolkit``",
+  "description": "Fixes ``add-skill`` getting stuck when a previous install is missing ``SKILL.md``."
+}

--- a/awscli/customizations/agenttoolkit/utils.py
+++ b/awscli/customizations/agenttoolkit/utils.py
@@ -20,6 +20,7 @@ import zipfile
 
 from awscli.customizations.agenttoolkit.agents import (
     AGENT_CONFIGS,
+    SKILL_FILENAME,
     SKILL_METADATA_FILENAME,
     get_detected_agents,
     universal_first,
@@ -183,7 +184,12 @@ def install_skill(
                             f'directory was not installed by the AWS CLI.\n'
                         )
                     continue
-                if not overwrite_existing:
+                # Marker is present, but if SKILL.md is missing the
+                # previous install is corrupted (e.g. user deleted files
+                # by hand).
+                skill_file = os.path.join(real_dir, SKILL_FILENAME)
+                is_corrupted = not os.path.exists(skill_file)
+                if not overwrite_existing and not is_corrupted:
                     if stream:
                         installed = read_installed_version(real_dir)
                         version_note = f' ({installed})' if installed else ''
@@ -195,6 +201,11 @@ def install_skill(
                             f'or remove it first to reinstall.\n'
                         )
                     continue
+                if is_corrupted and not overwrite_existing and stream:
+                    stream.write(
+                        f'  Reinstalling {skill_name} at {real_dir}: '
+                        f'previous install appears incomplete.\n'
+                    )
                 shutil.rmtree(real_dir)
             os.makedirs(real_dir, exist_ok=True)
             zf.extractall(real_dir)

--- a/tests/unit/customizations/agenttoolkit/test_add_skill.py
+++ b/tests/unit/customizations/agenttoolkit/test_add_skill.py
@@ -335,6 +335,19 @@ def test_add_skill_skips_unmarked_existing_dir(tmp_path):
     assert not (skill_dir / SKILL_METADATA_FILENAME).exists()
 
 
+def test_add_skill_heals_corrupted_install(tmp_path):
+    skill_dir = tmp_path / '.test-agent' / 'skills' / 'aws-s3'
+    skill_dir.mkdir(parents=True)
+    (skill_dir / SKILL_METADATA_FILENAME).write_text('{"version": "v1"}')
+    configs = [make_config(tmp_path)]
+    rc, output = _run_add(configs, ['--skill-name', 'aws-s3'])
+    assert rc == 0
+    assert 'previous install appears incomplete' in output
+    assert 'Installed aws-s3 (v1)' in output
+    assert (skill_dir / 'SKILL.md').exists()
+    assert (skill_dir / SKILL_METADATA_FILENAME).exists()
+
+
 def test_add_skill_zip_slip_rejected(tmp_path):
     (tmp_path / '.test-agent' / 'skills').mkdir(parents=True)
     configs = [make_config(tmp_path)]


### PR DESCRIPTION
#### *Description of changes:* 
`add-skill` previously got stuck when a previous install had its SKILL.md deleted by hand but its `.aws-skill-metadata` marker left behind. The marker made the toolkit treat the skill as already installed, but the skill was actually unusable. This change detects the corrupted state (marker present, SKILL.md missing) and reinstalls the skill.

#### *Testing:*

```
aws-cli % rm -rf /Users/.../.claude/skills/aws-cdk/SKILL.md
aws-cli % aws agent-toolkit add-skill --skill-name  aws-cdk --region us-east-1
  Reinstalling aws-cdk at /Users/.../.claude/skills/aws-cdk: previous install appears incomplete.
  Installed aws-cdk (v1) to Claude Code — ~/.claude/skills.
  aws-cdk is already installed (v1) at /Users/.../.kiro/skills/aws-cdk. Run "aws agent-toolkit update-skill --skill-name aws-cdk" to update, or remove it first to reinstall.
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
