### PR TITLE
Fix quoting in create-invalidation-for-distribution-tenant example

### DIFF
--- a/awscli/examples/cloudfront/create-invalidation-for-distribution-tenant.rst
+++ b/awscli/examples/cloudfront/create-invalidation-for-distribution-tenant.rst
@@ -4,7 +4,7 @@ The following ``create-invalidation-for-distribution-tenant`` example creates an
 
     aws cloudfront create-invalidation-for-distribution-tenant \
         --id dt_2wjDZi3hD1ivOXf6rpZJO1AB \
-        --invalidation-batch '{"Paths": {"Quantity": 1, "Items": ["/*"]}, "CallerReference": "invalidation-$(date +%s)"}'
+        --invalidation-batch '{"Paths": {"Quantity": 1, "Items": ["/*"]}, "CallerReference": "invalidation-'$(date +%s)'"}'
 
 Output::
 
@@ -21,7 +21,7 @@ Output::
                         "/*"
                     ]
                 },
-                "CallerReference": "invalidation-$(date +%s)"
+                "CallerReference": "invalidation-1783101622"
             }
         }
     }


### PR DESCRIPTION
Fix quoting in create-invalidation-for-distribution-tenant example

The create-invalidation-for-distribution-tenant example wrapped the entire --invalidation-batch JSON in single quotes, which prevents $(date +%s) from expanding in any POSIX shell. CallerReference was always the literal string "invalidation-$(date +%s)", so running the example more than once caused CloudFront to return the original invalidation instead of creating a new one.

Close the single quotes around the timestamp so $(date +%s) expands, and update the example output to show a real expanded value.

Fixes #10469
