### PR TITLE
Fix `--output text` `--query` emitting a stray `None` for the pagination resume hint

### DIFF
--- a/.changes/next-release/bugfix-text-output-pagination.json
+++ b/.changes/next-release/bugfix-text-output-pagination.json
@@ -1,0 +1,7 @@
+[
+  {
+    "category": "Output",
+    "description": "Fix an issue where ``--output text`` combined with ``--query`` would emit a stray ``None`` line for the pagination resume-token hint when a paginated response was truncated (for example with ``--max-items``). The ``NEXTTOKEN`` hint is pagination metadata and is no longer passed through the ``--query`` expression.",
+    "type": "bugfix"
+  }
+]

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -247,8 +247,13 @@ class TextFormatter(Formatter):
                     self._format_response(current, stream)
                 if response.resume_token:
                     # Tell the user about the next token so they can continue
-                    # if they want.
-                    self._format_response(
+                    # if they want.  This is pagination metadata rather than
+                    # part of the queried result set, so we render it directly
+                    # instead of going through ``_format_response``.  Passing it
+                    # through ``--query`` would run the user's data expression
+                    # against the ``NextToken`` hint and emit a stray ``None``
+                    # (or other unrelated value) into the output.
+                    text.format_text(
                         {'NextToken': {'NextToken': response.resume_token}},
                         stream,
                     )

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -74,6 +74,65 @@ class TestListUsers(BaseAWSCommandParamsTest):
             'ENGINEDEFAULTS\tNone\n')
 
 
+class TestTextPaginationResumeToken(BaseAWSCommandParamsTest):
+    """Regression tests for the resume-token hint in ``--output text``.
+
+    When a paginated response is truncated (e.g. via ``--max-items``) the
+    text formatter prints a ``NEXTTOKEN`` hint so users know how to resume.
+    This hint is pagination metadata and must not be run through ``--query``;
+    doing so used to emit a stray ``None`` (the result of searching the hint
+    with the user's data expression) into the output.
+    """
+
+    def setUp(self):
+        super(TestTextPaginationResumeToken, self).setUp()
+        # Two pages of results so that ``--max-items 1`` truncates and a
+        # resume token is generated.
+        self.parsed_responses = [
+            {
+                'Users': [{
+                    'UserName': 'alice',
+                    'Path': '/',
+                    'CreateDate': '2024-01-01T00:00:00Z',
+                    'UserId': 'A1',
+                    'Arn': 'arn:aws:iam::12345:user/alice',
+                }],
+                'IsTruncated': True,
+                'Marker': 'PAGE2',
+            },
+            {
+                'Users': [{
+                    'UserName': 'bob',
+                    'Path': '/',
+                    'CreateDate': '2024-01-02T00:00:00Z',
+                    'UserId': 'B1',
+                    'Arn': 'arn:aws:iam::12345:user/bob',
+                }],
+                'IsTruncated': False,
+            },
+        ]
+
+    def test_resume_token_hint_emitted_without_query(self):
+        output = self.run_cmd(
+            'iam list-users --max-items 1 --output text', expected_rc=0)[0]
+        lines = output.splitlines()
+        self.assertEqual(lines[0].split('\t')[0], 'USERS')
+        # The last line is the resume-token hint.
+        self.assertEqual(lines[-1].split('\t')[0], 'NEXTTOKEN')
+
+    def test_resume_token_hint_not_run_through_query(self):
+        output = self.run_cmd(
+            'iam list-users --max-items 1 --output text '
+            '--query Users[].UserName', expected_rc=0)[0]
+        lines = output.splitlines()
+        # The queried data is still rendered ...
+        self.assertEqual(lines[0], 'alice')
+        # ... and the resume-token hint survives untouched instead of being
+        # replaced by a stray ``None`` from applying the query to the hint.
+        self.assertEqual(lines[-1].split('\t')[0], 'NEXTTOKEN')
+        self.assertNotIn('None', lines)
+
+
 class TestDescribeChangesets(BaseAWSCommandParamsTest):
 
     def setUp(self):


### PR DESCRIPTION
Fixes: #10449

## Description

When `--output text` is combined with `--query` and a paginated response is
truncated (for example via `--max-items`), the CLI printed a stray `None` line:

```console
$ aws iam list-users --max-items 1 --output text --query 'Users[].UserName'
alice
None        # <-- bug
```

`TextFormatter` emits the `NEXTTOKEN` resume-token hint through
`_format_response`, which applies the user's `--query` expression. Evaluating a
data expression against the hint object
`{"NextToken": {"NextToken": "<token>"}}` returns `None`, and that `None` was
written to stdout, corrupting text/scripted output.

The resume-token hint is pagination metadata, not part of the queried result
set, so it is now rendered directly via `text.format_text(...)`, bypassing
`--query`:

```console
$ aws iam list-users --max-items 1 --output text --query 'Users[].UserName'
alice
NEXTTOKEN	<token>   # hint preserved, no stray None
```

## Scope

- `TextFormatter` only. The JSON and Table formatters aggregate the full result
  and apply `--query` once to the whole response, so they were never affected.
- No behavior change when `--query` is absent, and none for non-truncated
  responses (no resume token, so the branch is not entered).

## Changes

- `awscli/formatter.py` — render the resume-token hint with `text.format_text`
  instead of `_format_response` so the global `--query` is not applied to it.
- `tests/unit/output/test_text_output.py` — add `TestTextPaginationResumeToken`
  with two end-to-end functional tests (via `BaseAWSCommandParamsTest`):
  - the resume hint is still emitted without `--query`;
  - with `--query`, the queried data renders, the `NEXTTOKEN` hint is
    preserved, and no `None` line appears.
- `.changes/next-release/bugfix-text-output-pagination.json` — changelog entry.

## Testing

```console
$ python -m pytest tests/unit/output/test_text_output.py
```

- The new `--query` test fails on `develop` (reproduces the bug) and passes
  with this change.
- Existing `tests/unit/output/`, `tests/unit/test_text.py`, and
  `tests/functional/kinesis/test_list_streams.py` continue to pass.

## Checklist

- [x] Bug fix includes tests (per `CONTRIBUTING.md`).
- [x] Targets the `develop` branch.
- [x] Code follows PEP 8 and is consistent with the surrounding module.
- [x] Cross-platform; no platform-specific behavior introduced.
- [x] Changelog entry added under `.changes/next-release/`.
