### PR TITLE
Fix SSO login failure for China and EUSC partition URLs

### DIFF
--- a/.changes/next-release/bugfix-sso-17448.json
+++ b/.changes/next-release/bugfix-sso-17448.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``sso``",
+  "description": "Fix SSO login failure for China partition URLs"
+}

--- a/.changes/next-release/bugfix-sso-17448.json
+++ b/.changes/next-release/bugfix-sso-17448.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "``sso``",
-  "description": "Fix SSO login failure for China partition URLs"
+  "description": "Fix SSO login failure for non-commercial partition URLs (China and EUSC)"
 }

--- a/awscli/customizations/sso/resolve.py
+++ b/awscli/customizations/sso/resolve.py
@@ -26,10 +26,15 @@ LOG = logging.getLogger(__name__)
 _AWS_OWNED_SUFFIXES = (
     '.app.aws',
     '.portal.amazonaws.com',
+    '.portal.amazonaws.com.cn',
     '.awsapps.com',
+    '.awsapps.cn',
 )
 
-_AWS_OWNED_EXACT = 'identitycenter.amazonaws.com'
+_AWS_OWNED_EXACT = (
+    'identitycenter.amazonaws.com',
+    'identitycenter.amazonaws.com.cn',
+)
 
 _REGION_PATTERNS = (
     # {idcInstanceId}.portal.{region}.app.aws
@@ -39,6 +44,11 @@ _REGION_PATTERNS = (
     # {idcInstanceId}.{region}.portal.amazonaws.com
     re.compile(
         r'^[^.]+\.(?P<region>[a-z0-9-]+)\.portal\.amazonaws\.com$',
+        re.IGNORECASE,
+    ),
+    # {idcInstanceId}.{region}.portal.amazonaws.com.cn
+    re.compile(
+        r'^[^.]+\.(?P<region>[a-z0-9-]+)\.portal\.amazonaws\.com\.cn$',
         re.IGNORECASE,
     ),
 )
@@ -61,7 +71,7 @@ def _normalize_url(url):
 
 def is_aws_owned_domain(hostname):
     hostname = hostname.lower().rstrip('.')
-    if hostname == _AWS_OWNED_EXACT:
+    if hostname in _AWS_OWNED_EXACT:
         return True
     for suffix in _AWS_OWNED_SUFFIXES:
         if hostname == suffix.lstrip('.'):

--- a/awscli/customizations/sso/resolve.py
+++ b/awscli/customizations/sso/resolve.py
@@ -27,6 +27,9 @@ _AWS_OWNED_SUFFIXES = (
     '.app.aws',
     '.portal.amazonaws.com',
     '.portal.amazonaws.com.cn',
+    '.app.amazonwebservices.com.cn',
+    '.portal.amazonaws.eu',
+    '.api.amazonwebservices.eu',
     '.awsapps.com',
     '.awsapps.cn',
 )
@@ -49,6 +52,21 @@ _REGION_PATTERNS = (
     # {idcInstanceId}.{region}.portal.amazonaws.com.cn
     re.compile(
         r'^[^.]+\.(?P<region>[a-z0-9-]+)\.portal\.amazonaws\.com\.cn$',
+        re.IGNORECASE,
+    ),
+    # {idcInstanceId}.portal.{region}.app.amazonwebservices.com.cn
+    re.compile(
+        r'^[^.]+\.portal\.(?P<region>[a-z0-9-]+)\.app\.amazonwebservices\.com\.cn$',
+        re.IGNORECASE,
+    ),
+    # {idcInstanceId}.{region}.portal.amazonaws.eu
+    re.compile(
+        r'^[^.]+\.(?P<region>[a-z0-9-]+)\.portal\.amazonaws\.eu$',
+        re.IGNORECASE,
+    ),
+    # {idcInstanceId}.portal.{region}.api.amazonwebservices.eu
+    re.compile(
+        r'^[^.]+\.portal\.(?P<region>[a-z0-9-]+)\.api\.amazonwebservices\.eu$',
         re.IGNORECASE,
     ),
 )

--- a/tests/unit/customizations/sso/test_resolve.py
+++ b/tests/unit/customizations/sso/test_resolve.py
@@ -44,6 +44,9 @@ class TestIsAwsOwnedDomain:
             'ssoins-abc123.cn-north-1.portal.amazonaws.com.cn',
             'ssoins-abc123.cn-northwest-1.portal.amazonaws.com.cn',
             'identitycenter.amazonaws.com.cn',
+            'ssoins-abc123.portal.cn-north-1.app.amazonwebservices.com.cn',
+            'ssoins-abc123.eusc-de-east-1.portal.amazonaws.eu',
+            'ssoins-abc123.portal.eusc-de-east-1.api.amazonwebservices.eu',
         ],
     )
     def test_aws_owned_returns_true(self, hostname):
@@ -84,6 +87,18 @@ class TestExtractRegionFromHostname:
             (
                 'ssoins-abc.cn-northwest-1.portal.amazonaws.com.cn',
                 'cn-northwest-1',
+            ),
+            (
+                'ssoins-abc.portal.cn-north-1.app.amazonwebservices.com.cn',
+                'cn-north-1',
+            ),
+            (
+                'ssoins-abc.eusc-de-east-1.portal.amazonaws.eu',
+                'eusc-de-east-1',
+            ),
+            (
+                'ssoins-abc.portal.eusc-de-east-1.api.amazonwebservices.eu',
+                'eusc-de-east-1',
             ),
         ],
     )

--- a/tests/unit/customizations/sso/test_resolve.py
+++ b/tests/unit/customizations/sso/test_resolve.py
@@ -39,6 +39,11 @@ class TestIsAwsOwnedDomain:
             'awsapps.com',
             'identitycenter.amazonaws.com',
             'identitycenter.amazonaws.com.',
+            'd-abc123.awsapps.cn',
+            'myalias.awsapps.cn',
+            'ssoins-abc123.cn-north-1.portal.amazonaws.com.cn',
+            'ssoins-abc123.cn-northwest-1.portal.amazonaws.com.cn',
+            'identitycenter.amazonaws.com.cn',
         ],
     )
     def test_aws_owned_returns_true(self, hostname):
@@ -56,6 +61,9 @@ class TestIsAwsOwnedDomain:
             'notidentitycenter.amazonaws.com',
             'example.com',
             '',
+            'awsapps.cn.evil.net',
+            'evil-awsapps.cn',
+            'portal.amazonaws.com.cn.evil.net',
         ],
     )
     def test_non_aws_owned_returns_false(self, hostname):
@@ -72,6 +80,11 @@ class TestExtractRegionFromHostname:
             ('ssoins-abc.portal.cn-north-1.app.aws', 'cn-north-1'),
             ('ssoins-abc.us-gov-west-1.portal.amazonaws.com', 'us-gov-west-1'),
             ('ssoins-abc.us-west-2.portal.amazonaws.com', 'us-west-2'),
+            ('ssoins-abc.cn-north-1.portal.amazonaws.com.cn', 'cn-north-1'),
+            (
+                'ssoins-abc.cn-northwest-1.portal.amazonaws.com.cn',
+                'cn-northwest-1',
+            ),
         ],
     )
     def test_extracts_region(self, hostname, expected_region):
@@ -81,7 +94,9 @@ class TestExtractRegionFromHostname:
         'hostname',
         [
             'd-abc123.awsapps.com',
+            'd-abc123.awsapps.cn',
             'identitycenter.amazonaws.com',
+            'identitycenter.amazonaws.com.cn',
             'aws.mycompany.com',
         ],
     )


### PR DESCRIPTION
*Issue #, if available:*   Fixes #10464

*Description of changes:* The vanity URL resolver introduced in 2.35.13 only recognized commercial partition SSO domains. This PR adds all IdC endpoint formats across partitions to the allowlist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
