### PR TITLE
Add CLI examples for DMS Schema Conversion operations

### DIFF
--- a/awscli/examples/dms/cancel-metadata-model-conversion.rst
+++ b/awscli/examples/dms/cancel-metadata-model-conversion.rst
@@ -1,0 +1,19 @@
+**To cancel a metadata model conversion**
+
+The following ``cancel-metadata-model-conversion`` example cancels a metadata model conversion operation. ::
+
+    aws dms cancel-metadata-model-conversion \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --request-identifier a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+    {
+        "Request": {
+            "Status": "CANCELING",
+            "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+        }
+    }
+
+For more information, see `Converting database schemas <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-convert.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/cancel-metadata-model-creation.rst
+++ b/awscli/examples/dms/cancel-metadata-model-creation.rst
@@ -1,0 +1,19 @@
+**To cancel a metadata model creation**
+
+The following ``cancel-metadata-model-creation`` example cancels a metadata model creation operation. ::
+
+    aws dms cancel-metadata-model-creation \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --request-identifier a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+    {
+        "Request": {
+            "Status": "CANCELING",
+            "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+        }
+    }
+
+For more information, see `Creating statement metadata models <https://docs.aws.amazon.com/dms/latest/userguide/sc-metadata-model.html#sc-metadata-model-creation>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/create-data-provider.rst
+++ b/awscli/examples/dms/create-data-provider.rst
@@ -1,0 +1,66 @@
+**Example 1: To create a Microsoft SQL Server data provider**
+
+The following ``create-data-provider`` example creates a Microsoft SQL Server data provider. ::
+
+    aws dms create-data-provider \
+        --data-provider-name example-data-provider \
+        --engine sqlserver \
+        --description "Example data provider for documentation" \
+        --settings MicrosoftSqlServerSettings={ServerName=example-source-server.us-east-1.rds.amazonaws.com,Port=1433,DatabaseName=ExampleDatabase,SslMode=verify-full,CertificateArn=arn:aws:dms:us-east-1:123456789012:cert:EXAMPLEABCDEFGHIJKLMNOPQRS}
+
+Output::
+
+    {
+        "DataProvider": {
+            "DataProviderName": "example-data-provider",
+            "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "DataProviderCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "Description": "Example data provider for documentation",
+            "Engine": "sqlserver",
+            "Settings": {
+                "MicrosoftSqlServerSettings": {
+                    "ServerName": "example-source-server.us-east-1.rds.amazonaws.com",
+                    "Port": 1433,
+                    "DatabaseName": "ExampleDatabase",
+                    "SslMode": "verify-full",
+                    "CertificateArn": "arn:aws:dms:us-east-1:123456789012:cert:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            }
+        }
+    }
+
+For more information, see `Working with data providers <https://docs.aws.amazon.com/dms/latest/userguide/data-providers.html>`__ in the *AWS Database Migration Service User Guide*.
+
+**Example 2: To create a virtual data provider**
+
+The following ``create-data-provider`` example creates a virtual data provider, which doesn't require a connection to the database. ::
+
+    aws dms create-data-provider \
+        --data-provider-name example-virtual-data-provider \
+        --engine aurora-postgresql \
+        --description "Example data provider for documentation" \
+        --virtual \
+        --settings PostgreSqlSettings={ServerName=virtual,Port=5432,DatabaseName=virtual,SslMode=none}
+
+Output::
+
+    {
+        "DataProvider": {
+            "DataProviderName": "example-virtual-data-provider",
+            "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "DataProviderCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "Description": "Example data provider for documentation",
+            "Engine": "aurora-postgresql",
+            "Virtual": true,
+            "Settings": {
+                "PostgreSqlSettings": {
+                    "ServerName": "virtual",
+                    "Port": 5432,
+                    "DatabaseName": "virtual",
+                    "SslMode": "none"
+                }
+            }
+        }
+    }
+
+For more information, see `Working with virtual data providers <https://docs.aws.amazon.com/dms/latest/userguide/virtual-data-provider.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/create-instance-profile.rst
+++ b/awscli/examples/dms/create-instance-profile.rst
@@ -1,0 +1,32 @@
+**To create an instance profile**
+
+The following ``create-instance-profile`` example creates an instance profile. ::
+
+    aws dms create-instance-profile \
+        --instance-profile-name example-instance-profile \
+        --description "Example instance profile for documentation" \
+        --subnet-group-identifier example-replication-subnet-group \
+        --vpc-security-groups "sg-0123456789abcdef0" \
+        --kms-key-arn arn:aws:kms:us-east-1:123456789012:key/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 \
+        --network-type IPV4 \
+        --no-publicly-accessible
+
+Output::
+
+    {
+        "InstanceProfile": {
+            "InstanceProfileArn": "arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "PubliclyAccessible": false,
+            "NetworkType": "IPV4",
+            "InstanceProfileName": "example-instance-profile",
+            "Description": "Example instance profile for documentation",
+            "InstanceProfileCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "SubnetGroupIdentifier": "example-replication-subnet-group",
+            "VpcSecurityGroups": [
+                "sg-0123456789abcdef0"
+            ]
+        }
+    }
+
+For more information, see `Working with instance profiles <https://docs.aws.amazon.com/dms/latest/userguide/instance-profiles.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/create-migration-project.rst
+++ b/awscli/examples/dms/create-migration-project.rst
@@ -1,0 +1,48 @@
+**To create a migration project**
+
+The following ``create-migration-project`` example creates a migration project. ::
+
+    aws dms create-migration-project \
+        --migration-project-name example-migration-project \
+        --description "Example migration project for documentation" \
+        --source-data-provider-descriptors DataProviderIdentifier=arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS,SecretsManagerSecretId=arn:aws:secretsmanager:us-east-1:123456789012:secret:example-source-secret-A1B2C3,SecretsManagerAccessRoleArn=arn:aws:iam::123456789012:role/example-secrets-manager-role \
+        --target-data-provider-descriptors DataProviderIdentifier=arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS,SecretsManagerSecretId=arn:aws:secretsmanager:us-east-1:123456789012:secret:example-target-secret-A1B2C3,SecretsManagerAccessRoleArn=arn:aws:iam::123456789012:role/example-secrets-manager-role \
+        --instance-profile-identifier arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --transformation-rules '{"rules":[{"rule-type":"transformation","rule-id":"1","rule-name":"1","rule-target":"schema","rule-action":"rename","object-locator":{"schema-name":"ExampleSchema"},"value":"TargetSchema"}]}' \
+        --schema-conversion-application-attributes S3BucketPath=s3://amzn-s3-demo-bucket,S3BucketRoleArn=arn:aws:iam::123456789012:role/example-s3-access-role
+
+Output::
+
+    {
+        "MigrationProject": {
+            "MigrationProjectName": "example-migration-project",
+            "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "MigrationProjectCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "SourceDataProviderDescriptors": [
+                {
+                    "SecretsManagerSecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-source-secret-A1B2C3",
+                    "SecretsManagerAccessRoleArn": "arn:aws:iam::123456789012:role/example-secrets-manager-role",
+                    "DataProviderName": "example-data-provider",
+                    "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            ],
+            "TargetDataProviderDescriptors": [
+                {
+                    "SecretsManagerSecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-target-secret-A1B2C3",
+                    "SecretsManagerAccessRoleArn": "arn:aws:iam::123456789012:role/example-secrets-manager-role",
+                    "DataProviderName": "example-data-provider",
+                    "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            ],
+            "InstanceProfileArn": "arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "InstanceProfileName": "example-instance-profile",
+            "TransformationRules": "{\"rules\":[{\"rule-type\":\"transformation\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"rule-target\":\"schema\",\"rule-action\":\"rename\",\"object-locator\":{\"schema-name\":\"ExampleSchema\"},\"value\":\"TargetSchema\"}]}",
+            "Description": "Example migration project for documentation",
+            "SchemaConversionApplicationAttributes": {
+                "S3BucketPath": "s3://amzn-s3-demo-bucket",
+                "S3BucketRoleArn": "arn:aws:iam::123456789012:role/example-s3-access-role"
+            }
+        }
+    }
+
+For more information, see `Working with migration projects <https://docs.aws.amazon.com/dms/latest/userguide/migration-projects-create.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/delete-data-provider.rst
+++ b/awscli/examples/dms/delete-data-provider.rst
@@ -1,0 +1,29 @@
+**To delete a data provider**
+
+The following ``delete-data-provider`` example deletes a data provider identified by its ARN. ::
+
+    aws dms delete-data-provider \
+        --data-provider-identifier arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "DataProvider": {
+            "DataProviderName": "example-data-provider",
+            "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "DataProviderCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "Description": "Example data provider for documentation",
+            "Engine": "sqlserver",
+            "Settings": {
+                "MicrosoftSqlServerSettings": {
+                    "ServerName": "example-source-server.us-east-1.rds.amazonaws.com",
+                    "Port": 1433,
+                    "DatabaseName": "ExampleDatabase",
+                    "SslMode": "verify-full",
+                    "CertificateArn": "arn:aws:dms:us-east-1:123456789012:cert:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            }
+        }
+    }
+
+For more information, see `Working with data providers <https://docs.aws.amazon.com/dms/latest/userguide/data-providers.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/delete-instance-profile.rst
+++ b/awscli/examples/dms/delete-instance-profile.rst
@@ -1,0 +1,26 @@
+**To delete an instance profile**
+
+The following ``delete-instance-profile`` example deletes an instance profile identified by its ARN. ::
+
+    aws dms delete-instance-profile \
+        --instance-profile-identifier arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "InstanceProfile": {
+            "InstanceProfileArn": "arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "PubliclyAccessible": false,
+            "NetworkType": "IPV4",
+            "InstanceProfileName": "example-instance-profile",
+            "Description": "Example instance profile for documentation",
+            "InstanceProfileCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "SubnetGroupIdentifier": "example-replication-subnet-group",
+            "VpcSecurityGroups": [
+                "sg-0123456789abcdef0"
+            ]
+        }
+    }
+
+For more information, see `Working with instance profiles <https://docs.aws.amazon.com/dms/latest/userguide/instance-profiles.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/delete-migration-project.rst
+++ b/awscli/examples/dms/delete-migration-project.rst
@@ -1,0 +1,42 @@
+**To delete a migration project**
+
+The following ``delete-migration-project`` example deletes a migration project identified by its ARN. ::
+
+    aws dms delete-migration-project \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "MigrationProject": {
+            "MigrationProjectName": "example-migration-project",
+            "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "MigrationProjectCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "SourceDataProviderDescriptors": [
+                {
+                    "SecretsManagerSecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-source-secret-A1B2C3",
+                    "SecretsManagerAccessRoleArn": "arn:aws:iam::123456789012:role/example-secrets-manager-role",
+                    "DataProviderName": "example-data-provider",
+                    "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            ],
+            "TargetDataProviderDescriptors": [
+                {
+                    "SecretsManagerSecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-target-secret-A1B2C3",
+                    "SecretsManagerAccessRoleArn": "arn:aws:iam::123456789012:role/example-secrets-manager-role",
+                    "DataProviderName": "example-data-provider",
+                    "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            ],
+            "InstanceProfileArn": "arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "InstanceProfileName": "example-instance-profile",
+            "TransformationRules": "{\"rules\":[{\"rule-type\":\"transformation\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"rule-target\":\"schema\",\"rule-action\":\"rename\",\"object-locator\":{\"schema-name\":\"ExampleSchema\"},\"value\":\"TargetSchema\"}]}",
+            "Description": "Example migration project for documentation",
+            "SchemaConversionApplicationAttributes": {
+                "S3BucketPath": "s3://amzn-s3-demo-bucket",
+                "S3BucketRoleArn": "arn:aws:iam::123456789012:role/example-s3-access-role"
+            }
+        }
+    }
+
+For more information, see `Working with migration projects <https://docs.aws.amazon.com/dms/latest/userguide/migration-projects-manage.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-conversion-configuration.rst
+++ b/awscli/examples/dms/describe-conversion-configuration.rst
@@ -1,0 +1,15 @@
+**To describe a conversion configuration**
+
+The following ``describe-conversion-configuration`` example retrieves the conversion configuration for a migration project. ::
+
+    aws dms describe-conversion-configuration \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "MigrationProjectIdentifier": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+        "ConversionConfiguration": "{\"Common project settings\":{\"ShowSeverityLevelInSql\":\"CRITICAL\",\"EnableGenAiConversion\":false},\"MSSQL_TO_AURORA_POSTGRESQL\":{\"ConvertProceduresToFunction\":true,\"UniqueIndexGeneration\":true,\"CaseSensitivityNames\":false},\"Conversion version\":{\"MSSQL_TO_AURORA_POSTGRESQL_target_engine_version\":\"15\"}}"
+    }
+
+For more information, see `Specifying schema conversion settings <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-settings.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-data-providers.rst
+++ b/awscli/examples/dms/describe-data-providers.rst
@@ -1,0 +1,31 @@
+**To describe data providers**
+
+The following ``describe-data-providers`` example retrieves the details of a data provider identified by its ARN. ::
+
+    aws dms describe-data-providers \
+        --filters Name=data-provider-identifier,Values=arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "DataProviders": [
+            {
+                "DataProviderName": "example-data-provider",
+                "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "DataProviderCreationTime": "2026-01-09T12:30:00.000000+00:00",
+                "Description": "Example data provider for documentation",
+                "Engine": "sqlserver",
+                "Settings": {
+                    "MicrosoftSqlServerSettings": {
+                        "ServerName": "example-source-server.us-east-1.rds.amazonaws.com",
+                        "Port": 1433,
+                        "DatabaseName": "ExampleDatabase",
+                        "SslMode": "verify-full",
+                        "CertificateArn": "arn:aws:dms:us-east-1:123456789012:cert:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                    }
+                }
+            }
+        ]
+    }
+
+For more information, see `Working with data providers <https://docs.aws.amazon.com/dms/latest/userguide/data-providers.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-extension-pack-associations.rst
+++ b/awscli/examples/dms/describe-extension-pack-associations.rst
@@ -1,0 +1,40 @@
+**To describe extension pack associations**
+
+The following ``describe-extension-pack-associations`` example retrieves the status of operations that apply an extension pack to the target database, identified by their request IDs. ::
+
+    aws dms describe-extension-pack-associations \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --filters Name=request-id,Values=a1b2c3d4-5678-90ab-cdef-EXAMPLE11111,a1b2c3d4-5678-90ab-cdef-EXAMPLE22222,a1b2c3d4-5678-90ab-cdef-EXAMPLE33333
+
+Output::
+
+    {
+        "Requests": [
+            {
+                "Status": "SUCCESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+            },
+            {
+                "Status": "IN_PROGRESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Progress": {
+                    "ProgressPercent": 50.0,
+                    "ProgressStep": "IN_PROGRESS"
+                }
+            },
+            {
+                "Status": "FAILED",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Error": {
+                    "defaultErrorDetails": {
+                        "Message": "The database user in your target secret does not have sufficient privileges. Grant the required privileges and try again."
+                    }
+                }
+            }
+        ]
+    }
+
+For more information, see `Using extension packs <https://docs.aws.amazon.com/dms/latest/userguide/extension-pack.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-instance-profiles.rst
+++ b/awscli/examples/dms/describe-instance-profiles.rst
@@ -1,0 +1,28 @@
+**To describe instance profiles**
+
+The following ``describe-instance-profiles`` example retrieves the details of an instance profile identified by its ARN. ::
+
+    aws dms describe-instance-profiles \
+        --filters Name=instance-profile-identifier,Values=arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "InstanceProfiles": [
+            {
+                "InstanceProfileArn": "arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "PubliclyAccessible": false,
+                "NetworkType": "IPV4",
+                "InstanceProfileName": "example-instance-profile",
+                "Description": "Example instance profile for documentation",
+                "InstanceProfileCreationTime": "2026-01-09T12:30:00.000000+00:00",
+                "SubnetGroupIdentifier": "example-replication-subnet-group",
+                "VpcSecurityGroups": [
+                    "sg-0123456789abcdef0"
+                ]
+            }
+        ]
+    }
+
+For more information, see `Working with instance profiles <https://docs.aws.amazon.com/dms/latest/userguide/instance-profiles.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-metadata-model-assessments.rst
+++ b/awscli/examples/dms/describe-metadata-model-assessments.rst
@@ -1,0 +1,46 @@
+**To describe metadata model assessments**
+
+The following ``describe-metadata-model-assessments`` example retrieves the status of metadata model assessment operations identified by their request IDs. ::
+
+    aws dms describe-metadata-model-assessments \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --filters Name=request-id,Values=a1b2c3d4-5678-90ab-cdef-EXAMPLE11111,a1b2c3d4-5678-90ab-cdef-EXAMPLE22222,a1b2c3d4-5678-90ab-cdef-EXAMPLE33333
+
+Output::
+
+    {
+        "Requests": [
+            {
+                "Status": "SUCCESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+            },
+            {
+                "Status": "IN_PROGRESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Progress": {
+                    "ProgressPercent": 50.0,
+                    "TotalObjects": 100,
+                    "ProgressStep": "ANALYZING",
+                    "ProcessedObject": {
+                        "Name": "ExampleTable",
+                        "Type": "table",
+                        "EndpointType": "SOURCE"
+                    }
+                }
+            },
+            {
+                "Status": "FAILED",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Error": {
+                    "defaultErrorDetails": {
+                        "Message": "No objects were found according to the specified selection rules. Please review your selection rules and try again."
+                    }
+                }
+            }
+        ]
+    }
+
+For more information, see `Creating database migration assessment reports <https://docs.aws.amazon.com/dms/latest/userguide/assessment-reports.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-metadata-model-children.rst
+++ b/awscli/examples/dms/describe-metadata-model-children.rst
@@ -1,0 +1,33 @@
+**To describe metadata model children**
+
+The following ``describe-metadata-model-children`` example retrieves the child metadata models of the ``ExampleSchema`` schema from the source metadata tree. ::
+
+    aws dms describe-metadata-model-children \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection", "rule-id": "1", "rule-name": "1", "object-locator": {"server-name": "example-source-server.us-east-1.rds.amazonaws.com", "schema-name": "ExampleSchema"}, "rule-action": "explicit"}]}' \
+        --origin SOURCE
+
+Output::
+
+    {
+        "MetadataModelChildren": [
+            {
+                "MetadataModelName": "Tables",
+                "SelectionRules": "{\"rules\": [{\"rule-type\": \"selection\", \"rule-id\": \"1\", \"rule-name\": \"1\", \"object-locator\": {\"server-name\": \"example-source-server.us-east-1.rds.amazonaws.com\", \"schema-name\": \"ExampleSchema\", \"category-name\": \"Tables\"}, \"rule-action\": \"explicit\"}]}"
+            },
+            {
+                "MetadataModelName": "Views",
+                "SelectionRules": "{\"rules\": [{\"rule-type\": \"selection\", \"rule-id\": \"2\", \"rule-name\": \"2\", \"object-locator\": {\"server-name\": \"example-source-server.us-east-1.rds.amazonaws.com\", \"schema-name\": \"ExampleSchema\", \"category-name\": \"Views\"}, \"rule-action\": \"explicit\"}]}"
+            },
+            {
+                "MetadataModelName": "Functions",
+                "SelectionRules": "{\"rules\": [{\"rule-type\": \"selection\", \"rule-id\": \"3\", \"rule-name\": \"3\", \"object-locator\": {\"server-name\": \"example-source-server.us-east-1.rds.amazonaws.com\", \"schema-name\": \"ExampleSchema\", \"category-name\": \"Functions\"}, \"rule-action\": \"explicit\"}]}"
+            },
+            {
+                "MetadataModelName": "Sequences",
+                "SelectionRules": "{\"rules\": [{\"rule-type\": \"selection\", \"rule-id\": \"4\", \"rule-name\": \"4\", \"object-locator\": {\"server-name\": \"example-source-server.us-east-1.rds.amazonaws.com\", \"schema-name\": \"ExampleSchema\", \"category-name\": \"Sequences\"}, \"rule-action\": \"explicit\"}]}"
+            }
+        ]
+    }
+
+For more information, see `Navigating the metadata model tree <https://docs.aws.amazon.com/dms/latest/userguide/sc-metadata-model.html#sc-metadata-model-navigating>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-metadata-model-conversions.rst
+++ b/awscli/examples/dms/describe-metadata-model-conversions.rst
@@ -1,0 +1,46 @@
+**To describe metadata model conversions**
+
+The following ``describe-metadata-model-conversions`` example retrieves the status of metadata model conversion operations identified by their request IDs. ::
+
+    aws dms describe-metadata-model-conversions \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --filters Name=request-id,Values=a1b2c3d4-5678-90ab-cdef-EXAMPLE11111,a1b2c3d4-5678-90ab-cdef-EXAMPLE22222,a1b2c3d4-5678-90ab-cdef-EXAMPLE33333
+
+Output::
+
+    {
+        "Requests": [
+            {
+                "Status": "SUCCESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+            },
+            {
+                "Status": "IN_PROGRESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Progress": {
+                    "ProgressPercent": 50.0,
+                    "TotalObjects": 100,
+                    "ProgressStep": "CONVERTING",
+                    "ProcessedObject": {
+                        "Name": "ExampleTable",
+                        "Type": "table",
+                        "EndpointType": "SOURCE"
+                    }
+                }
+            },
+            {
+                "Status": "FAILED",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Error": {
+                    "defaultErrorDetails": {
+                        "Message": "No objects were found according to the specified selection rules. Please review your selection rules and try again."
+                    }
+                }
+            }
+        ]
+    }
+
+For more information, see `Converting database schemas <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-convert.html#schema-conversion-convert-steps>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-metadata-model-creations.rst
+++ b/awscli/examples/dms/describe-metadata-model-creations.rst
@@ -1,0 +1,36 @@
+**To describe metadata model creations**
+
+The following ``describe-metadata-model-creations`` example retrieves the status of metadata model creation operations identified by their request IDs. ::
+
+    aws dms describe-metadata-model-creations \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --filters Name=request-id,Values=a1b2c3d4-5678-90ab-cdef-EXAMPLE11111,a1b2c3d4-5678-90ab-cdef-EXAMPLE22222,a1b2c3d4-5678-90ab-cdef-EXAMPLE33333
+
+Output::
+
+    {
+        "Requests": [
+            {
+                "Status": "SUCCESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+            },
+            {
+                "Status": "IN_PROGRESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+            },
+            {
+                "Status": "FAILED",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Error": {
+                    "defaultErrorDetails": {
+                        "Message": "No objects were found according to the specified selection rules. Please review your selection rules and try again."
+                    }
+                }
+            }
+        ]
+    }
+
+For more information, see `Creating statement metadata models <https://docs.aws.amazon.com/dms/latest/userguide/sc-metadata-model.html#sc-metadata-model-creation>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-metadata-model-exports-as-script.rst
+++ b/awscli/examples/dms/describe-metadata-model-exports-as-script.rst
@@ -1,0 +1,48 @@
+**To describe metadata model exports as script**
+
+The following ``describe-metadata-model-exports-as-script`` example retrieves the status of operations that export metadata models as data definition language (DDL) scripts, identified by their request IDs. ::
+
+    aws dms describe-metadata-model-exports-as-script \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --filters Name=request-id,Values=a1b2c3d4-5678-90ab-cdef-EXAMPLE11111,a1b2c3d4-5678-90ab-cdef-EXAMPLE22222,a1b2c3d4-5678-90ab-cdef-EXAMPLE33333
+
+Output::
+
+    {
+        "Requests": [
+            {
+                "Status": "SUCCESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "ExportSqlDetails": {
+                    "S3ObjectKey": "s3://amzn-s3-demo-bucket/example-migration-project/ExampleScript.zip",
+                    "ObjectURL": "https://amzn-s3-demo-bucket.s3.us-east-1.amazonaws.com/example-migration-project/ExampleScript.zip"
+                }
+            },
+            {
+                "Status": "IN_PROGRESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Progress": {
+                    "ProgressPercent": 50.0,
+                    "TotalObjects": 100,
+                    "ProgressStep": "IN_PROGRESS",
+                    "ProcessedObject": {
+                        "EndpointType": "TARGET"
+                    }
+                }
+            },
+            {
+                "Status": "FAILED",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Error": {
+                    "defaultErrorDetails": {
+                        "Message": "No objects were found according to the specified selection rules. Please review your selection rules and try again."
+                    }
+                }
+            }
+        ]
+    }
+
+For more information, see `Saving your converted code to a SQL file <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-save-apply.html#schema-conversion-save>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-metadata-model-exports-to-target.rst
+++ b/awscli/examples/dms/describe-metadata-model-exports-to-target.rst
@@ -1,0 +1,44 @@
+**To describe metadata model exports to target**
+
+The following ``describe-metadata-model-exports-to-target`` example retrieves the status of operations that export converted metadata models to the target database, identified by their request IDs. ::
+
+    aws dms describe-metadata-model-exports-to-target \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --filters Name=request-id,Values=a1b2c3d4-5678-90ab-cdef-EXAMPLE11111,a1b2c3d4-5678-90ab-cdef-EXAMPLE22222,a1b2c3d4-5678-90ab-cdef-EXAMPLE33333
+
+Output::
+
+    {
+        "Requests": [
+            {
+                "Status": "SUCCESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+            },
+            {
+                "Status": "IN_PROGRESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Progress": {
+                    "ProgressPercent": 50.0,
+                    "TotalObjects": 100,
+                    "ProgressStep": "APPLYING",
+                    "ProcessedObject": {
+                        "EndpointType": "TARGET"
+                    }
+                }
+            },
+            {
+                "Status": "FAILED",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Error": {
+                    "defaultErrorDetails": {
+                        "Message": "No objects were found according to the specified selection rules. Please review your selection rules and try again."
+                    }
+                }
+            }
+        ]
+    }
+
+For more information, see `Applying your converted code <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-save-apply.html#schema-conversion-apply>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-metadata-model-imports.rst
+++ b/awscli/examples/dms/describe-metadata-model-imports.rst
@@ -1,0 +1,44 @@
+**To describe metadata model imports**
+
+The following ``describe-metadata-model-imports`` example retrieves the status of metadata import operations identified by their request IDs. ::
+
+    aws dms describe-metadata-model-imports \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --filters Name=request-id,Values=a1b2c3d4-5678-90ab-cdef-EXAMPLE11111,a1b2c3d4-5678-90ab-cdef-EXAMPLE22222,a1b2c3d4-5678-90ab-cdef-EXAMPLE33333
+
+Output::
+
+    {
+        "Requests": [
+            {
+                "Status": "SUCCESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+            },
+            {
+                "Status": "IN_PROGRESS",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Progress": {
+                    "ProgressPercent": 50.0,
+                    "TotalObjects": 100,
+                    "ProgressStep": "IN_PROGRESS",
+                    "ProcessedObject": {
+                        "EndpointType": "SOURCE"
+                    }
+                }
+            },
+            {
+                "Status": "FAILED",
+                "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "Error": {
+                    "defaultErrorDetails": {
+                        "Message": "No objects were found according to the specified selection rules. Please review your selection rules and try again."
+                    }
+                }
+            }
+        ]
+    }
+
+For more information, see `Navigating the metadata model tree <https://docs.aws.amazon.com/dms/latest/userguide/sc-metadata-model.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-metadata-model.rst
+++ b/awscli/examples/dms/describe-metadata-model.rst
@@ -1,0 +1,24 @@
+**To describe a metadata model**
+
+The following ``describe-metadata-model`` example retrieves detailed information about the ``ExampleTable`` table in the ``ExampleSchema`` schema from the source metadata tree, including its SQL definition and references to the corresponding converted metadata models in the target database. ::
+
+    aws dms describe-metadata-model \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection", "rule-id": "1", "rule-name": "1", "object-locator": {"server-name": "example-source-server.us-east-1.rds.amazonaws.com", "schema-name": "ExampleSchema", "table-name": "ExampleTable"}, "rule-action": "explicit"}]}' \
+        --origin SOURCE
+
+Output::
+
+    {
+        "MetadataModelName": "ExampleTable",
+        "MetadataModelType": "table",
+        "TargetMetadataModels": [
+            {
+                "MetadataModelName": "exampletable",
+                "SelectionRules": "{\"rules\": [{\"rule-type\": \"selection\", \"rule-id\": \"1\", \"rule-name\": \"1\", \"object-locator\": {\"server-name\": \"example-target-server.us-east-1.rds.amazonaws.com\", \"schema-name\": \"exampleschema\", \"table-name\": \"exampletable\"}, \"rule-action\": \"explicit\"}]}"
+            }
+        ],
+        "Definition": "CREATE TABLE ExampleTable (ExampleColumn INTEGER NOT NULL);"
+    }
+
+For more information, see `Navigating the metadata model tree <https://docs.aws.amazon.com/dms/latest/userguide/sc-metadata-model.html#sc-metadata-model-navigating>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/describe-migration-projects.rst
+++ b/awscli/examples/dms/describe-migration-projects.rst
@@ -1,0 +1,44 @@
+**To describe migration projects**
+
+The following ``describe-migration-projects`` example retrieves the details of a migration project identified by its ARN. ::
+
+    aws dms describe-migration-projects \
+        --filters Name=migration-project-identifier,Values=arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "MigrationProjects": [
+            {
+                "MigrationProjectName": "example-migration-project",
+                "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "MigrationProjectCreationTime": "2026-01-09T12:30:00.000000+00:00",
+                "SourceDataProviderDescriptors": [
+                    {
+                        "SecretsManagerSecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-source-secret-A1B2C3",
+                        "SecretsManagerAccessRoleArn": "arn:aws:iam::123456789012:role/example-secrets-manager-role",
+                        "DataProviderName": "example-data-provider",
+                        "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                    }
+                ],
+                "TargetDataProviderDescriptors": [
+                    {
+                        "SecretsManagerSecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-target-secret-A1B2C3",
+                        "SecretsManagerAccessRoleArn": "arn:aws:iam::123456789012:role/example-secrets-manager-role",
+                        "DataProviderName": "example-data-provider",
+                        "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                    }
+                ],
+                "InstanceProfileArn": "arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS",
+                "InstanceProfileName": "example-instance-profile",
+                "TransformationRules": "{\"rules\":[{\"rule-type\":\"transformation\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"rule-target\":\"schema\",\"rule-action\":\"rename\",\"object-locator\":{\"schema-name\":\"ExampleSchema\"},\"value\":\"TargetSchema\"}]}",
+                "Description": "Example migration project for documentation",
+                "SchemaConversionApplicationAttributes": {
+                    "S3BucketPath": "s3://amzn-s3-demo-bucket",
+                    "S3BucketRoleArn": "arn:aws:iam::123456789012:role/example-s3-access-role"
+                }
+            }
+        ]
+    }
+
+For more information, see `Working with migration projects <https://docs.aws.amazon.com/dms/latest/userguide/migration-projects.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/export-metadata-model-assessment.rst
+++ b/awscli/examples/dms/export-metadata-model-assessment.rst
@@ -1,0 +1,24 @@
+**To export a conversion assessment report**
+
+The following ``export-metadata-model-assessment`` example exports a conversion assessment report for all objects in the ``ExampleSchema`` schema. ::
+
+    aws dms export-metadata-model-assessment \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection", "rule-id": "1", "rule-name": "1", "object-locator": {"server-name": "example-source-server.us-east-1.rds.amazonaws.com", "schema-name": "ExampleSchema"}, "rule-action": "explicit"}]}' \
+        --file-name example-assessment-report \
+        --assessment-report-types pdf csv
+
+Output::
+
+    {
+        "PdfReport": {
+            "S3ObjectKey": "example-migration-project/example-assessment-report.pdf",
+            "ObjectURL": "https://amzn-s3-demo-bucket.s3.amazonaws.com/example-migration-project/example-assessment-report.pdf"
+        },
+        "CsvReport": {
+            "S3ObjectKey": "example-migration-project/example-assessment-report.zip",
+            "ObjectURL": "https://amzn-s3-demo-bucket.s3.amazonaws.com/example-migration-project/example-assessment-report.zip"
+        }
+    }
+
+For more information, see `Creating database migration assessment reports <https://docs.aws.amazon.com/dms/latest/userguide/assessment-reports.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/get-target-selection-rules.rst
+++ b/awscli/examples/dms/get-target-selection-rules.rst
@@ -1,0 +1,15 @@
+**To convert source selection rules to target selection rules**
+
+The following ``get-target-selection-rules`` example converts source selection rules that select the ``ExampleTable`` table in the ``ExampleSchema`` schema into target selection rules that reference its converted counterpart. ::
+
+    aws dms get-target-selection-rules \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection", "rule-id": "1", "rule-name": "1", "object-locator": {"server-name": "example-source-server.us-east-1.rds.amazonaws.com", "database-name": "ExampleDatabase", "schema-name": "ExampleSchema", "table-name": "ExampleTable"}, "rule-action": "explicit"}]}'
+
+Output::
+
+    {
+        "TargetSelectionRules": "{\"rules\": [{\"rule-type\": \"selection\", \"rule-id\": \"1\", \"rule-name\": \"1\", \"object-locator\": {\"server-name\": \"example-target-server.us-east-1.rds.amazonaws.com\", \"schema-name\": \"exampledatabase_exampleschema\", \"table-name\": \"exampletable\"}, \"rule-action\": \"explicit\"}]}"
+    }
+
+For more information, see `Using selection rules <https://docs.aws.amazon.com/dms/latest/userguide/sc-selection-rules.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/modify-conversion-configuration.rst
+++ b/awscli/examples/dms/modify-conversion-configuration.rst
@@ -1,0 +1,15 @@
+**To modify a conversion configuration**
+
+The following ``modify-conversion-configuration`` example enables generative AI assisted conversion and updates a conversion path setting for a migration project. ::
+
+    aws dms modify-conversion-configuration \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --conversion-configuration '{"Common project settings":{"EnableGenAiConversion":true},"MSSQL_TO_AURORA_POSTGRESQL":{"ConvertProceduresToFunction":false}}'
+
+Output::
+
+    {
+        "MigrationProjectIdentifier": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS"
+    }
+
+For more information, see `Specifying schema conversion settings <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-settings.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/modify-data-provider.rst
+++ b/awscli/examples/dms/modify-data-provider.rst
@@ -1,0 +1,32 @@
+**To modify a data provider**
+
+The following ``modify-data-provider`` example updates the description and server name of a data provider. ::
+
+    aws dms modify-data-provider \
+        --data-provider-identifier arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --description "Updated data provider description" \
+        --engine sqlserver \
+        --settings MicrosoftSqlServerSettings={ServerName=new-source-server.us-east-1.rds.amazonaws.com}
+
+Output::
+
+    {
+        "DataProvider": {
+            "DataProviderName": "example-data-provider",
+            "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "DataProviderCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "Description": "Updated data provider description",
+            "Engine": "sqlserver",
+            "Settings": {
+                "MicrosoftSqlServerSettings": {
+                    "ServerName": "new-source-server.us-east-1.rds.amazonaws.com",
+                    "Port": 1433,
+                    "DatabaseName": "ExampleDatabase",
+                    "SslMode": "verify-full",
+                    "CertificateArn": "arn:aws:dms:us-east-1:123456789012:cert:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            }
+        }
+    }
+
+For more information, see `Working with data providers <https://docs.aws.amazon.com/dms/latest/userguide/data-providers.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/modify-instance-profile.rst
+++ b/awscli/examples/dms/modify-instance-profile.rst
@@ -1,0 +1,28 @@
+**To modify an instance profile**
+
+The following ``modify-instance-profile`` example updates the description and network type of an instance profile. ::
+
+    aws dms modify-instance-profile \
+        --instance-profile-identifier arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --description "Updated instance profile description" \
+        --network-type DUAL
+
+Output::
+
+    {
+        "InstanceProfile": {
+            "InstanceProfileArn": "arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "PubliclyAccessible": false,
+            "NetworkType": "DUAL",
+            "InstanceProfileName": "example-instance-profile",
+            "Description": "Updated instance profile description",
+            "InstanceProfileCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "SubnetGroupIdentifier": "example-replication-subnet-group",
+            "VpcSecurityGroups": [
+                "sg-0123456789abcdef0"
+            ]
+        }
+    }
+
+For more information, see `Working with instance profiles <https://docs.aws.amazon.com/dms/latest/userguide/instance-profiles.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/modify-migration-project.rst
+++ b/awscli/examples/dms/modify-migration-project.rst
@@ -1,0 +1,44 @@
+**To modify a migration project**
+
+The following ``modify-migration-project`` example updates the source data provider and description of a migration project. ::
+
+    aws dms modify-migration-project \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --description "Updated migration project description" \
+        --source-data-provider-descriptors DataProviderIdentifier=arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "MigrationProject": {
+            "MigrationProjectName": "example-migration-project",
+            "MigrationProjectArn": "arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "MigrationProjectCreationTime": "2026-01-09T12:30:00.000000+00:00",
+            "SourceDataProviderDescriptors": [
+                {
+                    "SecretsManagerSecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-source-secret-A1B2C3",
+                    "SecretsManagerAccessRoleArn": "arn:aws:iam::123456789012:role/example-secrets-manager-role",
+                    "DataProviderName": "example-data-provider",
+                    "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            ],
+            "TargetDataProviderDescriptors": [
+                {
+                    "SecretsManagerSecretId": "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-target-secret-A1B2C3",
+                    "SecretsManagerAccessRoleArn": "arn:aws:iam::123456789012:role/example-secrets-manager-role",
+                    "DataProviderName": "example-data-provider",
+                    "DataProviderArn": "arn:aws:dms:us-east-1:123456789012:data-provider:EXAMPLEABCDEFGHIJKLMNOPQRS"
+                }
+            ],
+            "InstanceProfileArn": "arn:aws:dms:us-east-1:123456789012:instance-profile:EXAMPLEABCDEFGHIJKLMNOPQRS",
+            "InstanceProfileName": "example-instance-profile",
+            "TransformationRules": "{\"rules\":[{\"rule-type\":\"transformation\",\"rule-id\":\"1\",\"rule-name\":\"1\",\"rule-target\":\"schema\",\"rule-action\":\"rename\",\"object-locator\":{\"schema-name\":\"ExampleSchema\"},\"value\":\"TargetSchema\"}]}",
+            "Description": "Updated migration project description",
+            "SchemaConversionApplicationAttributes": {
+                "S3BucketPath": "s3://amzn-s3-demo-bucket",
+                "S3BucketRoleArn": "arn:aws:iam::123456789012:role/example-s3-access-role"
+            }
+        }
+    }
+
+For more information, see `Working with migration projects <https://docs.aws.amazon.com/dms/latest/userguide/migration-projects-manage.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/start-extension-pack-association.rst
+++ b/awscli/examples/dms/start-extension-pack-association.rst
@@ -1,0 +1,14 @@
+**To apply an extension pack to the target database**
+
+The following ``start-extension-pack-association`` example queues the application of an extension pack to the target database. ::
+
+    aws dms start-extension-pack-association \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS
+
+Output::
+
+    {
+        "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Using extension packs <https://docs.aws.amazon.com/dms/latest/userguide/extension-pack.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/start-metadata-model-assessment.rst
+++ b/awscli/examples/dms/start-metadata-model-assessment.rst
@@ -1,0 +1,15 @@
+**To assess all objects in a schema**
+
+The following ``start-metadata-model-assessment`` example queues an assessment of the conversion complexity for all objects in the ``ExampleSchema`` schema. ::
+
+    aws dms start-metadata-model-assessment \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection","rule-id": "1","rule-name": "1","object-locator": {"server-name": "example-source-server.us-east-1.rds.amazonaws.com", "schema-name": "ExampleSchema"},"rule-action": "explicit"}]}'
+
+Output::
+
+    {
+        "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Creating database migration assessment reports <https://docs.aws.amazon.com/dms/latest/userguide/assessment-reports.html>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/start-metadata-model-conversion.rst
+++ b/awscli/examples/dms/start-metadata-model-conversion.rst
@@ -1,0 +1,15 @@
+**To convert all objects in a schema**
+
+The following ``start-metadata-model-conversion`` example queues a conversion of all objects in the ``ExampleSchema`` schema to the target database format. ::
+
+    aws dms start-metadata-model-conversion \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection","rule-id": "1","rule-name": "1","object-locator": {"server-name": "example-source-server.us-east-1.rds.amazonaws.com", "schema-name": "ExampleSchema"},"rule-action": "explicit"}]}'
+
+Output::
+
+    {
+        "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Converting database schemas <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-convert.html#schema-conversion-convert-steps>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/start-metadata-model-creation.rst
+++ b/awscli/examples/dms/start-metadata-model-creation.rst
@@ -1,0 +1,17 @@
+**To create a metadata model for a SQL statement**
+
+The following ``start-metadata-model-creation`` example queues the creation of a metadata model for a SQL statement. The selection rule specifies the schema where the metadata model is placed, and ``--metadata-model-name`` provides a unique identifier for use in subsequent operations. ::
+
+    aws dms start-metadata-model-creation \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection", "rule-id": "1", "rule-name": "1", "object-locator": {"server-name": "example-source-server.us-east-1.rds.amazonaws.com", "database-name": "ExampleDatabase", "schema-name": "ExampleSchema"}, "rule-action": "explicit"}]}' \
+        --metadata-model-name ExampleStatement \
+        --properties StatementProperties={Definition="SELECT * FROM ExampleTable;"}
+
+Output::
+
+    {
+        "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Creating statement metadata models <https://docs.aws.amazon.com/dms/latest/userguide/sc-metadata-model.html#sc-metadata-model-creation>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/start-metadata-model-export-as-script.rst
+++ b/awscli/examples/dms/start-metadata-model-export-as-script.rst
@@ -1,0 +1,17 @@
+**To export converted metadata models as DDL scripts**
+
+The following ``start-metadata-model-export-as-script`` example queues an export of converted metadata models for all objects in the ``ExampleSchema`` schema as data definition language (DDL) scripts to the Amazon S3 bucket associated with the migration project. ::
+
+    aws dms start-metadata-model-export-as-script \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection","rule-id": "1","rule-name": "1","object-locator": {"server-name": "example-target-server.us-east-1.rds.amazonaws.com", "schema-name": "ExampleSchema"},"rule-action": "explicit"}]}' \
+        --origin TARGET \
+        --file-name ExampleScript
+
+Output::
+
+    {
+        "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Saving your converted code to a SQL file <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-save-apply.html#schema-conversion-save>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/start-metadata-model-export-to-target.rst
+++ b/awscli/examples/dms/start-metadata-model-export-to-target.rst
@@ -1,0 +1,16 @@
+**To export converted metadata models to the target database**
+
+The following ``start-metadata-model-export-to-target`` example queues an export of converted metadata models for all objects in the ``ExampleSchema`` schema to the target database. ::
+
+    aws dms start-metadata-model-export-to-target \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection","rule-id": "1","rule-name": "1","object-locator": {"server-name": "example-target-server.us-east-1.rds.amazonaws.com", "schema-name": "ExampleSchema"},"rule-action": "explicit"}]}' \
+        --overwrite-extension-pack
+
+Output::
+
+    {
+        "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Applying your converted code <https://docs.aws.amazon.com/dms/latest/userguide/schema-conversion-save-apply.html#schema-conversion-apply>`__ in the *AWS Database Migration Service User Guide*.

--- a/awscli/examples/dms/start-metadata-model-import.rst
+++ b/awscli/examples/dms/start-metadata-model-import.rst
@@ -1,0 +1,17 @@
+**To import metadata from the source database**
+
+The following ``start-metadata-model-import`` example queues a metadata import for all objects in the ``ExampleSchema`` schema from the source database. ::
+
+    aws dms start-metadata-model-import \
+        --migration-project-identifier arn:aws:dms:us-east-1:123456789012:migration-project:EXAMPLEABCDEFGHIJKLMNOPQRS \
+        --selection-rules '{"rules": [{"rule-type": "selection","rule-id": "1","rule-name": "1","object-locator": {"server-name": "example-source-server.us-east-1.rds.amazonaws.com", "schema-name": "ExampleSchema"},"rule-action": "explicit"}]}' \
+        --origin SOURCE \
+        --no-refresh
+
+Output::
+
+    {
+        "RequestIdentifier": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Navigating the metadata model tree <https://docs.aws.amazon.com/dms/latest/userguide/sc-metadata-model.html#sc-metadata-model-navigating>`__ in the *AWS Database Migration Service User Guide*.


### PR DESCRIPTION
Add command examples for 34 DMS operations covering Schema Conversion, data providers, instance profiles, and migration projects.

Operations covered:
- cancel-metadata-model-conversion, cancel-metadata-model-creation
- create-data-provider, create-instance-profile, create-migration-project
- delete-data-provider, delete-instance-profile, delete-migration-project
- describe-conversion-configuration, describe-data-providers, describe-extension-pack-associations, describe-instance-profiles, describe-metadata-model, describe-metadata-model-assessments, describe-metadata-model-children, describe-metadata-model-conversions, describe-metadata-model-creations, describe-metadata-model-exports-as-script, describe-metadata-model-exports-to-target, describe-metadata-model-imports, describe-migration-projects
- export-metadata-model-assessment, get-target-selection-rules
- modify-conversion-configuration, modify-data-provider, modify-instance-profile, modify-migration-project
- start-extension-pack-association, start-metadata-model-assessment, start-metadata-model-conversion, start-metadata-model-creation, start-metadata-model-export-as-script, start-metadata-model-export-to-target, start-metadata-model-import

All examples have been tested against the real DMS service and validated with `pytest tests/functional/docs/test_examples.py` (11756 tests passed).