### PR TITLE
fix(pagination): silent pagination truncation when native API uses PageSize or StartingToken

### DIFF
--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -194,7 +194,7 @@ def add_paging_argument(argument_table, arg_name, argument, shadowed_args):
 
 def check_should_enable_pagination(input_tokens, shadowed_args, argument_table,
                                    parsed_args, parsed_globals, **kwargs):
-    normalized_paging_args = ['start_token', 'max_items']
+    normalized_paging_args = ['starting_token', 'page_size', 'max_items']
     for token in input_tokens:
         py_name = token.replace('-', '_')
         if getattr(parsed_args, py_name) is not None and \


### PR DESCRIPTION
Fixes #10442

This pull request fixes a critical bug where providing the global pagination parameters `--page-size` or `--starting-token` silently disabled automatic pagination for a subset of AWS API commands, resulting in silent data truncation (returning only the first page and exiting with code 0).

## Motivation and Context
The AWS CLI supports automatic pagination by injecting global parameters (`--page-size`, `--starting-token`, `--max-items`) and intentionally disabling automatic pagination if the user specifies a raw, native API pagination parameter (e.g., `--next-token` or `--marker`). 

The logic checking for this collision in `awscli.customizations.paginate.check_should_enable_pagination` had a typographical error (`start_token` instead of `starting_token`) and completely omitted `page_size`:

```python
normalized_paging_args = ['start_token', 'max_items']
```

As a result, if an API operation naturally defines its `limit_key` as exactly `"PageSize"` (rather than `"MaxResults"` or `"MaxItems"`), the raw API argument name shadows the global CLI argument. Because `page_size` was missing from `normalized_paging_args`, the CLI assumed the user was intentionally specifying the undocumented raw API parameter and disabled automatic pagination.

This silently broke automated pagination for over 50 operations across `elb`, `elbv2`, `servicecatalog`, `pinpoint-email`, `mailmanager`, `sesv2`, `ce`, and `lakeformation` (whenever `--page-size` was explicitly specified), as well as `ssm-quicksetup` (when `--starting-token` was specified).

This fix corrects the tuple to properly exempt the global parameters from disabling pagination:
```python
normalized_paging_args = ['starting_token', 'page_size', 'max_items']
```

## Testing Done
Validated via `aws elbv2 describe-load-balancers --page-size 10`, confirming that the CLI now automatically paginates and fetches all load balancers instead of aborting after the first 10 items.
Added a direct mock validation simulating the parser flow, verifying `parsed_globals.paginate` remains `True`.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
