### PR TITLE
[v2] Add redirect port option to sso login

### DIFF
--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -13,7 +13,10 @@
 import os
 
 from awscli.customizations.configure.writer import ConfigFileWriter
-from awscli.customizations.exceptions import ParamValidationError
+from awscli.customizations.exceptions import (
+    ConfigurationError,
+    ParamValidationError,
+)
 from awscli.customizations.sso.resolve import resolve_start_url
 from awscli.customizations.sso.utils import (
     LOGIN_ARGS,
@@ -22,6 +25,8 @@ from awscli.customizations.sso.utils import (
     do_sso_login,
 )
 from awscli.customizations.utils import uni_print
+
+SSO_REDIRECT_PORT_CONFIG_VAR = 'sso_redirect_port'
 
 
 class LoginCommand(BaseSSOCommand):
@@ -58,8 +63,10 @@ class LoginCommand(BaseSSOCommand):
     ]
 
     def _run_main(self, parsed_args, parsed_globals):
-        self._validate_redirect_port(parsed_args.redirect_port)
         sso_config = self._get_sso_config(sso_session=parsed_args.sso_session)
+        redirect_port = self._resolve_redirect_port(
+            parsed_args.redirect_port, sso_config
+        )
         start_url = sso_config['sso_start_url']
         configured_region = sso_config.get('sso_region')
 
@@ -88,7 +95,7 @@ class LoginCommand(BaseSSOCommand):
             session_name=sso_config.get('session_name'),
             registration_scopes=sso_config.get('registration_scopes'),
             use_device_code=parsed_args.use_device_code,
-            redirect_port=parsed_args.redirect_port,
+            redirect_port=redirect_port,
         )
 
         # Only rewrite sso_region after successful login.
@@ -116,11 +123,38 @@ class LoginCommand(BaseSSOCommand):
             config_path,
         )
 
-    def _validate_redirect_port(self, redirect_port):
+    def _resolve_redirect_port(self, redirect_port, sso_config):
+        if redirect_port is not None:
+            self._validate_redirect_port(
+                redirect_port, '--redirect-port', ParamValidationError
+            )
+            return redirect_port
+        if SSO_REDIRECT_PORT_CONFIG_VAR not in sso_config:
+            return None
+        return self._parse_redirect_port_config(
+            sso_config[SSO_REDIRECT_PORT_CONFIG_VAR]
+        )
+
+    def _parse_redirect_port_config(self, redirect_port):
+        try:
+            parsed_redirect_port = int(redirect_port)
+        except ValueError:
+            raise ConfigurationError(
+                f'Invalid value for {SSO_REDIRECT_PORT_CONFIG_VAR}. '
+                'Value must be an integer between 1 and 65535.'
+            )
+        self._validate_redirect_port(
+            parsed_redirect_port,
+            SSO_REDIRECT_PORT_CONFIG_VAR,
+            ConfigurationError,
+        )
+        return parsed_redirect_port
+
+    def _validate_redirect_port(self, redirect_port, name, error_cls):
         if redirect_port is None:
             return
         if redirect_port < 1 or redirect_port > 65535:
-            raise ParamValidationError(
-                'Invalid value for --redirect-port. '
+            raise error_cls(
+                f'Invalid value for {name}. '
                 'Value must be between 1 and 65535.'
             )

--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -13,6 +13,7 @@
 import os
 
 from awscli.customizations.configure.writer import ConfigFileWriter
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.sso.resolve import resolve_start_url
 from awscli.customizations.sso.utils import (
     LOGIN_ARGS,
@@ -36,6 +37,16 @@ class LoginCommand(BaseSSOCommand):
     )
     ARG_TABLE = LOGIN_ARGS + [
         {
+            'name': 'redirect-port',
+            'cli_type_name': 'integer',
+            'help_text': (
+                'The localhost port to use for the Authorization Code '
+                'callback server. When omitted, a random available port is '
+                'selected.'
+            ),
+            'required': False,
+        },
+        {
             'name': 'sso-session',
             'help_text': (
                 'An explicit SSO session to use to login. By default, this '
@@ -43,10 +54,11 @@ class LoginCommand(BaseSSOCommand):
                 'of the requested profile and generally does not require this '
                 'argument to be set.'
             ),
-        }
+        },
     ]
 
     def _run_main(self, parsed_args, parsed_globals):
+        self._validate_redirect_port(parsed_args.redirect_port)
         sso_config = self._get_sso_config(sso_session=parsed_args.sso_session)
         start_url = sso_config['sso_start_url']
         configured_region = sso_config.get('sso_region')
@@ -76,6 +88,7 @@ class LoginCommand(BaseSSOCommand):
             session_name=sso_config.get('session_name'),
             registration_scopes=sso_config.get('registration_scopes'),
             use_device_code=parsed_args.use_device_code,
+            redirect_port=parsed_args.redirect_port,
         )
 
         # Only rewrite sso_region after successful login.
@@ -102,3 +115,12 @@ class LoginCommand(BaseSSOCommand):
             {'__section__': section, 'sso_region': new_region},
             config_path,
         )
+
+    def _validate_redirect_port(self, redirect_port):
+        if redirect_port is None:
+            return
+        if redirect_port < 1 or redirect_port > 65535:
+            raise ParamValidationError(
+                'Invalid value for --redirect-port. '
+                'Value must be between 1 and 65535.'
+            )

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -86,6 +86,7 @@ def do_sso_login(
     session_name=None,
     use_device_code=False,
     resolved_start_url=None,
+    redirect_port=None,
 ):
     if token_cache is None:
         token_cache = JSONFileCache(SSO_TOKEN_DIR, dumps_func=_sso_json_dumps)
@@ -101,7 +102,7 @@ def do_sso_login(
             sso_region=sso_region,
             client_creator=session.create_client,
             parsed_globals=parsed_globals,
-            auth_code_fetcher=AuthCodeFetcher(),
+            auth_code_fetcher=AuthCodeFetcher(redirect_port=redirect_port),
             cache=token_cache,
             on_pending_authorization=on_pending_authorization,
         )
@@ -230,7 +231,7 @@ class AuthCodeFetcher:
     # How long we wait overall for the callback
     _OVERALL_TIMEOUT = 60 * 10
 
-    def __init__(self):
+    def __init__(self, redirect_port=None):
         self._auth_code = None
         self._state = None
         self._is_done = False
@@ -239,7 +240,8 @@ class AuthCodeFetcher:
         # AuthCodeFetcher so that it can pass back the state and auth code
         try:
             handler = partial(OAuthCallbackHandler, self)
-            self.http_server = HTTPServer(('', 0), handler)
+            server_port = 0 if redirect_port is None else redirect_port
+            self.http_server = HTTPServer(('', server_port), handler)
             self.http_server.timeout = self._REQUEST_TIMEOUT
         except OSError as e:
             raise AuthCodeFetcherError(error_msg=e)

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -354,6 +354,10 @@ class BaseSSOCommand(BasicCommand):
             parsed_scopes = parse_sso_registration_scopes(raw_scopes)
             sso_config['registration_scopes'] = parsed_scopes
 
+        redirect_port_var = 'sso_redirect_port'
+        if redirect_port_var in session_config:
+            sso_config[redirect_port_var] = session_config[redirect_port_var]
+
         if missing:
             error_msg = f'Missing the following required SSO configuration values: {", ".join(missing)}. '
             raise InvalidSSOConfigError(error_msg)

--- a/tests/functional/sso/__init__.py
+++ b/tests/functional/sso/__init__.py
@@ -200,7 +200,9 @@ class BaseSSOTest(BaseAWSCommandParamsTest):
         )
         return content
 
-    def get_sso_session_config(self, session_name, include_profile=True):
+    def get_sso_session_config(
+        self, session_name, include_profile=True, redirect_port=None
+    ):
         content = ''
         if include_profile:
             content += (
@@ -216,7 +218,9 @@ class BaseSSOTest(BaseAWSCommandParamsTest):
         )
         if self.registration_scopes:
             scopes = ', '.join(self.registration_scopes)
-            content += f'sso_registration_scopes={scopes}'
+            content += f'sso_registration_scopes={scopes}\n'
+        if redirect_port is not None:
+            content += f'sso_redirect_port={redirect_port}\n'
         return content
 
     def set_config_file_content(self, content=None):

--- a/tests/functional/sso/__init__.py
+++ b/tests/functional/sso/__init__.py
@@ -168,14 +168,17 @@ class BaseSSOTest(BaseAWSCommandParamsTest):
             verificationUriComplete, kwargs['verificationUriComplete']
         )
 
-    def assert_auth_browser_handler_called_with(self, expected_scopes):
+    def assert_auth_browser_handler_called_with(
+        self, expected_scopes, expected_redirect_port=55555
+    ):
         # The endpoint is subject to the endpoint rules, and the
         # code_challenge is not fixed so assert against the rest of the url
         expected_url = (
             'authorize?'
             'response_type=code'
             '&client_id=auth-client-id'
-            '&redirect_uri=http%3A%2F%2F127.0.0.1%3A55555%2Foauth%2Fcallback'
+            '&redirect_uri=http%3A%2F%2F127.0.0.1%3A'
+            f'{expected_redirect_port}%2Foauth%2Fcallback'
             '&state=00000000-0000-0000-0000-000000000000'
             '&code_challenge_method=S256'
             '&scopes=' + expected_scopes

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -321,6 +321,38 @@ class TestLoginCommand(BaseSSOTest):
             expected_redirect_port=34535,
         )
 
+    def test_login_auth_sso_session_with_configured_redirect_port(self):
+        content = self.get_sso_session_config(
+            'test-session', redirect_port=34535
+        )
+        self.set_config_file_content(content=content)
+        self.fetcher_mock.return_value.redirect_uri_with_port.return_value = (
+            'http://127.0.0.1:34535/oauth/callback'
+        )
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.fetcher_mock.assert_called_once_with(redirect_port=34535)
+        self.assert_auth_browser_handler_called_with(
+            'sso%3Aaccount%3Aaccess',
+            expected_redirect_port=34535,
+        )
+
+    def test_login_redirect_port_arg_overrides_configured_redirect_port(self):
+        content = self.get_sso_session_config(
+            'test-session', redirect_port=34535
+        )
+        self.set_config_file_content(content=content)
+        self.fetcher_mock.return_value.redirect_uri_with_port.return_value = (
+            'http://127.0.0.1:45678/oauth/callback'
+        )
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login --redirect-port 45678')
+        self.fetcher_mock.assert_called_once_with(redirect_port=45678)
+        self.assert_auth_browser_handler_called_with(
+            'sso%3Aaccount%3Aaccess',
+            expected_redirect_port=45678,
+        )
+
     def test_login_invalid_redirect_port(self):
         for redirect_port in (0, 65536):
             with self.subTest(redirect_port=redirect_port):
@@ -329,6 +361,16 @@ class TestLoginCommand(BaseSSOTest):
                     expected_rc=252,
                 )
                 self.assertIn('Invalid value for --redirect-port', stderr)
+
+    def test_login_invalid_configured_redirect_port(self):
+        for redirect_port in ('0', '65536', 'invalid'):
+            with self.subTest(redirect_port=redirect_port):
+                content = self.get_sso_session_config(
+                    'test-session', redirect_port=redirect_port
+                )
+                self.set_config_file_content(content=content)
+                _, stderr, _ = self.run_cmd('sso login', expected_rc=253)
+                self.assertIn('Invalid value for sso_redirect_port', stderr)
 
     def test_login_device_sso_with_explicit_sso_session_arg(self):
         content = self.get_sso_session_config(

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -307,6 +307,29 @@ class TestLoginCommand(BaseSSOTest):
             expected_token=self.access_token,
         )
 
+    def test_login_auth_sso_session_with_redirect_port(self):
+        content = self.get_sso_session_config('test-session')
+        self.set_config_file_content(content=content)
+        self.fetcher_mock.return_value.redirect_uri_with_port.return_value = (
+            'http://127.0.0.1:34535/oauth/callback'
+        )
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login --redirect-port 34535')
+        self.fetcher_mock.assert_called_once_with(redirect_port=34535)
+        self.assert_auth_browser_handler_called_with(
+            'sso%3Aaccount%3Aaccess',
+            expected_redirect_port=34535,
+        )
+
+    def test_login_invalid_redirect_port(self):
+        for redirect_port in (0, 65536):
+            with self.subTest(redirect_port=redirect_port):
+                _, stderr, _ = self.run_cmd(
+                    f'sso login --redirect-port {redirect_port}',
+                    expected_rc=252,
+                )
+                self.assertIn('Invalid value for --redirect-port', stderr)
+
     def test_login_device_sso_with_explicit_sso_session_arg(self):
         content = self.get_sso_session_config(
             'test-session', include_profile=False

--- a/tests/unit/customizations/sso/test_utils.py
+++ b/tests/unit/customizations/sso/test_utils.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
+import socket
 import threading
 import webbrowser
 
@@ -142,6 +143,31 @@ class TestDoSSOLogin(unittest.TestCase):
         self.assert_token_cache_was_filled()
         # Handler should not have been invoked as client was pre-authorized
         self.on_pending_authorization_mock.assert_not_called()
+
+    def test_do_sso_login_passes_redirect_port_to_auth_code_fetcher(self):
+        with mock.patch(
+            'awscli.customizations.sso.utils.AuthCodeFetcher'
+        ) as auth_code_fetcher:
+            with mock.patch(
+                'awscli.customizations.sso.utils.SSOTokenFetcherAuth'
+            ) as token_fetcher:
+                do_sso_login(
+                    session=self.session,
+                    sso_region=self.region,
+                    parsed_globals=mock.Mock(),
+                    start_url=self.start_url,
+                    session_name='test-session',
+                    redirect_port=34535,
+                )
+
+        auth_code_fetcher.assert_called_once_with(redirect_port=34535)
+        token_fetcher.return_value.fetch_token.assert_called_once_with(
+            start_url=self.start_url,
+            session_name='test-session',
+            force_refresh=False,
+            registration_scopes=None,
+            resolved_start_url=None,
+        )
 
 
 class BaseHandlerTest(unittest.TestCase):
@@ -330,3 +356,21 @@ def test_get_auth_code_and_state_timeout():
     """
     with pytest.raises(PendingAuthorizationExpiredError):
         AuthCodeFetcher().get_auth_code_and_state()
+
+
+def test_auth_code_fetcher_uses_redirect_port():
+    redirect_port = _get_available_port()
+    fetcher = AuthCodeFetcher(redirect_port=redirect_port)
+    try:
+        assert fetcher.http_server.server_port == redirect_port
+        assert fetcher.redirect_uri_with_port() == (
+            f'http://127.0.0.1:{redirect_port}/oauth/callback'
+        )
+    finally:
+        fetcher.http_server.server_close()
+
+
+def _get_available_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('', 0))
+        return sock.getsockname()[1]


### PR DESCRIPTION
*Issue #, if available:* Fixes #10433

*Description of changes:* Adds support for specifying a fixed localhost port for the PKCE callback server used by `aws sso login`.

Users can set the port per command with `--redirect-port`, or configure it on the SSO session with `sso_redirect_port`. When neither value is provided, the existing behavior is preserved and the callback server continues to bind to a randomly selected available port.

The CLI option takes precedence over `sso_redirect_port`. Invalid port values are rejected before starting the login flow.

Added unit and functional test coverage for the CLI option, SSO session configuration, CLI precedence over config, invalid port values, and binding the callback server to the requested port.

Validated with targeted pytest, ruff, and pre-commit checks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.