### PR TITLE
docs(ec2): Add examples for modify/describe ipam-pool-allocation APIs

### DIFF
--- a/awscli/examples/ec2/describe-ipam-pool-allocations.rst
+++ b/awscli/examples/ec2/describe-ipam-pool-allocations.rst
@@ -1,0 +1,64 @@
+**Example 1: To describe all your IPAM pool allocations**
+
+The following ``describe-ipam-pool-allocations`` example describes all IPAM pool allocations owned by you.
+
+(Linux)::
+
+    aws ec2 describe-ipam-pool-allocations
+
+(Windows)::
+
+    aws ec2 describe-ipam-pool-allocations
+
+Output::
+
+    {
+        "IpamPoolAllocations": [
+            {
+                "Cidr": "10.0.0.0/24",
+                "IpamPoolAllocationId": "ipam-pool-alloc-018ecc28043b54ba38e2cd99943cebfbd",
+                "Description": "Engineering team allocation",
+                "ResourceType": "custom",
+                "ResourceOwner": "123456789012",
+                "Tags": []
+            },
+            {
+                "Cidr": "10.0.1.0/24",
+                "IpamPoolAllocationId": "ipam-pool-alloc-0e6186d73999e47389266a5d6991e6220",
+                "ResourceType": "custom",
+                "ResourceOwner": "123456789012",
+                "Tags": []
+            }
+        ]
+    }
+
+**Example 2: To describe a specific IPAM pool allocation**
+
+The following ``describe-ipam-pool-allocations`` example describes a specific IPAM pool allocation by its ID.
+
+(Linux)::
+
+    aws ec2 describe-ipam-pool-allocations \
+        --ipam-pool-allocation-ids ipam-pool-alloc-018ecc28043b54ba38e2cd99943cebfbd
+
+(Windows)::
+
+    aws ec2 describe-ipam-pool-allocations ^
+        --ipam-pool-allocation-ids ipam-pool-alloc-018ecc28043b54ba38e2cd99943cebfbd
+
+Output::
+
+    {
+        "IpamPoolAllocations": [
+            {
+                "Cidr": "10.0.0.0/24",
+                "IpamPoolAllocationId": "ipam-pool-alloc-018ecc28043b54ba38e2cd99943cebfbd",
+                "Description": "Engineering team allocation",
+                "ResourceType": "custom",
+                "ResourceOwner": "123456789012",
+                "Tags": []
+            }
+        ]
+    }
+
+For more information, see `View allocations for a pool <https://docs.aws.amazon.com/vpc/latest/ipam/view-alloc-ipam.html>`__ in the *Amazon VPC IPAM User Guide*.

--- a/awscli/examples/ec2/modify-ipam-pool-allocation.rst
+++ b/awscli/examples/ec2/modify-ipam-pool-allocation.rst
@@ -1,0 +1,29 @@
+**To modify an IPAM pool allocation**
+
+The following ``modify-ipam-pool-allocation`` example modifies the description of an IPAM pool allocation.
+
+(Linux)::
+
+    aws ec2 modify-ipam-pool-allocation \
+        --ipam-pool-allocation-id ipam-pool-alloc-018ecc28043b54ba38e2cd99943cebfbd \
+        --description "Engineering team  us-west-2 allocation"
+
+(Windows)::
+
+    aws ec2 modify-ipam-pool-allocation ^
+        --ipam-pool-allocation-id ipam-pool-alloc-018ecc28043b54ba38e2cd99943cebfbd ^
+        --description "Engineering team  us-west-2 allocation"
+
+Output::
+
+    {
+        "IpamPoolAllocation": {
+            "Cidr": "10.0.0.0/24",
+            "IpamPoolAllocationId": "ipam-pool-alloc-018ecc28043b54ba38e2cd99943cebfbd",
+            "Description": "Engineering team  us-west-2 allocation",
+            "ResourceType": "custom",
+            "ResourceOwner": "123456789012"
+        }
+    }
+
+For more information, see `Modify an IPAM pool allocation <https://docs.aws.amazon.com/vpc/latest/ipam/modify-alloc-ipam.html>`__ in the *Amazon VPC IPAM User Guide*.


### PR DESCRIPTION
Add CLI examples for two IPAM pool allocation commands:
- modify-ipam-pool-allocation: modifying the description of an allocation
- describe-ipam-pool-allocations: listing all allocations and filtering by ID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
