### PR TITLE
fix: resolve --query corrupting pagination resume token in text output and --page-size/--starting-token silently disabling auto-pagination

### DIFF
--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -194,7 +194,7 @@ def add_paging_argument(argument_table, arg_name, argument, shadowed_args):
 
 def check_should_enable_pagination(input_tokens, shadowed_args, argument_table,
                                    parsed_args, parsed_globals, **kwargs):
-    normalized_paging_args = ['start_token', 'max_items']
+    normalized_paging_args = ['start_token', 'max_items', 'page_size', 'starting_token']
     for token in input_tokens:
         py_name = token.replace('-', '_')
         if getattr(parsed_args, py_name) is not None and \

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -247,8 +247,9 @@ class TextFormatter(Formatter):
                     self._format_response(current, stream)
                 if response.resume_token:
                     # Tell the user about the next token so they can continue
-                    # if they want.
-                    self._format_response(
+                    # if they want. Write directly to bypass any --query filter
+                    # since this is pagination metadata, not response data.
+                    text.format_text(
                         {'NextToken': {'NextToken': response.resume_token}},
                         stream,
                     )

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -309,6 +309,38 @@ class TestShouldEnablePagination(TestPaginateBase):
         self.assertFalse(self.parsed_globals.paginate)
         self.assertEqual(arg_table['foo'], mock.sentinel.ORIGINAL_ARG)
 
+    def test_page_size_does_not_disable_pagination_when_api_limit_key_is_page_size(self):
+        # Regression test for #10442: when an API's native limit_key is named
+        # "PageSize", the CLI token becomes "page-size" which clashes with our
+        # unified --page-size arg.  Using --page-size must NOT disable
+        # auto-pagination.
+        input_tokens = ['page-size']
+        self.parsed_globals.paginate = True
+        self.parsed_args.page_size = 10
+        paginate.check_should_enable_pagination(
+            input_tokens, {}, {}, self.parsed_args, self.parsed_globals)
+        self.assertTrue(
+            self.parsed_globals.paginate,
+            "--page-size incorrectly disabled auto-pagination when API "
+            "limit_key is named 'PageSize'",
+        )
+
+    def test_starting_token_does_not_disable_pagination_when_api_input_token_is_starting_token(self):
+        # Regression test for #10442: when an API's native input_token is
+        # named "StartingToken", the CLI token becomes "starting-token" which
+        # clashes with our unified --starting-token arg.  Using
+        # --starting-token must NOT disable auto-pagination.
+        input_tokens = ['starting-token']
+        self.parsed_globals.paginate = True
+        self.parsed_args.starting_token = 'abc123'
+        paginate.check_should_enable_pagination(
+            input_tokens, {}, {}, self.parsed_args, self.parsed_globals)
+        self.assertTrue(
+            self.parsed_globals.paginate,
+            "--starting-token incorrectly disabled auto-pagination when API "
+            "input_token is named 'StartingToken'",
+        )
+
 
 class TestPaginateV2Debug(TestPaginateBase):
     def setUp(self):

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -20,7 +20,9 @@ import sys
 import re
 import locale
 
-from awscli.formatter import Formatter
+from botocore.paginate import PageIterator
+
+from awscli.formatter import Formatter, TextFormatter
 
 
 class TestListUsers(BaseAWSCommandParamsTest):
@@ -151,3 +153,61 @@ class TestDescribeChangesets(BaseAWSCommandParamsTest):
                     key, actual_count, count
                 )
             )
+
+
+class TestTextFormatterResumeToken(unittest.TestCase):
+    """Tests for issue #10449: --query must not corrupt the NextToken hint."""
+
+    def _make_formatter(self, query=None):
+        args = mock.Mock()
+        args.query = query
+        return TextFormatter(args)
+
+    def _make_paginated_response(self, pages, resume_token=None):
+        result_key = mock.Mock()
+        result_key.expression = 'Users'
+        result_key.search.side_effect = lambda page: page.get('Users', [])
+
+        response = mock.Mock(spec=PageIterator)
+        response.result_keys = [result_key]
+        response.non_aggregate_part = {}
+        response.__iter__ = mock.Mock(return_value=iter(pages))
+        response.resume_token = resume_token
+        return response
+
+    def test_resume_token_printed_without_query(self):
+        formatter = self._make_formatter(query=None)
+        stream = StringIO()
+        pages = [{'Users': [{'UserName': 'alice'}]}]
+        response = self._make_paginated_response(pages, resume_token='tok123')
+        formatter('list-users', response, stream)
+        output = stream.getvalue()
+        self.assertIn('NEXTTOKEN', output)
+        self.assertIn('tok123', output)
+
+    def test_resume_token_not_filtered_to_none_when_query_set(self):
+        # Regression test for #10449: a JMESPath query on data keys
+        # must not cause the NextToken hint to print as "None".
+        query = mock.Mock()
+        query.search.side_effect = lambda data: (
+            None if 'NextToken' in data
+            else [u['UserName'] for u in data.get('Users', [])]
+        )
+        formatter = self._make_formatter(query=query)
+        stream = StringIO()
+        pages = [{'Users': [{'UserName': 'alice'}]}]
+        response = self._make_paginated_response(pages, resume_token='tok123')
+        formatter('list-users', response, stream)
+        output = stream.getvalue()
+        self.assertIn('NEXTTOKEN', output)
+        self.assertIn('tok123', output)
+        self.assertNotIn('None', output)
+
+    def test_no_resume_token_output_when_not_truncated(self):
+        formatter = self._make_formatter(query=None)
+        stream = StringIO()
+        pages = [{'Users': [{'UserName': 'alice'}]}]
+        response = self._make_paginated_response(pages, resume_token=None)
+        formatter('list-users', response, stream)
+        output = stream.getvalue()
+        self.assertNotIn('NEXTTOKEN', output)


### PR DESCRIPTION
## Summary

- **Fix #10449** — `aws --output text` with `--query` was printing a spurious `None` line when a paginated response was truncated. The `TextFormatter` was passing the pagination resume-token hint `{'NextToken': {'NextToken': <token>}}` through `_format_response()`, which applied the user's `--query` JMESPath expression to it. Any data query (e.g. `Users[].UserName`) evaluates to `None` against that metadata dict and the literal string `None` was written to stdout, silently corrupting script output.

- **Fix #10442** — Using `--page-size` against APIs whose native `limit_key` is named `PageSize` (e.g. `aws elbv2 describe-load-balancers`), or `--starting-token` against APIs whose native `input_token` is named `StartingToken` (e.g. `aws ssm-quicksetup list-configurations`), silently disabled automatic pagination and returned only the first page with exit code 0. The root cause was that `check_should_enable_pagination()` only had `['start_token', 'max_items']` in `normalized_paging_args`, so `page_size` and `starting_token` were misidentified as user-specified native API args, triggering `--no-paginate`.

## Changes

### `awscli/formatter.py`
- In `TextFormatter.__call__`, write the resume-token hint directly via `text.format_text()` instead of routing it through `_format_response()`, so the `--query` filter is never applied to pagination metadata.

### `awscli/customizations/paginate.py`
- Added `page_size` and `starting_token` to `normalized_paging_args` in `check_should_enable_pagination()` so the unified CLI pagination args are never mistaken for native API pagination params.

## Test plan

- [ ] `aws iam list-users --max-items 1 --output text --query 'Users[].UserName'` — confirm no `None` line appears after the username, and `NEXTTOKEN` line is still printed
- [ ] `aws elbv2 describe-load-balancers --page-size 5` — confirm all load balancers are returned (not just first page)
- [ ] `aws ssm-quicksetup list-configurations --starting-token <token>` — confirm pagination resumes correctly and auto-pagination is not disabled
- [ ] Existing pagination unit tests pass