### PR TITLE
Add release workflow for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.x"
+
+      - name: Install build
+        run: python -m pip install build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1.14.0
+        with:
+          repository-url: https://upload.pypi.org/legacy/
+          skip-existing: true
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,3 @@ jobs:
         with:
           repository-url: https://upload.pypi.org/legacy/
           skip-existing: true
-          


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a GitHub Actions workflow for publishing `AWSCLI` to PyPI using trusted publishing (OIDC). This replaces credential-based publishing with a more secure, token-free approach where PyPI verifies the package origin directly through GitHub's OIDC identity.

*Testing*
Ran a test build and verified that a package was published to `test.pypi` as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.