### PR TITLE
[v2] Add changelog entry for upgrading OpenSSL bundled with Linux installers to 3.5.7

### DIFF
--- a/.changes/next-release/enhancement-OpenSSL-23919.json
+++ b/.changes/next-release/enhancement-OpenSSL-23919.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "OpenSSL",
+  "description": "Upgraded the OpenSSL module that is bundled with AWS CLI v2 Linux installers to version ``3.5.7``."
+}


### PR DESCRIPTION
*Issue #, if available:*

* Contributes to https://github.com/aws/aws-cli/issues/10426.

*Description of changes:*

* Add changelog entry for upgrading the OpenSSL module bundled with AWS CLI v2 Linux installers.

*Description of tests:*

* Ran all tests (see GitHub CI).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
