### PR TITLE
Add SSO start URL resolver for vanity domain support

### DIFF
--- a/awscli/customizations/sso/resolve.py
+++ b/awscli/customizations/sso/resolve.py
@@ -40,9 +40,20 @@ _REGION_PATTERNS = (
     ),
 )
 
-_ALL_PARTITIONS = ('aws', 'aws-cn', 'aws-us-gov')
-
 _MAX_REDIRECTS = 1
+
+_DEFAULT_PORTS = {'https': 443, 'http': 80}
+
+_DEFAULT_TIMEOUT = 10
+
+
+def _normalize_url(url):
+    parsed = urllib.parse.urlparse(url)
+    netloc = parsed.hostname or ''
+    if parsed.port and parsed.port != _DEFAULT_PORTS.get(parsed.scheme):
+        netloc = f'{netloc}:{parsed.port}'
+    path = parsed.path.rstrip('/')
+    return urllib.parse.urlunparse((parsed.scheme, netloc, path, '', '', ''))
 
 
 def is_aws_owned_domain(hostname):
@@ -66,20 +77,7 @@ def _extract_region_from_hostname(hostname):
     return None
 
 
-def _validate_region(region, session):
-    available = set()
-    for partition in _ALL_PARTITIONS:
-        available.update(
-            session.get_available_regions('sso-oidc', partition_name=partition)
-        )
-    if region not in available:
-        raise ConfigurationError(
-            f"Region '{region}' parsed from the resolved start URL is not "
-            f"a known AWS region. Verify the start URL is correct."
-        )
-
-
-def _follow_redirect(url):
+def _follow_redirect(url, timeout=_DEFAULT_TIMEOUT):
     class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
         def redirect_request(self, req, fp, code, msg, headers, newurl):
             return None
@@ -87,17 +85,17 @@ def _follow_redirect(url):
     opener = urllib.request.build_opener(_NoRedirectHandler)
     redirect_codes = (301, 302, 303, 307, 308)
 
-    for _attempt in range(_MAX_REDIRECTS):
+    for _ in range(_MAX_REDIRECTS):
         try:
             req = urllib.request.Request(url, method='HEAD')
-            resp = opener.open(req, timeout=10)
+            resp = opener.open(req, timeout=timeout)
             resp.close()
             return url
         except urllib.error.HTTPError as e:
             if e.code in (405, 501):
                 try:
                     req = urllib.request.Request(url, method='GET')
-                    resp = opener.open(req, timeout=10)
+                    resp = opener.open(req, timeout=timeout)
                     resp.close()
                     return url
                 except urllib.error.HTTPError as e2:
@@ -135,7 +133,9 @@ def _follow_redirect(url):
     return url
 
 
-def resolve_start_url(start_url, session, configured_region=None):
+def resolve_start_url(
+    start_url, session, configured_region=None, timeout=None
+):
     parsed = urllib.parse.urlparse(start_url)
 
     if parsed.scheme != 'https':
@@ -158,7 +158,10 @@ def resolve_start_url(start_url, session, configured_region=None):
     LOG.debug(
         "Start URL '%s' is not AWS-owned, following redirects", start_url
     )
-    resolved_url = _follow_redirect(start_url)
+    effective_timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT
+    resolved_url = _normalize_url(
+        _follow_redirect(start_url, timeout=effective_timeout)
+    )
 
     resolved_hostname = urllib.parse.urlparse(resolved_url).hostname
     if not resolved_hostname or not is_aws_owned_domain(resolved_hostname):
@@ -174,14 +177,13 @@ def resolve_start_url(start_url, session, configured_region=None):
 
     region = _extract_region_from_hostname(resolved_hostname)
 
-    if region:
-        _validate_region(region, session)
-    elif configured_region:
-        region = configured_region
-    else:
-        raise ConfigurationError(
-            f"Cannot determine region from start URL '{start_url}'. "
-            f"Please provide sso_region in your configuration."
-        )
+    if not region:
+        if configured_region:
+            region = configured_region
+        else:
+            raise ConfigurationError(
+                f"Cannot determine region from start URL '{start_url}'. "
+                f"Please provide sso_region in your configuration."
+            )
 
     return resolved_url, region

--- a/awscli/customizations/sso/resolve.py
+++ b/awscli/customizations/sso/resolve.py
@@ -1,0 +1,183 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from awscli.customizations.exceptions import ConfigurationError
+
+LOG = logging.getLogger(__name__)
+
+_AWS_OWNED_SUFFIXES = (
+    '.app.aws',
+    '.portal.amazonaws.com',
+    '.awsapps.com',
+)
+
+_AWS_OWNED_EXACT = 'identitycenter.amazonaws.com'
+
+_REGION_PATTERNS = (
+    # {idcInstanceId}.portal.{region}.app.aws
+    re.compile(
+        r'^[^.]+\.portal\.(?P<region>[a-z0-9-]+)\.app\.aws$', re.IGNORECASE
+    ),
+    # {idcInstanceId}.{region}.portal.amazonaws.com
+    re.compile(
+        r'^[^.]+\.(?P<region>[a-z0-9-]+)\.portal\.amazonaws\.com$',
+        re.IGNORECASE,
+    ),
+)
+
+_ALL_PARTITIONS = ('aws', 'aws-cn', 'aws-us-gov')
+
+_MAX_REDIRECTS = 1
+
+
+def is_aws_owned_domain(hostname):
+    hostname = hostname.lower().rstrip('.')
+    if hostname == _AWS_OWNED_EXACT:
+        return True
+    for suffix in _AWS_OWNED_SUFFIXES:
+        if hostname == suffix.lstrip('.'):
+            return True
+        if hostname.endswith(suffix):
+            return True
+    return False
+
+
+def _extract_region_from_hostname(hostname):
+    hostname = hostname.lower().rstrip('.')
+    for pattern in _REGION_PATTERNS:
+        match = pattern.match(hostname)
+        if match:
+            return match.group('region')
+    return None
+
+
+def _validate_region(region, session):
+    available = set()
+    for partition in _ALL_PARTITIONS:
+        available.update(
+            session.get_available_regions('sso-oidc', partition_name=partition)
+        )
+    if region not in available:
+        raise ConfigurationError(
+            f"Region '{region}' parsed from the resolved start URL is not "
+            f"a known AWS region. Verify the start URL is correct."
+        )
+
+
+def _follow_redirect(url):
+    class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            return None
+
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    redirect_codes = (301, 302, 303, 307, 308)
+
+    for _attempt in range(_MAX_REDIRECTS):
+        try:
+            req = urllib.request.Request(url, method='HEAD')
+            resp = opener.open(req, timeout=10)
+            resp.close()
+            return url
+        except urllib.error.HTTPError as e:
+            if e.code == 405:
+                try:
+                    req = urllib.request.Request(url, method='GET')
+                    resp = opener.open(req, timeout=10)
+                    resp.close()
+                    return url
+                except urllib.error.HTTPError as e2:
+                    if e2.code in redirect_codes:
+                        location = e2.headers.get('Location')
+                        if not location:
+                            raise ConfigurationError(
+                                "Redirect response missing Location header."
+                            )
+                        url = urllib.parse.urljoin(url, location)
+                    else:
+                        raise ConfigurationError(
+                            f"Failed to resolve start URL: HTTP {e2.code}"
+                        )
+                except urllib.error.URLError as e2:
+                    raise ConfigurationError(
+                        f"Failed to resolve start URL: {e2.reason}"
+                    )
+            elif e.code in redirect_codes:
+                location = e.headers.get('Location')
+                if not location:
+                    raise ConfigurationError(
+                        "Redirect response missing Location header."
+                    )
+                url = urllib.parse.urljoin(url, location)
+            else:
+                raise ConfigurationError(
+                    f"Failed to resolve start URL: HTTP {e.code}"
+                )
+        except urllib.error.URLError as e:
+            raise ConfigurationError(
+                f"Failed to resolve start URL: {e.reason}"
+            )
+
+    return url
+
+
+def resolve_start_url(start_url, session, configured_region=None):
+    parsed = urllib.parse.urlparse(start_url)
+
+    if parsed.scheme != 'https':
+        raise ConfigurationError(
+            "The sso_start_url must use the https scheme."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise ConfigurationError(f"Invalid sso_start_url: '{start_url}'")
+
+    if is_aws_owned_domain(hostname):
+        resolved_url = start_url
+    else:
+        LOG.debug(
+            "Start URL '%s' is not AWS-owned, following redirects", start_url
+        )
+        resolved_url = _follow_redirect(start_url)
+
+        resolved_hostname = urllib.parse.urlparse(resolved_url).hostname
+        if not resolved_hostname or not is_aws_owned_domain(resolved_hostname):
+            raise ConfigurationError(
+                f"Could not resolve start URL '{start_url}' to an "
+                f"AWS-owned endpoint. Final URL: '{resolved_url}'"
+            )
+
+        if urllib.parse.urlparse(resolved_url).scheme != 'https':
+            raise ConfigurationError(
+                f"Resolved URL must use https. Got: '{resolved_url}'"
+            )
+
+    resolved_hostname = urllib.parse.urlparse(resolved_url).hostname
+    region = _extract_region_from_hostname(resolved_hostname)
+
+    if region:
+        _validate_region(region, session)
+    elif configured_region:
+        region = configured_region
+    else:
+        raise ConfigurationError(
+            f"Cannot determine region from start URL '{start_url}'. "
+            f"Please provide sso_region in your configuration."
+        )
+
+    return resolved_url, region

--- a/awscli/customizations/sso/resolve.py
+++ b/awscli/customizations/sso/resolve.py
@@ -94,7 +94,7 @@ def _follow_redirect(url):
             resp.close()
             return url
         except urllib.error.HTTPError as e:
-            if e.code == 405:
+            if e.code in (405, 501):
                 try:
                     req = urllib.request.Request(url, method='GET')
                     resp = opener.open(req, timeout=10)

--- a/awscli/customizations/sso/resolve.py
+++ b/awscli/customizations/sso/resolve.py
@@ -148,26 +148,30 @@ def resolve_start_url(start_url, session, configured_region=None):
         raise ConfigurationError(f"Invalid sso_start_url: '{start_url}'")
 
     if is_aws_owned_domain(hostname):
-        resolved_url = start_url
-    else:
-        LOG.debug(
-            "Start URL '%s' is not AWS-owned, following redirects", start_url
-        )
-        resolved_url = _follow_redirect(start_url)
-
-        resolved_hostname = urllib.parse.urlparse(resolved_url).hostname
-        if not resolved_hostname or not is_aws_owned_domain(resolved_hostname):
+        if not configured_region:
             raise ConfigurationError(
-                f"Could not resolve start URL '{start_url}' to an "
-                f"AWS-owned endpoint. Final URL: '{resolved_url}'"
+                "Missing required configuration: sso_region. "
+                "Please run 'aws configure sso' to set it."
             )
+        return start_url, configured_region
 
-        if urllib.parse.urlparse(resolved_url).scheme != 'https':
-            raise ConfigurationError(
-                f"Resolved URL must use https. Got: '{resolved_url}'"
-            )
+    LOG.debug(
+        "Start URL '%s' is not AWS-owned, following redirects", start_url
+    )
+    resolved_url = _follow_redirect(start_url)
 
     resolved_hostname = urllib.parse.urlparse(resolved_url).hostname
+    if not resolved_hostname or not is_aws_owned_domain(resolved_hostname):
+        raise ConfigurationError(
+            f"Could not resolve start URL '{start_url}' to an "
+            f"AWS-owned endpoint. Final URL: '{resolved_url}'"
+        )
+
+    if urllib.parse.urlparse(resolved_url).scheme != 'https':
+        raise ConfigurationError(
+            f"Resolved URL must use https. Got: '{resolved_url}'"
+        )
+
     region = _extract_region_from_hostname(resolved_hostname)
 
     if region:

--- a/tests/unit/customizations/sso/test_resolve.py
+++ b/tests/unit/customizations/sso/test_resolve.py
@@ -1,0 +1,334 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import urllib.error
+
+import pytest
+
+from awscli.customizations.exceptions import ConfigurationError
+from awscli.customizations.sso.resolve import (
+    _extract_region_from_hostname,
+    _follow_redirect,
+    is_aws_owned_domain,
+    resolve_start_url,
+)
+from awscli.testutils import mock
+
+
+class TestIsAwsOwnedDomain:
+    @pytest.mark.parametrize(
+        'hostname',
+        [
+            'ssoins-abc123.portal.us-west-2.app.aws',
+            'ssoins-abc123.portal.us-east-1.app.aws',
+            'SSOINS-ABC123.PORTAL.US-WEST-2.APP.AWS',
+            'ssoins-abc123.us-west-2.portal.amazonaws.com',
+            'd-abc123.awsapps.com',
+            'myalias.awsapps.com',
+            'awsapps.com',
+            'identitycenter.amazonaws.com',
+            'identitycenter.amazonaws.com.',
+        ],
+    )
+    def test_aws_owned_returns_true(self, hostname):
+        assert is_aws_owned_domain(hostname) is True
+
+    @pytest.mark.parametrize(
+        'hostname',
+        [
+            'aws.mycompany.com',
+            'awsapps.com.evil.net',
+            'evil-awsapps.com',
+            'x.app.aws.example.com',
+            'amazonaws.com.example.net',
+            'portal.amazonaws.com.evil.net',
+            'notidentitycenter.amazonaws.com',
+            'example.com',
+            '',
+        ],
+    )
+    def test_non_aws_owned_returns_false(self, hostname):
+        assert is_aws_owned_domain(hostname) is False
+
+
+class TestExtractRegionFromHostname:
+    @pytest.mark.parametrize(
+        'hostname, expected_region',
+        [
+            ('ssoins-abc.portal.us-west-2.app.aws', 'us-west-2'),
+            ('ssoins-abc.portal.us-east-1.app.aws', 'us-east-1'),
+            ('ssoins-abc.portal.eu-west-1.app.aws', 'eu-west-1'),
+            ('ssoins-abc.portal.cn-north-1.app.aws', 'cn-north-1'),
+            ('ssoins-abc.us-gov-west-1.portal.amazonaws.com', 'us-gov-west-1'),
+            ('ssoins-abc.us-west-2.portal.amazonaws.com', 'us-west-2'),
+        ],
+    )
+    def test_extracts_region(self, hostname, expected_region):
+        assert _extract_region_from_hostname(hostname) == expected_region
+
+    @pytest.mark.parametrize(
+        'hostname',
+        [
+            'd-abc123.awsapps.com',
+            'identitycenter.amazonaws.com',
+            'aws.mycompany.com',
+        ],
+    )
+    def test_returns_none_for_region_less_hostnames(self, hostname):
+        assert _extract_region_from_hostname(hostname) is None
+
+
+class TestResolveStartUrl:
+    def _mock_session(self, regions=None):
+        if regions is None:
+            regions = [
+                'us-east-1',
+                'us-west-2',
+                'eu-west-1',
+                'us-gov-west-1',
+                'cn-north-1',
+            ]
+        session = mock.Mock()
+        session.get_available_regions.return_value = regions
+        return session
+
+    def test_aws_owned_url_returns_immediately(self):
+        session = self._mock_session()
+        resolved_url, region = resolve_start_url(
+            'https://ssoins-abc.portal.us-west-2.app.aws',
+            session=session,
+        )
+        assert resolved_url == 'https://ssoins-abc.portal.us-west-2.app.aws'
+        assert region == 'us-west-2'
+
+    def test_aws_owned_url_no_network_call(self):
+        session = self._mock_session()
+        with mock.patch('urllib.request.build_opener') as mock_opener:
+            resolve_start_url(
+                'https://ssoins-abc.portal.us-west-2.app.aws',
+                session=session,
+            )
+            mock_opener.assert_not_called()
+
+    def test_awsapps_url_requires_configured_region(self):
+        session = self._mock_session()
+        with pytest.raises(
+            ConfigurationError, match='Cannot determine region'
+        ):
+            resolve_start_url(
+                'https://d-abc123.awsapps.com/start',
+                session=session,
+            )
+
+    def test_awsapps_url_uses_configured_region(self):
+        session = self._mock_session()
+        resolved_url, region = resolve_start_url(
+            'https://d-abc123.awsapps.com/start',
+            session=session,
+            configured_region='us-east-1',
+        )
+        assert resolved_url == 'https://d-abc123.awsapps.com/start'
+        assert region == 'us-east-1'
+
+    def test_http_scheme_raises_error(self):
+        session = self._mock_session()
+        with pytest.raises(ConfigurationError, match='https scheme'):
+            resolve_start_url('http://aws.mycompany.com', session=session)
+
+    def test_invalid_url_raises_error(self):
+        session = self._mock_session()
+        with pytest.raises(ConfigurationError, match='Invalid sso_start_url'):
+            resolve_start_url('https://', session=session)
+
+    def test_invalid_region_raises_error(self):
+        session = self._mock_session(regions=['us-east-1', 'us-west-2'])
+        with pytest.raises(ConfigurationError, match='not a known AWS region'):
+            resolve_start_url(
+                'https://ssoins-abc.portal.fake-region-1.app.aws',
+                session=session,
+            )
+
+    def test_invalid_parsed_region_does_not_fall_back_to_configured(self):
+        session = self._mock_session(regions=['us-east-1', 'us-west-2'])
+        with pytest.raises(ConfigurationError, match='not a known AWS region'):
+            resolve_start_url(
+                'https://ssoins-abc.portal.fake-region-1.app.aws',
+                session=session,
+                configured_region='us-east-1',
+            )
+
+    def test_govcloud_region_accepted(self):
+        session = mock.Mock()
+        session.get_available_regions.side_effect = (
+            lambda service, partition_name='aws': {
+                'aws': ['us-east-1', 'us-west-2'],
+                'aws-us-gov': ['us-gov-west-1'],
+                'aws-cn': ['cn-north-1'],
+            }.get(partition_name, [])
+        )
+        resolved_url, region = resolve_start_url(
+            'https://ssoins-abc.portal.us-gov-west-1.app.aws',
+            session=session,
+        )
+        assert region == 'us-gov-west-1'
+
+    def test_china_region_accepted(self):
+        session = mock.Mock()
+        session.get_available_regions.side_effect = (
+            lambda service, partition_name='aws': {
+                'aws': ['us-east-1', 'us-west-2'],
+                'aws-us-gov': ['us-gov-west-1'],
+                'aws-cn': ['cn-north-1'],
+            }.get(partition_name, [])
+        )
+        resolved_url, region = resolve_start_url(
+            'https://ssoins-abc.portal.cn-north-1.app.aws',
+            session=session,
+        )
+        assert region == 'cn-north-1'
+
+    def test_vanity_url_follows_redirect(self):
+        session = self._mock_session()
+        redirect_url = 'https://ssoins-abc.portal.us-east-1.app.aws:443/'
+
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = redirect_url
+            resolved_url, region = resolve_start_url(
+                'https://aws.mycompany.com',
+                session=session,
+            )
+            assert resolved_url == redirect_url
+            assert region == 'us-east-1'
+            mock_follow.assert_called_once_with('https://aws.mycompany.com')
+
+    def test_vanity_url_resolves_to_non_aws_domain_raises_error(self):
+        session = self._mock_session()
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = 'https://not-aws.example.com'
+            with pytest.raises(ConfigurationError, match='Could not resolve'):
+                resolve_start_url('https://aws.mycompany.com', session=session)
+
+    def test_vanity_url_resolves_to_http_raises_error(self):
+        session = self._mock_session()
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = (
+                'http://ssoins-abc.portal.us-east-1.app.aws'
+            )
+            with pytest.raises(ConfigurationError, match='must use https'):
+                resolve_start_url('https://aws.mycompany.com', session=session)
+
+
+class TestFollowRedirect:
+    def _make_http_error(self, code, headers=None):
+        if headers is None:
+            headers = {}
+        import http.client
+
+        msg = http.client.HTTPMessage()
+        for k, v in headers.items():
+            msg[k] = v
+        return urllib.error.HTTPError(
+            url='https://example.com',
+            code=code,
+            msg='',
+            hdrs=msg,
+            fp=None,
+        )
+
+    def test_head_redirect_returns_location(self):
+        redirect_target = 'https://ssoins-abc.portal.us-east-1.app.aws'
+        with mock.patch('urllib.request.build_opener') as mock_build:
+            mock_opener = mock.Mock()
+            mock_build.return_value = mock_opener
+            mock_opener.open.side_effect = self._make_http_error(
+                302, {'Location': redirect_target}
+            )
+            result = _follow_redirect('https://aws.mycompany.com')
+            assert result == redirect_target
+
+    @pytest.mark.parametrize('head_error_code', [405, 501])
+    def test_head_unsupported_falls_back_to_get(self, head_error_code):
+        redirect_target = 'https://ssoins-abc.portal.us-east-1.app.aws'
+        with mock.patch('urllib.request.build_opener') as mock_build:
+            mock_opener = mock.Mock()
+            mock_build.return_value = mock_opener
+            mock_opener.open.side_effect = [
+                self._make_http_error(head_error_code),
+                self._make_http_error(302, {'Location': redirect_target}),
+            ]
+            result = _follow_redirect('https://aws.mycompany.com')
+            assert result == redirect_target
+            assert mock_opener.open.call_count == 2
+
+    def test_head_200_returns_original_url(self):
+        with mock.patch('urllib.request.build_opener') as mock_build:
+            mock_opener = mock.Mock()
+            mock_build.return_value = mock_opener
+            mock_response = mock.Mock()
+            mock_opener.open.return_value = mock_response
+            result = _follow_redirect('https://aws.mycompany.com')
+            assert result == 'https://aws.mycompany.com'
+            mock_response.close.assert_called_once()
+
+    def test_missing_location_header_raises_error(self):
+        with mock.patch('urllib.request.build_opener') as mock_build:
+            mock_opener = mock.Mock()
+            mock_build.return_value = mock_opener
+            mock_opener.open.side_effect = self._make_http_error(302, {})
+            with pytest.raises(ConfigurationError, match='missing Location'):
+                _follow_redirect('https://aws.mycompany.com')
+
+    def test_non_redirect_error_raises_configuration_error(self):
+        with mock.patch('urllib.request.build_opener') as mock_build:
+            mock_opener = mock.Mock()
+            mock_build.return_value = mock_opener
+            mock_opener.open.side_effect = self._make_http_error(500)
+            with pytest.raises(ConfigurationError, match='HTTP 500'):
+                _follow_redirect('https://aws.mycompany.com')
+
+    def test_url_error_raises_configuration_error(self):
+        with mock.patch('urllib.request.build_opener') as mock_build:
+            mock_opener = mock.Mock()
+            mock_build.return_value = mock_opener
+            mock_opener.open.side_effect = urllib.error.URLError(
+                'Name or service not known'
+            )
+            with pytest.raises(ConfigurationError, match='Name or service'):
+                _follow_redirect('https://aws.mycompany.com')
+
+    def test_relative_location_is_resolved(self):
+        with mock.patch('urllib.request.build_opener') as mock_build:
+            mock_opener = mock.Mock()
+            mock_build.return_value = mock_opener
+            mock_opener.open.side_effect = self._make_http_error(
+                302, {'Location': '/start'}
+            )
+            result = _follow_redirect('https://aws.mycompany.com/portal')
+            assert result == 'https://aws.mycompany.com/start'
+
+    def test_stops_after_max_redirects(self):
+        intermediate = 'https://intermediate.example.com/path'
+        with mock.patch('urllib.request.build_opener') as mock_build:
+            mock_opener = mock.Mock()
+            mock_build.return_value = mock_opener
+            mock_opener.open.side_effect = self._make_http_error(
+                302, {'Location': intermediate}
+            )
+            result = _follow_redirect('https://aws.mycompany.com')
+            assert result == intermediate
+            assert mock_opener.open.call_count == 1

--- a/tests/unit/customizations/sso/test_resolve.py
+++ b/tests/unit/customizations/sso/test_resolve.py
@@ -18,6 +18,7 @@ from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.sso.resolve import (
     _extract_region_from_hostname,
     _follow_redirect,
+    _normalize_url,
     is_aws_owned_domain,
     resolve_start_url,
 )
@@ -87,19 +88,25 @@ class TestExtractRegionFromHostname:
         assert _extract_region_from_hostname(hostname) is None
 
 
+class TestNormalizeUrl:
+    @pytest.mark.parametrize(
+        'url, expected',
+        [
+            ('https://example.com:443/', 'https://example.com'),
+            ('https://example.com:443/path/', 'https://example.com/path'),
+            ('https://example.com/', 'https://example.com'),
+            ('https://example.com:8443/path', 'https://example.com:8443/path'),
+            ('http://example.com:80/', 'http://example.com'),
+            ('https://example.com', 'https://example.com'),
+        ],
+    )
+    def test_normalize_url(self, url, expected):
+        assert _normalize_url(url) == expected
+
+
 class TestResolveStartUrl:
-    def _mock_session(self, regions=None):
-        if regions is None:
-            regions = [
-                'us-east-1',
-                'us-west-2',
-                'eu-west-1',
-                'us-gov-west-1',
-                'cn-north-1',
-            ]
-        session = mock.Mock()
-        session.get_available_regions.return_value = regions
-        return session
+    def _mock_session(self):
+        return mock.Mock()
 
     def test_aws_owned_url_returns_configured_region(self):
         session = self._mock_session()
@@ -139,6 +146,7 @@ class TestResolveStartUrl:
             session=session,
             configured_region='us-east-1',
         )
+        assert resolved_url == 'https://ssoins-abc.portal.us-west-2.app.aws'
         assert region == 'us-east-1'
 
     def test_awsapps_url_requires_configured_region(self):
@@ -172,84 +180,10 @@ class TestResolveStartUrl:
         with pytest.raises(ConfigurationError, match='Invalid sso_start_url'):
             resolve_start_url('https://', session=session)
 
-    def test_vanity_url_invalid_region_raises_error(self):
-        session = self._mock_session(regions=['us-east-1', 'us-west-2'])
-        with mock.patch(
-            'awscli.customizations.sso.resolve._follow_redirect'
-        ) as mock_follow:
-            mock_follow.return_value = (
-                'https://ssoins-abc.portal.fake-region-1.app.aws'
-            )
-            with pytest.raises(
-                ConfigurationError, match='not a known AWS region'
-            ):
-                resolve_start_url(
-                    'https://aws.mycompany.com',
-                    session=session,
-                )
-
-    def test_vanity_url_invalid_region_does_not_fall_back_to_configured(self):
-        session = self._mock_session(regions=['us-east-1', 'us-west-2'])
-        with mock.patch(
-            'awscli.customizations.sso.resolve._follow_redirect'
-        ) as mock_follow:
-            mock_follow.return_value = (
-                'https://ssoins-abc.portal.fake-region-1.app.aws'
-            )
-            with pytest.raises(
-                ConfigurationError, match='not a known AWS region'
-            ):
-                resolve_start_url(
-                    'https://aws.mycompany.com',
-                    session=session,
-                    configured_region='us-east-1',
-                )
-
-    def test_vanity_url_govcloud_region_accepted(self):
-        session = mock.Mock()
-        session.get_available_regions.side_effect = (
-            lambda service, partition_name='aws': {
-                'aws': ['us-east-1', 'us-west-2'],
-                'aws-us-gov': ['us-gov-west-1'],
-                'aws-cn': ['cn-north-1'],
-            }.get(partition_name, [])
-        )
-        with mock.patch(
-            'awscli.customizations.sso.resolve._follow_redirect'
-        ) as mock_follow:
-            mock_follow.return_value = (
-                'https://ssoins-abc.portal.us-gov-west-1.app.aws'
-            )
-            resolved_url, region = resolve_start_url(
-                'https://aws.mycompany.com',
-                session=session,
-            )
-            assert region == 'us-gov-west-1'
-
-    def test_vanity_url_china_region_accepted(self):
-        session = mock.Mock()
-        session.get_available_regions.side_effect = (
-            lambda service, partition_name='aws': {
-                'aws': ['us-east-1', 'us-west-2'],
-                'aws-us-gov': ['us-gov-west-1'],
-                'aws-cn': ['cn-north-1'],
-            }.get(partition_name, [])
-        )
-        with mock.patch(
-            'awscli.customizations.sso.resolve._follow_redirect'
-        ) as mock_follow:
-            mock_follow.return_value = (
-                'https://ssoins-abc.portal.cn-north-1.app.aws'
-            )
-            resolved_url, region = resolve_start_url(
-                'https://aws.mycompany.com',
-                session=session,
-            )
-            assert region == 'cn-north-1'
-
     def test_vanity_url_follows_redirect(self):
         session = self._mock_session()
         redirect_url = 'https://ssoins-abc.portal.us-east-1.app.aws:443/'
+        normalized_url = 'https://ssoins-abc.portal.us-east-1.app.aws'
 
         with mock.patch(
             'awscli.customizations.sso.resolve._follow_redirect'
@@ -259,9 +193,26 @@ class TestResolveStartUrl:
                 'https://aws.mycompany.com',
                 session=session,
             )
-            assert resolved_url == redirect_url
+            assert resolved_url == normalized_url
             assert region == 'us-east-1'
-            mock_follow.assert_called_once_with('https://aws.mycompany.com')
+            mock_follow.assert_called_once_with(
+                'https://aws.mycompany.com', timeout=10
+            )
+
+    def test_vanity_url_uses_parsed_region_not_configured(self):
+        session = self._mock_session()
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = (
+                'https://ssoins-abc.portal.us-west-2.app.aws'
+            )
+            resolved_url, region = resolve_start_url(
+                'https://aws.mycompany.com',
+                session=session,
+                configured_region='eu-west-1',
+            )
+            assert region == 'us-west-2'
 
     def test_vanity_url_resolves_to_non_aws_domain_raises_error(self):
         session = self._mock_session()
@@ -282,6 +233,47 @@ class TestResolveStartUrl:
             )
             with pytest.raises(ConfigurationError, match='must use https'):
                 resolve_start_url('https://aws.mycompany.com', session=session)
+
+    def test_vanity_url_region_less_requires_configured_region(self):
+        session = self._mock_session()
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = 'https://d-abc123.awsapps.com/start'
+            with pytest.raises(
+                ConfigurationError, match='Cannot determine region'
+            ):
+                resolve_start_url('https://aws.mycompany.com', session=session)
+
+    def test_vanity_url_region_less_uses_configured_region(self):
+        session = self._mock_session()
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = 'https://d-abc123.awsapps.com/start'
+            resolved_url, region = resolve_start_url(
+                'https://aws.mycompany.com',
+                session=session,
+                configured_region='us-east-1',
+            )
+            assert region == 'us-east-1'
+
+    def test_custom_timeout_passed_to_follow_redirect(self):
+        session = self._mock_session()
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = (
+                'https://ssoins-abc.portal.us-east-1.app.aws'
+            )
+            resolve_start_url(
+                'https://aws.mycompany.com',
+                session=session,
+                timeout=5,
+            )
+            mock_follow.assert_called_once_with(
+                'https://aws.mycompany.com', timeout=5
+            )
 
 
 class TestFollowRedirect:

--- a/tests/unit/customizations/sso/test_resolve.py
+++ b/tests/unit/customizations/sso/test_resolve.py
@@ -101,11 +101,12 @@ class TestResolveStartUrl:
         session.get_available_regions.return_value = regions
         return session
 
-    def test_aws_owned_url_returns_immediately(self):
+    def test_aws_owned_url_returns_configured_region(self):
         session = self._mock_session()
         resolved_url, region = resolve_start_url(
             'https://ssoins-abc.portal.us-west-2.app.aws',
             session=session,
+            configured_region='us-west-2',
         )
         assert resolved_url == 'https://ssoins-abc.portal.us-west-2.app.aws'
         assert region == 'us-west-2'
@@ -116,13 +117,35 @@ class TestResolveStartUrl:
             resolve_start_url(
                 'https://ssoins-abc.portal.us-west-2.app.aws',
                 session=session,
+                configured_region='us-west-2',
             )
             mock_opener.assert_not_called()
+
+    def test_aws_owned_url_without_configured_region_raises_error(self):
+        session = self._mock_session()
+        with pytest.raises(
+            ConfigurationError,
+            match='Missing required configuration: sso_region',
+        ):
+            resolve_start_url(
+                'https://ssoins-abc.portal.us-west-2.app.aws',
+                session=session,
+            )
+
+    def test_aws_owned_url_uses_configured_region_not_hostname(self):
+        session = self._mock_session()
+        resolved_url, region = resolve_start_url(
+            'https://ssoins-abc.portal.us-west-2.app.aws',
+            session=session,
+            configured_region='us-east-1',
+        )
+        assert region == 'us-east-1'
 
     def test_awsapps_url_requires_configured_region(self):
         session = self._mock_session()
         with pytest.raises(
-            ConfigurationError, match='Cannot determine region'
+            ConfigurationError,
+            match='Missing required configuration: sso_region',
         ):
             resolve_start_url(
                 'https://d-abc123.awsapps.com/start',
@@ -149,24 +172,40 @@ class TestResolveStartUrl:
         with pytest.raises(ConfigurationError, match='Invalid sso_start_url'):
             resolve_start_url('https://', session=session)
 
-    def test_invalid_region_raises_error(self):
+    def test_vanity_url_invalid_region_raises_error(self):
         session = self._mock_session(regions=['us-east-1', 'us-west-2'])
-        with pytest.raises(ConfigurationError, match='not a known AWS region'):
-            resolve_start_url(
-                'https://ssoins-abc.portal.fake-region-1.app.aws',
-                session=session,
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = (
+                'https://ssoins-abc.portal.fake-region-1.app.aws'
             )
+            with pytest.raises(
+                ConfigurationError, match='not a known AWS region'
+            ):
+                resolve_start_url(
+                    'https://aws.mycompany.com',
+                    session=session,
+                )
 
-    def test_invalid_parsed_region_does_not_fall_back_to_configured(self):
+    def test_vanity_url_invalid_region_does_not_fall_back_to_configured(self):
         session = self._mock_session(regions=['us-east-1', 'us-west-2'])
-        with pytest.raises(ConfigurationError, match='not a known AWS region'):
-            resolve_start_url(
-                'https://ssoins-abc.portal.fake-region-1.app.aws',
-                session=session,
-                configured_region='us-east-1',
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = (
+                'https://ssoins-abc.portal.fake-region-1.app.aws'
             )
+            with pytest.raises(
+                ConfigurationError, match='not a known AWS region'
+            ):
+                resolve_start_url(
+                    'https://aws.mycompany.com',
+                    session=session,
+                    configured_region='us-east-1',
+                )
 
-    def test_govcloud_region_accepted(self):
+    def test_vanity_url_govcloud_region_accepted(self):
         session = mock.Mock()
         session.get_available_regions.side_effect = (
             lambda service, partition_name='aws': {
@@ -175,13 +214,19 @@ class TestResolveStartUrl:
                 'aws-cn': ['cn-north-1'],
             }.get(partition_name, [])
         )
-        resolved_url, region = resolve_start_url(
-            'https://ssoins-abc.portal.us-gov-west-1.app.aws',
-            session=session,
-        )
-        assert region == 'us-gov-west-1'
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = (
+                'https://ssoins-abc.portal.us-gov-west-1.app.aws'
+            )
+            resolved_url, region = resolve_start_url(
+                'https://aws.mycompany.com',
+                session=session,
+            )
+            assert region == 'us-gov-west-1'
 
-    def test_china_region_accepted(self):
+    def test_vanity_url_china_region_accepted(self):
         session = mock.Mock()
         session.get_available_regions.side_effect = (
             lambda service, partition_name='aws': {
@@ -190,11 +235,17 @@ class TestResolveStartUrl:
                 'aws-cn': ['cn-north-1'],
             }.get(partition_name, [])
         )
-        resolved_url, region = resolve_start_url(
-            'https://ssoins-abc.portal.cn-north-1.app.aws',
-            session=session,
-        )
-        assert region == 'cn-north-1'
+        with mock.patch(
+            'awscli.customizations.sso.resolve._follow_redirect'
+        ) as mock_follow:
+            mock_follow.return_value = (
+                'https://ssoins-abc.portal.cn-north-1.app.aws'
+            )
+            resolved_url, region = resolve_start_url(
+                'https://aws.mycompany.com',
+                session=session,
+            )
+            assert region == 'cn-north-1'
 
     def test_vanity_url_follows_redirect(self):
         session = self._mock_session()


### PR DESCRIPTION
*Description of changes:* Adds a start URL resolver module for vanity domain support in SSO login flows. Subsequent PRs will wire it into `aws sso login` and `aws configure sso`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
