### PR TITLE
Fix configure get to support printing section values

### DIFF
--- a/awscli/customizations/configure/get.py
+++ b/awscli/customizations/configure/get.py
@@ -60,13 +60,9 @@ class ConfigureGetCommand(BasicCommand):
             self._stream.write('\n')
             return 0
         elif isinstance(value, dict):
-            # TODO: add support for this. We would need to print it off in
-            # the same format as the config file.
-            self._error_stream.write(
-                'varname (%s) must reference a value, not a section or '
-                'sub-section.' % varname
-            )
-            return 1
+            for key, val in value.items():
+                self._stream.write('%s = %s\n' % (key, val))
+            return 0
         else:
             return 1
 

--- a/tests/unit/customizations/configure/test_get.py
+++ b/tests/unit/customizations/configure/test_get.py
@@ -120,14 +120,9 @@ class TestConfigureGetCommand(unittest.TestCase):
         session.config = {'s3': {'signature_version': 's3v4'}}
         stream, error_stream, config_get = self.create_command(session)
         rc = config_get(args=['s3'], parsed_globals=None)
-        self.assertEqual(rc, 1)
-
-        error_message = error_stream.getvalue()
-        expected_message = (
-            'varname (s3) must reference a value, not a section or '
-            'sub-section.')
-        self.assertEqual(error_message, expected_message)
-        self.assertEqual(stream.getvalue(), '')
+        self.assertEqual(rc, 0)
+        self.assertEqual(stream.getvalue(), 'signature_version = s3v4\n')
+        self.assertEqual(error_stream.getvalue(), '')
 
     def test_get_non_string_returns_error(self):
         # This should never happen, but we handle this case so we should


### PR DESCRIPTION
**Description of changes:**  
  
`aws configure get` previously returned an error when the requested  
config key pointed to a section (dict) instead of a scalar value.  
For example:  
  
    $ aws configure get s3  
    varname (s3) must reference a value, not a section or sub-section.  
  
This PR fixes that by printing the section's key-value pairs in  
config file format:  
  
    $ aws configure get s3  
    signature_version = s3v4  
  
**Changes:**  
- `awscli/customizations/configure/get.py`: Handle `dict` values in  
  `ConfigureGetCommand` by printing each key-value pair instead of  
  returning an error.  
- `tests/unit/customizations/configure/test_get.py`: Updated  
  `test_get_section_returns_error` to assert the correct output  
  instead of the old error behavior.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
