### PR TITLE
fix typos and grammar in s3 examples

### DIFF
--- a/awscli/examples/s3/_concepts.rst
+++ b/awscli/examples/s3/_concepts.rst
@@ -13,11 +13,11 @@ are two types of path arguments: ``LocalPath`` and ``S3Uri``.
 ``LocalPath``: represents the path of a local file or directory.  It can be
 written as an absolute path or relative path.
 
-``S3Uri``: represents the location of a S3 object, prefix, or bucket.  This
+``S3Uri``: represents the location of an S3 object, prefix, or bucket.  This
 must be written in the form ``s3://amzn-s3-demo-bucket/mykey`` where ``amzn-s3-demo-bucket`` is
 the specified S3 bucket, ``mykey`` is the specified S3 key.  The path argument
 must begin with ``s3://`` in order to denote that the path argument refers to
-a S3 object. Note that prefixes are separated by forward slashes. For
+an S3 object. Note that prefixes are separated by forward slashes. For
 example, if the S3 object ``myobject`` had the prefix ``myprefix``, the
 S3 key would be ``myprefix/myobject``, and if the object was in the bucket
 ``amzn-s3-demo-bucket``, the ``S3Uri`` would be ``s3://amzn-s3-demo-bucket/myprefix/myobject``.

--- a/awscli/examples/s3/cp.rst
+++ b/awscli/examples/s3/cp.rst
@@ -23,7 +23,7 @@ Output::
 
 **Example 3: Copying a file from S3 to S3**
 
-The following ``cp`` command copies a single s3 object to a specified bucket and key::
+The following ``cp`` command copies a single S3 object to a specified bucket and key::
 
     aws s3 cp s3://amzn-s3-demo-bucket/test.txt s3://amzn-s3-demo-bucket/test2.txt
 

--- a/awscli/examples/s3/ls.rst
+++ b/awscli/examples/s3/ls.rst
@@ -1,6 +1,6 @@
 **Example 1: Listing all user owned buckets**
 
-The following ``ls`` command lists all of the bucket owned by the user.  In this example, the user owns the buckets ``amzn-s3-demo-bucket`` and ``amzn-s3-demo-bucket2``.  The timestamp is the date the bucket was created, shown in your machine's time zone.  This date can change when making changes to your bucket, such as editing its bucket policy.  Note if  ``s3://`` is used for the path argument ``<S3Uri>``, it will list all of the buckets as well. ::
+The following ``ls`` command lists all of the buckets owned by the user.  In this example, the user owns the buckets ``amzn-s3-demo-bucket`` and ``amzn-s3-demo-bucket2``.  The timestamp is the date the bucket was created, shown in your machine's time zone.  This date can change when making changes to your bucket, such as editing its bucket policy.  Note if  ``s3://`` is used for the path argument ``<S3Uri>``, it will list all of the buckets as well. ::
 
     aws s3 ls
 
@@ -77,7 +77,7 @@ Output::
 
 **Example 6: Listing from an S3 access point**
 
-The following ``ls`` command list objects from access point (``myaccesspoint``)::
+The following ``ls`` command lists objects from access point (``myaccesspoint``)::
 
     aws s3 ls s3://arn:aws:s3:us-west-2:123456789012:accesspoint/myaccesspoint/
 

--- a/awscli/examples/s3/mv.rst
+++ b/awscli/examples/s3/mv.rst
@@ -10,7 +10,7 @@ Output::
 
 **Example 2: Move an object to the specified bucket and key**
 
-The following ``mv`` command moves a single s3 object to a specified bucket and key. ::
+The following ``mv`` command moves a single S3 object to a specified bucket and key. ::
 
     aws s3 mv s3://amzn-s3-demo-bucket/test.txt s3://amzn-s3-demo-bucket/test2.txt
 
@@ -28,7 +28,7 @@ Output::
 
     move: s3://amzn-s3-demo-bucket/test.txt to test2.txt
 
-**Example 4: Move an object with it's original name to the specified bucket**
+**Example 4: Move an object with its original name to the specified bucket**
 
 The following ``mv`` command moves a single object to a specified bucket while retaining its original name::
 

--- a/awscli/examples/s3/presign.rst
+++ b/awscli/examples/s3/presign.rst
@@ -6,7 +6,7 @@ The following ``presign`` command generates a pre-signed URL for a specified buc
 
 Output::
 
-    https://amzn-s3-demo-bucket.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMBLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
+    https://amzn-s3-demo-bucket.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMPLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
 
 **Example 2: To create a pre-signed URL with a custom lifetime that links to an object in an S3 bucket**
 
@@ -17,6 +17,6 @@ The following ``presign`` command generates a pre-signed URL for a specified buc
 
 Output::
 
-    https://amzn-s3-demo-bucket.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMBLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
+    https://amzn-s3-demo-bucket.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMPLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
 
-For more information, see `Share an Object with Others <https://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html>`__ in the *S3 Developer Guide* guide.
+For more information, see `Share an Object with Others <https://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html>`__ in the *Amazon S3 Developer Guide*.

--- a/awscli/examples/s3/rm.rst
+++ b/awscli/examples/s3/rm.rst
@@ -1,6 +1,6 @@
 **Example 1: Delete an S3 object**
 
-The following ``rm`` command deletes a single s3 object::
+The following ``rm`` command deletes a single S3 object::
 
     aws s3 rm s3://amzn-s3-demo-bucket/test2.txt
 


### PR DESCRIPTION
fix typos and grammar in s3 examples

went through the s3 examples directory and fixed a handful of things:

- "s3" -> "S3" where it's used as a noun (cp.rst, mv.rst, rm.rst)
- "all of the bucket owned" -> "all of the buckets owned" (ls.rst)
- "command list objects" -> "command lists objects" (ls.rst)
- "it's original name" -> "its original name" (mv.rst, possessive not contraction)
- "a S3 object" -> "an S3 object" (_concepts.rst, 2 places)
- "EXAMBLE" -> "EXAMPLE" in example presigned URLs (presign.rst)
- "S3 Developer Guide* guide" -> "Amazon S3 Developer Guide*" (presign.rst, redundant word)

relates to #10075
