### PR TITLE
Add --yes flag to skip wizard prompts

### DIFF
--- a/.changes/next-release/enhancement-agenttoolkit-1848.json
+++ b/.changes/next-release/enhancement-agenttoolkit-1848.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``agent-toolkit``",
+  "description": "Adds ``--force`` to ``aws configure agent-toolkit`` to skip interactive prompts and run end-to-end with defaults: select all detected agents, install default skills, and configure the AWS MCP server."
+}

--- a/.changes/next-release/enhancement-agenttoolkit-1848.json
+++ b/.changes/next-release/enhancement-agenttoolkit-1848.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
-  "category": "``agent-toolkit``",
-  "description": "Adds ``--force`` to ``aws configure agent-toolkit`` to skip interactive prompts and run end-to-end with defaults: select all detected agents, install default skills, and configure the AWS MCP server."
+  "category": "agent-toolkit",
+  "description": "Adds ``--yes`` to ``aws configure agent-toolkit`` to skip interactive prompts and accept defaults: select all detected agents, install default skills, and configure the AWS MCP server."
 }

--- a/awscli/customizations/agenttoolkit/configure.py
+++ b/awscli/customizations/agenttoolkit/configure.py
@@ -41,6 +41,18 @@ class ConfigureAgentToolkitCommand(BasicCommand):
         'those configuration directories, not per project.'
     )
     SYNOPSIS = 'aws configure agent-toolkit'
+    ARG_TABLE = [
+        {
+            'name': 'force',
+            'help_text': (
+                'Skip all interactive prompts and run end-to-end with '
+                'defaults: select all detected agents, install default '
+                'skills, and configure the AWS MCP server.'
+            ),
+            'default': False,
+            'action': 'store_true',
+        },
+    ]
 
     def __init__(self, session, stream=None, agent_configs=None, client=None):
         super().__init__(session)
@@ -51,6 +63,7 @@ class ConfigureAgentToolkitCommand(BasicCommand):
         self._client = client
 
     def _run_main(self, parsed_args, parsed_globals):
+        force = getattr(parsed_args, 'force', False)
         uni_print('\nDetecting installed AI coding agents...\n', self._stream)
         wizard_configs = [
             c for c in self._agent_configs if c.id != UNIVERSAL_ROW_ID
@@ -87,10 +100,14 @@ class ConfigureAgentToolkitCommand(BasicCommand):
                 'Install one and re-run \'aws configure agent-toolkit\'.'
             )
 
-        selected_agents = multiselect_choice(
-            '\nSelect agents to configure',
-            detected,
-            display_format=lambda a: a.display_label,
+        selected_agents = (
+            detected
+            if force
+            else multiselect_choice(
+                '\nSelect agents to configure',
+                detected,
+                display_format=lambda a: a.display_label,
+            )
         )
 
         if not selected_agents:
@@ -105,8 +122,8 @@ class ConfigureAgentToolkitCommand(BasicCommand):
             install_targets.append(universal_agent)
 
         client = self._client or create_client(self._session, parsed_globals)
-        self._install_default_skills(install_targets, client)
-        self._configure_mcp(selected_agents)
+        self._install_default_skills(install_targets, client, force=force)
+        self._configure_mcp(selected_agents, force=force)
 
         uni_print(
             '\nYou can discover additional skills with '
@@ -115,7 +132,7 @@ class ConfigureAgentToolkitCommand(BasicCommand):
         )
         return 0
 
-    def _install_default_skills(self, selected_agents, client):
+    def _install_default_skills(self, selected_agents, client, force=False):
         uni_print('\nFetching default AWS skills...\n', self._stream)
         paginator = client.get_paginator('list_skills')
         default_skills = []
@@ -128,7 +145,7 @@ class ConfigureAgentToolkitCommand(BasicCommand):
         names = ', '.join(s['name'] for s in default_skills)
         uni_print(f'  Found: {names}\n', self._stream)
 
-        if not yes_no_choice(
+        if not force and not yes_no_choice(
             f'\nInstall {len(default_skills)} default AWS skills? [Y/n]: '
         ):
             return
@@ -177,8 +194,10 @@ class ConfigureAgentToolkitCommand(BasicCommand):
                 '\nNo skills were installed successfully.\n', self._stream
             )
 
-    def _configure_mcp(self, agents):
-        if not yes_no_choice('\nConfigure AWS MCP server connection? [Y/n]: '):
+    def _configure_mcp(self, agents, force=False):
+        if not force and not yes_no_choice(
+            '\nConfigure AWS MCP server connection? [Y/n]: '
+        ):
             return
 
         uni_print('\nAWS MCP server configured for:\n', self._stream)

--- a/awscli/customizations/agenttoolkit/configure.py
+++ b/awscli/customizations/agenttoolkit/configure.py
@@ -43,11 +43,11 @@ class ConfigureAgentToolkitCommand(BasicCommand):
     SYNOPSIS = 'aws configure agent-toolkit'
     ARG_TABLE = [
         {
-            'name': 'force',
+            'name': 'yes',
             'help_text': (
-                'Skip all interactive prompts and run end-to-end with '
-                'defaults: select all detected agents, install default '
-                'skills, and configure the AWS MCP server.'
+                'Skip all interactive prompts and accept defaults: '
+                'select all detected agents, install default skills, '
+                'and configure the AWS MCP server.'
             ),
             'default': False,
             'action': 'store_true',
@@ -63,7 +63,7 @@ class ConfigureAgentToolkitCommand(BasicCommand):
         self._client = client
 
     def _run_main(self, parsed_args, parsed_globals):
-        force = getattr(parsed_args, 'force', False)
+        yes = getattr(parsed_args, 'yes', False)
         uni_print('\nDetecting installed AI coding agents...\n', self._stream)
         wizard_configs = [
             c for c in self._agent_configs if c.id != UNIVERSAL_ROW_ID
@@ -102,7 +102,7 @@ class ConfigureAgentToolkitCommand(BasicCommand):
 
         selected_agents = (
             detected
-            if force
+            if yes
             else multiselect_choice(
                 '\nSelect agents to configure',
                 detected,
@@ -122,8 +122,8 @@ class ConfigureAgentToolkitCommand(BasicCommand):
             install_targets.append(universal_agent)
 
         client = self._client or create_client(self._session, parsed_globals)
-        self._install_default_skills(install_targets, client, force=force)
-        self._configure_mcp(selected_agents, force=force)
+        self._install_default_skills(install_targets, client, yes=yes)
+        self._configure_mcp(selected_agents, yes=yes)
 
         uni_print(
             '\nYou can discover additional skills with '
@@ -132,7 +132,7 @@ class ConfigureAgentToolkitCommand(BasicCommand):
         )
         return 0
 
-    def _install_default_skills(self, selected_agents, client, force=False):
+    def _install_default_skills(self, selected_agents, client, yes=False):
         uni_print('\nFetching default AWS skills...\n', self._stream)
         paginator = client.get_paginator('list_skills')
         default_skills = []
@@ -145,7 +145,7 @@ class ConfigureAgentToolkitCommand(BasicCommand):
         names = ', '.join(s['name'] for s in default_skills)
         uni_print(f'  Found: {names}\n', self._stream)
 
-        if not force and not yes_no_choice(
+        if not yes and not yes_no_choice(
             f'\nInstall {len(default_skills)} default AWS skills? [Y/n]: '
         ):
             return
@@ -194,8 +194,8 @@ class ConfigureAgentToolkitCommand(BasicCommand):
                 '\nNo skills were installed successfully.\n', self._stream
             )
 
-    def _configure_mcp(self, agents, force=False):
-        if not force and not yes_no_choice(
+    def _configure_mcp(self, agents, yes=False):
+        if not yes and not yes_no_choice(
             '\nConfigure AWS MCP server connection? [Y/n]: '
         ):
             return

--- a/tests/unit/customizations/agenttoolkit/test_configure.py
+++ b/tests/unit/customizations/agenttoolkit/test_configure.py
@@ -56,7 +56,7 @@ def _make_client(skills=None):
     return client
 
 
-def _run(agent_configs, yes_no_return=True, client=None, force=False):
+def _run(agent_configs, yes_no_return=True, client=None, yes=False):
     stream = StringIO()
     session = make_session()
     if client is None:
@@ -65,7 +65,7 @@ def _run(agent_configs, yes_no_return=True, client=None, force=False):
         session, stream=stream, agent_configs=agent_configs, client=client
     )
     parsed_args = MagicMock()
-    parsed_args.force = force
+    parsed_args.yes = yes
     with (
         patch(
             'awscli.customizations.agenttoolkit.configure.multiselect_choice',
@@ -219,7 +219,7 @@ def test_wizard_credits_universal_row_for_shared_path_install(tmp_path):
     assert (universal_dir / 'aws-cdk' / 'SKILL.md').exists()
 
 
-def test_force_skips_all_prompts(tmp_path):
+def test_yes_skips_all_prompts(tmp_path):
     configs = _make_agent_configs(tmp_path, count=1)
     zip_bytes, checksum = make_skill_zip()
     client = _make_client(skills=[{'name': 'aws-serverless'}])
@@ -243,7 +243,7 @@ def test_force_skips_all_prompts(tmp_path):
             client=client,
         )
         parsed_args = MagicMock()
-        parsed_args.force = True
+        parsed_args.yes = True
         cmd._run_main(parsed_args, None)
     multiselect_mock.assert_not_called()
     yes_no_mock.assert_not_called()

--- a/tests/unit/customizations/agenttoolkit/test_configure.py
+++ b/tests/unit/customizations/agenttoolkit/test_configure.py
@@ -56,7 +56,7 @@ def _make_client(skills=None):
     return client
 
 
-def _run(agent_configs, yes_no_return=True, client=None):
+def _run(agent_configs, yes_no_return=True, client=None, force=False):
     stream = StringIO()
     session = make_session()
     if client is None:
@@ -64,6 +64,8 @@ def _run(agent_configs, yes_no_return=True, client=None):
     cmd = ConfigureAgentToolkitCommand(
         session, stream=stream, agent_configs=agent_configs, client=client
     )
+    parsed_args = MagicMock()
+    parsed_args.force = force
     with (
         patch(
             'awscli.customizations.agenttoolkit.configure.multiselect_choice',
@@ -74,7 +76,7 @@ def _run(agent_configs, yes_no_return=True, client=None):
             return_value=yes_no_return,
         ),
     ):
-        rc = cmd._run_main(None, None)
+        rc = cmd._run_main(parsed_args, None)
     return rc, stream
 
 
@@ -215,6 +217,42 @@ def test_wizard_credits_universal_row_for_shared_path_install(tmp_path):
     output = stream.getvalue()
     assert 'Universal (Codex)' in output
     assert (universal_dir / 'aws-cdk' / 'SKILL.md').exists()
+
+
+def test_force_skips_all_prompts(tmp_path):
+    configs = _make_agent_configs(tmp_path, count=1)
+    zip_bytes, checksum = make_skill_zip()
+    client = _make_client(skills=[{'name': 'aws-serverless'}])
+    with (
+        patch(
+            'awscli.customizations.agenttoolkit.configure.get_skill_download',
+            return_value=(zip_bytes, checksum, 'v1'),
+        ),
+        patch(
+            'awscli.customizations.agenttoolkit.configure.multiselect_choice',
+        ) as multiselect_mock,
+        patch(
+            'awscli.customizations.agenttoolkit.configure.yes_no_choice',
+        ) as yes_no_mock,
+    ):
+        stream = StringIO()
+        cmd = ConfigureAgentToolkitCommand(
+            make_session(),
+            stream=stream,
+            agent_configs=configs,
+            client=client,
+        )
+        parsed_args = MagicMock()
+        parsed_args.force = True
+        cmd._run_main(parsed_args, None)
+    multiselect_mock.assert_not_called()
+    yes_no_mock.assert_not_called()
+    skill_path = (
+        tmp_path / '.agent-0' / 'skills' / 'aws-serverless' / 'SKILL.md'
+    )
+    assert skill_path.exists()
+    mcp_path = tmp_path / '.agent-0' / 'mcp.json'
+    assert mcp_path.exists()
 
 
 def test_skill_checksum_failure_reported(tmp_path):


### PR DESCRIPTION
*Description of changes:* 
Adds `--yes` to `aws configure agent-toolkit` to skip all interactive prompts and run end-to-end with defaults: auto-selects every detected agent, installs default AWS skills, and configures the AWS MCP server connection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
