### PR TITLE
Fix shorthand syntax error location rendering

### DIFF
--- a/.changes/next-release/bugfix-shorthand-error-location.json
+++ b/.changes/next-release/bugfix-shorthand-error-location.json
@@ -1,7 +1,5 @@
-[
-  {
-    "category": "Shorthand",
-    "description": "Fix an issue where shorthand syntax error messages printed the literal text ``{self._error_location()}`` instead of the input expression annotated with a caret pointing at the location of the syntax error.",
-    "type": "bugfix"
-  }
-]
+{
+  "category": "Shorthand",
+  "description": "Fix an issue where shorthand syntax error messages printed the literal text ``{self._error_location()}`` instead of the input expression annotated with a caret pointing at the location of the syntax error.",
+  "type": "bugfix"
+}

--- a/.changes/next-release/bugfix-shorthand-error-location.json
+++ b/.changes/next-release/bugfix-shorthand-error-location.json
@@ -1,0 +1,7 @@
+[
+  {
+    "category": "Shorthand",
+    "description": "Fix an issue where shorthand syntax error messages printed the literal text ``{self._error_location()}`` instead of the input expression annotated with a caret pointing at the location of the syntax error.",
+    "type": "bugfix"
+  }
+]

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -93,7 +93,7 @@ class ShorthandParseSyntaxError(ShorthandParseError):
     def _construct_msg(self):
         return (
             f"Expected: '{self.expected}', received: '{self.actual}' "
-            f"for input:\n" "{self._error_location()}"
+            f"for input:\n{self._error_location()}"
         )
 
 

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -175,6 +175,38 @@ def test_error_parsing(expr):
 
 
 @pytest.mark.parametrize(
+    "expr, expected_message", (
+        # The error message must include the original input with a
+        # caret pointing at the location of the syntax error.
+        (
+            'a=b,c==d',
+            "Expected: ',', received: '=' for input:\n"
+            "a=b,c==d\n"
+            "      ^",
+        ),
+        (
+            'a={b',
+            "Expected: '=', received: 'EOF' for input:\n"
+            "a={b\n"
+            "    ^",
+        ),
+        (
+            'foo=bar,foo=baz',
+            'Second instance of key "foo" encountered for input:\n'
+            'foo=bar,foo=baz\n'
+            '        ^\n'
+            'This is often because there is a preceding "," instead '
+            'of a space.',
+        ),
+    )
+)
+def test_error_message_includes_error_location(expr, expected_message):
+    with pytest.raises(shorthand.ShorthandParseError) as excinfo:
+        shorthand.ShorthandParser().parse(expr)
+    assert str(excinfo.value) == expected_message
+
+
+@pytest.mark.parametrize(
     "expr", (
         # starting with " but unclosed, then repeated \
         f'foo="' + '\\' * 100,


### PR DESCRIPTION
Fixes #10467

Since commit 9a2e0478 ("Format base *.py files at top level awscli
directory", August 2024), shorthand syntax errors have printed the literal
text `{self._error_location()}` instead of the input expression annotated
with a caret pointing at the parse failure:

```
$ aws dynamodb put-item --table-name t --item 'a=b,c==d'

Error parsing parameter '--item': Expected: ',', received: '=' for input:
{self._error_location()}
```

The f-string conversion in that commit left the final fragment of
`ShorthandParseSyntaxError._construct_msg` without the `f` prefix, so the
placeholder inside it was emitted verbatim. This affects every command whose
shorthand value fails to parse (`--tags`, `--item`, `--attributes`,
`--environment`, ...). The sibling `DuplicateKeyInObjectError` was converted
correctly and is unaffected.

This PR adds the missing `f` prefix, restoring the exact pre-regression
message:

```
Error parsing parameter '--item': Expected: ',', received: '=' for input:
a=b,c==d
      ^
```

## Changes

- `awscli/shorthand.py` — move the `{self._error_location()}` placeholder
  into the f-string fragment (one line).
- `tests/unit/test_shorthand.py` — add
  `test_error_message_includes_error_location`, parametrized over a
  mid-string syntax error, an EOF syntax error, and the duplicate-key error.
  Each case asserts the complete message, including the caret position. The
  pre-existing `test_error_parsing` only asserts the exception type, which
  is the coverage gap that allowed this to regress silently; these cases
  close it for both shorthand error types.
- `.changes/next-release/bugfix-shorthand-error-location.json` — changelog
  entry.

## Testing

Per CONTRIBUTING.md, the bug fix includes tests:

- `tests/unit/test_shorthand.py`: 117 passed (includes the 3 new regression
  cases)
- `tests/unit/test_argprocess.py`: 65 passed (shorthand error surfacing
  through `ParamError`)
- Verified end-to-end through `bin/aws` that the caret diagnostic is
  restored (no credentials required; parsing fails client-side)

No parsing behavior changes; only the error-message string on an
error-only path is affected. The restored text is identical to the output
of all releases prior to August 2024.

This pull request was generated with the assistance of AI tooling and
reviewed by Abuhaithem, per the repository's Automated Tools contribution
guidelines.