### PR TITLE
Fix NameError in ParamUnknownKeyError formatting

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -55,7 +55,7 @@ class ParamUnknownKeyError(Exception):
     def __init__(self, key, valid_keys):
         valid_keys = ', '.join(valid_keys)
         full_message = (
-            f"Unknown key '{key}', valid choices are: {valid_key}"
+            f"Unknown key '{key}', valid choices are: {valid_keys}"
         )
         super().__init__(full_message)
 


### PR DESCRIPTION
**Description:**
This PR fixes a typo in `awscli/argprocess.py` where a `NameError` was raised during shorthand parsing errors because `valid_key` was used instead of `valid_keys`.

Fixes #10405

**Testing Done:**
- [x] Verified locally via Python REPL that instantiating `ParamUnknownKeyError` now successfully formats the error string instead of crashing with a `NameError`.
- [x] Ran local unit tests to ensure no regressions.

