### PR TITLE
fix: LakeFormation Data Cells Filters: TIMESTAMP data type not supported for row level filter predicate (closes #10397)

### DIFF
--- a/awscli/examples/lakeformation/create-data-cells-filter.rst
+++ b/awscli/examples/lakeformation/create-data-cells-filter.rst
@@ -77,3 +77,36 @@ Contents of ``input.json``::
 This command produces no output.
 
 For more information, see `Data filtering and cell-level security in Lake Formation <https://docs.aws.amazon.com/lake-formation/latest/dg/data-filtering.html>`__ in the *AWS Lake Formation Developer Guide*.
+
+.. note::
+
+   **TIMESTAMP data type not supported in RowFilter FilterExpression**
+
+   AWS Lake Formation Data Cells Filters do **not** support ``TIMESTAMP`` columns
+   in the ``RowFilter.FilterExpression`` predicate.  Attempting to use a timestamp
+   column in the filter expression (e.g.
+   ``"timestamp" > '2026-05-01 00:00:00'``) will return::
+
+       InvalidInputException: TIMESTAMP data type not supported for row level filter predicate.
+
+   **Tested expressions that all fail:**
+
+   - ``"timestamp" > '2026-05-01 00:00:00'``
+   - ``timestamp > date_sub(current_date(), 30)``
+   - ``timestamp > cast(now() - interval 30 days as timestamp)``
+   - ``timestamp >= current_timestamp - interval '30' day``
+   - ``timestamp >= current_date() - INTERVAL 30 DAYS``
+
+   **Workarounds:**
+
+   - Filter on a *derived string column* (e.g., a partition column formatted as
+     ``YYYY-MM-DD``) using string comparison instead of a native timestamp column.
+   - Pre-process the table to store the date portion as a ``STRING`` or ``DATE``
+     column and apply the row filter on that column.
+   - Use column-level security (``ColumnNames`` / ``ExcludedColumnNames``) to
+     restrict access to the timestamp column entirely rather than filtering by
+     value.
+
+   For more information see the
+   `Data Cells Filters documentation <https://docs.aws.amazon.com/lake-formation/latest/dg/data-filtering.html>`__.
+


### PR DESCRIPTION
Fixes #10397

---
This fix was implemented autonomously by **[Conduct AI](https://conductai.ai)** — an open-source platform that turns AI agents into reusable team automations via YAML playbooks.
- 🔗 Platform: [conductai.ai](https://conductai.ai)
- 📦 Source: [github.com/sseshachala/conductai](https://github.com/sseshachala/conductai)
> Want Conduct AI to automate fixes in your repo too? [Get started free →](https://conductai.ai)

