### PR TITLE
fix: bump urllib3 upper bound to <=2.7.0 for CVE-2026-44431 and CVE-2026-44432 (#10350)

### DIFF
--- a/.changes/next-release/urllib3-270-cve-10350.json
+++ b/.changes/next-release/urllib3-270-cve-10350.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Dependencies",
+  "description": "Bump urllib3 upper bound to <=2.7.0 to resolve CVE-2026-44431 (CVSS 8.2, High - sensitive headers not stripped on cross-origin redirects via ProxyManager API) and CVE-2026-44432 (CVSS 8.9, High - Brotli decompression bomb via streaming API)."
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "awscrt==0.32.2",
     "python-dateutil>=2.1,<=2.9.0",
     "jmespath>=0.7.1,<1.1.0",
-    "urllib3>=1.25.4,<=2.6.3",
+    "urllib3>=1.25.4,<=2.7.0",
     "wcwidth<0.3.0",
 ]
 dynamic = ["version"]

--- a/requirements/download-deps/portable-exe-lock.txt
+++ b/requirements/download-deps/portable-exe-lock.txt
@@ -191,9 +191,9 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via python-dateutil
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c
     # via awscli (pyproject.toml)
 wcwidth==0.2.14 \
     --hash=sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605 \

--- a/requirements/download-deps/portable-exe-win-lock.txt
+++ b/requirements/download-deps/portable-exe-win-lock.txt
@@ -193,9 +193,9 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via python-dateutil
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c
     # via awscli (D:/a/aws-cli/aws-cli/pyproject.toml)
 wcwidth==0.2.14 \
     --hash=sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605 \

--- a/requirements/download-deps/system-sandbox-lock.txt
+++ b/requirements/download-deps/system-sandbox-lock.txt
@@ -153,9 +153,9 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via python-dateutil
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c
     # via awscli (pyproject.toml)
 wcwidth==0.2.14 \
     --hash=sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605 \

--- a/requirements/download-deps/system-sandbox-win-lock.txt
+++ b/requirements/download-deps/system-sandbox-win-lock.txt
@@ -153,9 +153,9 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via python-dateutil
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c
     # via awscli (D:/a/aws-cli/aws-cli/pyproject.toml)
 wcwidth==0.2.14 \
     --hash=sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605 \


### PR DESCRIPTION
## Summary

Updates the urllib3 upper bound in `pyproject.toml` from `<=2.6.3` to `<=2.7.0` to resolve two high-severity CVEs:

- **CVE-2026-44431** (CVSS 8.2, High): sensitive headers (Authorization, Cookie, Proxy-Authorization) not stripped on cross-origin redirects when using the low-level ProxyManager API path
- **CVE-2026-44432** (CVSS 8.9, High): decompression bomb via Brotli streaming API (CWE-409)

Also updates all four download-deps lock files to pin `urllib3==2.7.0` with correct PyPI SHA256 hashes.

Upstream botocore already merged the same bump in boto/botocore#3702 (May 12).

Fixes #10350