### PR TITLE
Add 'amz-invocation-id' and 'amz-sdk-request' headers

### DIFF
--- a/.changes/next-release/enhancement-retries-78592.json
+++ b/.changes/next-release/enhancement-retries-78592.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "retries",
+  "description": "Set the ``amz-invocation-id`` and ``amz-sdk-request`` headers with information about retries"
+}

--- a/awscli/botocore/endpoint.py
+++ b/awscli/botocore/endpoint.py
@@ -12,10 +12,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import datetime
 import logging
 import os
 import threading
 import time
+import uuid
 
 from botocore import parsers
 from botocore.awsrequest import create_request_object
@@ -142,10 +144,54 @@ class Endpoint:
         self._encode_headers(request.headers)
         return request.prepare()
 
+    def _calculate_ttl(
+        self, response_received_timestamp, date_header, read_timeout
+    ):
+        local_timestamp = datetime.datetime.utcnow()
+        date_conversion = datetime.datetime.strptime(
+            date_header, "%a, %d %b %Y %H:%M:%S %Z"
+        )
+        estimated_skew = date_conversion - response_received_timestamp
+        ttl = (
+            local_timestamp
+            + datetime.timedelta(seconds=read_timeout)
+            + estimated_skew
+        )
+        return ttl.strftime('%Y%m%dT%H%M%SZ')
+
+    def _set_ttl(self, retries_context, read_timeout, success_response):
+        response_date_header = success_response[0].headers.get('Date')
+        has_streaming_input = retries_context.get('has_streaming_input')
+        if response_date_header and not has_streaming_input:
+            try:
+                response_received_timestamp = datetime.datetime.utcnow()
+                retries_context['ttl'] = self._calculate_ttl(
+                    response_received_timestamp,
+                    response_date_header,
+                    read_timeout,
+                )
+            except Exception:
+                logger.debug(
+                    "Exception received when updating retries context "
+                    "with TTL",
+                    exc_info=True,
+                )
+
+    def _update_retries_context(self, context, attempt, success_response=None):
+        retries_context = context.setdefault('retries', {})
+        retries_context['attempt'] = attempt
+        if 'invocation-id' not in retries_context:
+            retries_context['invocation-id'] = str(uuid.uuid4())
+
+        if success_response:
+            read_timeout = context['client_config'].read_timeout
+            self._set_ttl(retries_context, read_timeout, success_response)
+
     def _send_request(self, request_dict, operation_model):
         attempts = 1
-        request = self.create_request(request_dict, operation_model)
         context = request_dict['context']
+        self._update_retries_context(context, attempts)
+        request = self.create_request(request_dict, operation_model)
         success_response, exception = self._get_response(
             request, operation_model, context
         )
@@ -157,6 +203,7 @@ class Endpoint:
             exception,
         ):
             attempts += 1
+            self._update_retries_context(context, attempts, success_response)
             # If there is a stream associated with the request, we need
             # to reset it before attempting to send the request again.
             # This will ensure that we resend the entire contents of the

--- a/awscli/botocore/handlers.py
+++ b/awscli/botocore/handlers.py
@@ -1014,6 +1014,21 @@ def remove_polly_start_speech_synthesis_stream(class_attributes, **kwargs):
         del class_attributes['start_speech_synthesis_stream']
 
 
+def add_retry_headers(request, **kwargs):
+    retries_context = request.context.get('retries')
+    if not retries_context:
+        return
+    headers = request.headers
+    headers['amz-sdk-invocation-id'] = retries_context['invocation-id']
+    sdk_retry_keys = ('ttl', 'attempt', 'max')
+    sdk_request_headers = [
+        f'{key}={retries_context[key]}'
+        for key in sdk_retry_keys
+        if key in retries_context
+    ]
+    headers['amz-sdk-request'] = '; '.join(sdk_request_headers)
+
+
 def remove_bucket_from_url_paths_from_model(params, model, context, **kwargs):
     """Strips leading `{Bucket}/` from any operations that have it.
 
@@ -1418,6 +1433,7 @@ BUILTIN_HANDLERS = [
     ('before-call.glacier.UploadArchive', add_glacier_checksums),
     ('before-call.glacier.UploadMultipartPart', add_glacier_checksums),
     ('before-call.ec2.CopySnapshot', inject_presigned_url_ec2),
+    ('request-created', add_retry_headers),
     ('request-created.machine-learning.Predict', switch_host_machinelearning),
     ('needs-retry.s3.*', _update_status_code, REGISTER_FIRST),
     ('choose-signer.cognito-identity.GetId', disable_signing),

--- a/awscli/botocore/retries/standard.py
+++ b/awscli/botocore/retries/standard.py
@@ -443,6 +443,11 @@ class MaxAttemptsChecker(BaseRetryableChecker):
 
     def is_retryable(self, context):
         under_max_attempts = context.attempt_number < self._max_attempts
+        retries_context = context.request_context.get('retries')
+        if retries_context:
+            retries_context['max'] = max(
+                retries_context.get('max', 0), self._max_attempts
+            )
         if not under_max_attempts:
             logger.debug("Max attempts of %s reached.", self._max_attempts)
             context.add_retry_metadata(MaxAttemptsReached=True)

--- a/tests/functional/botocore/test_retry.py
+++ b/tests/functional/botocore/test_retry.py
@@ -11,8 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import contextlib
+import datetime
 import json
 
+import botocore.endpoint
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
@@ -22,8 +24,10 @@ from tests.functional.botocore.test_useragent import (
     parse_registered_feature_ids,
 )
 
+RETRY_MODES = ('standard', 'adaptive')
 
-class TestRetry(BaseSessionTest):
+
+class BaseRetryTest(BaseSessionTest):
     def setUp(self):
         super().setUp()
         self.region = 'us-west-2'
@@ -193,3 +197,146 @@ class TestRetry(BaseSessionTest):
         feature_lists = self._get_feature_id_lists_from_retries(client)
         # Confirm all requests register `'RETRY_MODE_ADAPTIVE': 'F'`
         assert all('F' in feature_list for feature_list in feature_lists)
+
+
+class TestRetryHeader(BaseRetryTest):
+    def _retry_headers_test_cases(self):
+        responses = [
+            [
+                (500, {'Date': 'Sat, 01 Jun 2019 00:00:00 GMT'}),
+                (500, {'Date': 'Sat, 01 Jun 2019 00:00:01 GMT'}),
+                (200, {'Date': 'Sat, 01 Jun 2019 00:00:02 GMT'}),
+            ],
+            [
+                (500, {'Date': 'Sat, 01 Jun 2019 00:10:03 GMT'}),
+                (500, {'Date': 'Sat, 01 Jun 2019 00:10:09 GMT'}),
+                (200, {'Date': 'Sat, 01 Jun 2019 00:10:15 GMT'}),
+            ],
+        ]
+
+        # The first, third and seventh datetime values of each
+        # utcnow_side_effects list are side_effect values for when
+        # utcnow is called in SigV4 signing.
+        utcnow_side_effects = [
+            [
+                datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 1, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 1, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 2, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+            ],
+            [
+                datetime.datetime(2020, 6, 1, 0, 0, 0, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 5, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 6, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 11, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 12, 0),
+                datetime.datetime(2019, 6, 1, 0, 0, 0, 0),
+            ],
+        ]
+        expected_headers = [
+            [
+                b'attempt=1',
+                b'ttl=20190601T000011Z; attempt=2; max=3',
+                b'ttl=20190601T000012Z; attempt=3; max=3',
+            ],
+            [
+                b'attempt=1',
+                b'ttl=20190601T001014Z; attempt=2; max=3',
+                b'ttl=20190601T001020Z; attempt=3; max=3',
+            ],
+        ]
+        test_cases = list(
+            zip(responses, utcnow_side_effects, expected_headers)
+        )
+        return test_cases
+
+    def _test_amz_sdk_request_header_with_test_case(
+        self, responses, utcnow_side_effects, expected_headers, client_config
+    ):
+        datetime_patcher = mock.patch.object(
+            botocore.endpoint.datetime,
+            'datetime',
+            mock.Mock(wraps=datetime.datetime),
+        )
+        mocked_datetime = datetime_patcher.start()
+        mocked_datetime.utcnow.side_effect = utcnow_side_effects
+
+        client = self.session.create_client(
+            'dynamodb', self.region, config=client_config
+        )
+        with ClientHTTPStubber(client) as http_stubber:
+            for response in responses:
+                http_stubber.add_response(
+                    headers=response[1], status=response[0], body=b'{}'
+                )
+            client.list_tables()
+            amz_sdk_request_headers = [
+                request.headers['amz-sdk-request']
+                for request in http_stubber.requests
+            ]
+            self.assertListEqual(amz_sdk_request_headers, expected_headers)
+        datetime_patcher.stop()
+
+    def test_amz_sdk_request_header(self):
+        test_cases = self._retry_headers_test_cases()
+        for retry_mode in RETRY_MODES:
+            retries_config = {'mode': retry_mode, 'max_attempts': 3}
+            client_config = Config(read_timeout=10, retries=retries_config)
+            for test_case in test_cases:
+                self._test_amz_sdk_request_header_with_test_case(
+                    *test_case, client_config=client_config
+                )
+
+    def test_amz_sdk_invocation_id_header_persists(self):
+        for retry_mode in RETRY_MODES:
+            client_config = Config(retries={'mode': retry_mode})
+            client = self.session.create_client(
+                'dynamodb', self.region, config=client_config
+            )
+            num_retries = 2
+            with ClientHTTPStubber(client) as http_stubber:
+                for _ in range(num_retries):
+                    http_stubber.add_response(status=500)
+                http_stubber.add_response(status=200)
+                client.list_tables()
+                amz_sdk_invocation_id_headers = [
+                    request.headers['amz-sdk-invocation-id']
+                    for request in http_stubber.requests
+                ]
+                self.assertEqual(
+                    amz_sdk_invocation_id_headers[0],
+                    amz_sdk_invocation_id_headers[1],
+                )
+                self.assertEqual(
+                    amz_sdk_invocation_id_headers[1],
+                    amz_sdk_invocation_id_headers[2],
+                )
+
+    def test_amz_sdk_invocation_id_header_unique_per_invocation(self):
+        client = self.session.create_client('dynamodb', self.region)
+        num_of_invocations = 2
+        with ClientHTTPStubber(client) as http_stubber:
+            for _ in range(num_of_invocations):
+                http_stubber.add_response(status=500)
+                http_stubber.add_response(status=200)
+                client.list_tables()
+            amz_sdk_invocation_id_headers = [
+                request.headers['amz-sdk-invocation-id']
+                for request in http_stubber.requests
+            ]
+            self.assertEqual(
+                amz_sdk_invocation_id_headers[0],
+                amz_sdk_invocation_id_headers[1],
+            )
+            self.assertEqual(
+                amz_sdk_invocation_id_headers[2],
+                amz_sdk_invocation_id_headers[3],
+            )
+            self.assertNotEqual(
+                amz_sdk_invocation_id_headers[0],
+                amz_sdk_invocation_id_headers[2],
+            )

--- a/tests/unit/botocore/test_endpoint.py
+++ b/tests/unit/botocore/test_endpoint.py
@@ -10,11 +10,14 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import datetime
 import io
 import socket
 
+import botocore.endpoint
 import pytest
 from botocore.awsrequest import AWSRequest
+from botocore.config import Config
 from botocore.endpoint import DEFAULT_TIMEOUT, Endpoint, EndpointCreator
 from botocore.exceptions import (
     ConnectionClosedError,
@@ -137,6 +140,34 @@ class TestEndpointFeatures(TestEndpointBase):
         request = prepare.call_args[0][0]
         self.assertEqual(request.context['signing']['region'], 'us-west-2')
 
+    def test_make_request_sets_retries_config_in_context(self):
+        r = request_dict()
+        r['context'] = {'signing': {'region': 'us-west-2'}}
+        with mock.patch(
+            'botocore.endpoint.Endpoint.prepare_request'
+        ) as prepare:
+            self.endpoint.make_request(self.op, r)
+        request = prepare.call_args[0][0]
+        self.assertIn('retries', request.context)
+
+    def test_exception_caught_when_constructing_retries_context(self):
+        r = request_dict()
+        datetime_patcher = mock.patch.object(
+            botocore.endpoint.datetime,
+            'datetime',
+            mock.Mock(wraps=datetime.datetime),
+        )
+        r['context'] = {'signing': {'region': 'us-west-2'}}
+        with mock.patch(
+            'botocore.endpoint.Endpoint.prepare_request'
+        ) as prepare:
+            mocked_datetime = datetime_patcher.start()
+            mocked_datetime.side_effect = Exception()
+            self.endpoint.make_request(self.op, r)
+            datetime_patcher.stop()
+        request = prepare.call_args[0][0]
+        self.assertIn('retries', request.context)
+
     def test_parses_modeled_exception_fields(self):
         # Setup the service model to have exceptions to generate the mapping
         self.service_model = mock.Mock(spec=ServiceModel)
@@ -204,7 +235,9 @@ class TestRetryInterface(TestEndpointBase):
         self.event_emitter.emit.side_effect = self.get_emitter_responses(
             num_retries=1
         )
-        self.endpoint.make_request(self._operation, request_dict())
+        r = request_dict()
+        r['context']['client_config'] = Config()
+        self.endpoint.make_request(self._operation, r)
         self.assert_events_emitted(
             self.event_emitter,
             expected_events=[
@@ -242,7 +275,9 @@ class TestRetryInterface(TestEndpointBase):
         parser = mock.Mock()
         parser.parse.return_value = {'ResponseMetadata': {}}
         self.factory.return_value.create_parser.return_value = parser
-        response = self.endpoint.make_request(self._operation, request_dict())
+        r = request_dict()
+        r['context']['client_config'] = Config()
+        response = self.endpoint.make_request(self._operation, r)
         self.assertEqual(response[1]['ResponseMetadata']['RetryAttempts'], 1)
 
     def test_retry_attempts_is_zero_when_not_retried(self):
@@ -279,6 +314,7 @@ class TestS3ResetStreamOnRetry(TestEndpointBase):
         op.metadata = {'protocol': 'rest-xml'}
         request = request_dict()
         request['body'] = body
+        request['context']['client_config'] = Config()
         self.event_emitter.emit.side_effect = self.get_emitter_responses(
             num_retries=2
         )


### PR DESCRIPTION
*Issue #, if available:* Ports the following botocore PRs to CLIv2:
  * https://github.com/boto/botocore/pull/2599
  * https://github.com/boto/botocore/pull/2612
  
 A service team reached out internally about why these weren't set for the CLI.

*Description of changes:* These add the following headers to all requests
  * `amz-sdk-invocation-id`: A uuid unique to each SDK request invocation.
  * `amz-sdk-request`: Includes the following retry information for each SDK request: TTL, request attempt number, max number of retry attempts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
