### PR TITLE
[v2] Implement update command

### DIFF
--- a/.changes/next-release/feature-update-59722.json
+++ b/.changes/next-release/feature-update-59722.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``update``",
+  "description": "Adds the ``update`` command, which downloads and installs the latest AWS CLI version."
+}

--- a/awscli/autocomplete/local/indexer.py
+++ b/awscli/autocomplete/local/indexer.py
@@ -32,6 +32,7 @@ class ModelIndexer:
         'login',
         'logout',
         'agent-toolkit',
+        'update',
     ]
 
     _CREATE_CMD_TABLE = """\

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -93,6 +93,7 @@ LOG_FORMAT = (
 )
 HISTORY_RECORDER = get_global_history_recorder()
 METADATA_FILENAME = 'metadata.json'
+INSTALL_FILENAME = 'install.json'
 _NO_AUTO_PROMPT_ARGS = ['help', '--version']
 _CLI_AUTO_PROMPT_OPTION = '--cli-auto-prompt'
 _NO_CLI_AUTO_PROMPT_OPTION = '--no-cli-auto-prompt'
@@ -166,16 +167,17 @@ def resolve_auto_prompt_mode(args, session):
         return 'off'
 
 
-def _get_distribution_source():
-    metadata_file = os.path.join(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data'),
-        METADATA_FILENAME,
-    )
-    metadata = {}
-    if os.path.isfile(metadata_file):
-        with open(metadata_file) as f:
-            metadata = json.load(f)
-    return metadata.get('distribution_source', 'other')
+def get_distribution_source():
+    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+    for name in (INSTALL_FILENAME, METADATA_FILENAME):
+        path = os.path.join(data_dir, name)
+        if not os.path.isfile(path):
+            continue
+        with open(path) as f:
+            data = json.load(f)
+        if 'distribution_source' in data:
+            return data['distribution_source']
+    return 'other'
 
 
 def _get_distribution():
@@ -199,7 +201,7 @@ def _get_linux_distribution():
 
 def _add_distribution_source_to_user_agent(session):
     add_metadata_component_to_user_agent_extra(
-        session, 'installer', _get_distribution_source()
+        session, 'installer', get_distribution_source()
     )
 
 
@@ -554,7 +556,7 @@ class CLIDriver:
                 f' exec-env/{os.environ.get("AWS_EXECUTION_ENV")}'
             )
 
-        version_string += f' {_get_distribution_source()}/{platform.machine()}'
+        version_string += f' {get_distribution_source()}/{platform.machine()}'
 
         if linux_distribution := _get_distribution():
             version_string += f'.{linux_distribution}'

--- a/awscli/customizations/update.py
+++ b/awscli/customizations/update.py
@@ -153,7 +153,9 @@ class UnixUpdateCommand(BaseUpdateCommand):
     def _is_system_install(self, install_metadata):
         if 'script_install' in install_metadata:
             return install_metadata['script_install'].get('system', False)
-        aws_bin = os.path.abspath(sys.argv[0])
+        if not sys.executable:
+            return False
+        aws_bin = os.path.realpath(sys.executable)
         return aws_bin.startswith(self.SYSTEM_INSTALL_DIR + os.sep)
 
     def _assert_elevated(self):

--- a/awscli/customizations/update.py
+++ b/awscli/customizations/update.py
@@ -1,0 +1,277 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import ctypes
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from awscli.botocore.awsrequest import AWSRequest
+from awscli.botocore.httpsession import URLLib3Session
+from awscli.clidriver import (
+    INSTALL_FILENAME,
+    get_distribution_source,
+)
+from awscli.compat import is_windows
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.utils import uni_print
+
+_DOWNLOAD_BASE_URL = 'https://awscli.amazonaws.com'
+
+_SUPPORTED_SOURCES = ('exe', 'script-exe', 'update-exe')
+
+
+def download_with_retry(url, dest, retries=1, session=None):
+    session = session or URLLib3Session()
+    uni_print(f"Downloading {url}\n")
+    request = AWSRequest(method='GET', url=url).prepare()
+    for attempt in range(retries + 1):
+        try:
+            response = session.send(request)
+            if response.status_code != 200:
+                raise UpdateError(
+                    f"unexpected HTTP status {response.status_code}"
+                )
+            with open(dest, 'wb') as out:
+                out.write(response.content)
+            return
+        except Exception as exc:
+            if attempt == retries:
+                raise UpdateError(f"failed to download {url}: {exc}")
+            uni_print(f"download failed ({exc}); retrying...\n", sys.stderr)
+
+
+class BaseUpdateCommand(BasicCommand):
+    NAME = 'update'
+    DESCRIPTION = (
+        'Update the AWS CLI to the latest version.\n\n'
+        'Note that ``update`` is only supported if the '
+        'current CLI instance was installed using an official '
+        'installer, install script, or the ``update`` command. '
+        'Other distribution mechanisms such as source or container '
+        'images are not supported.'
+    )
+    SYNOPSIS = 'aws update'
+    ARG_TABLE = []
+
+    _no_color = False
+
+    def __init__(
+        self, session, source=None, install_metadata=None, downloader=None
+    ):
+        super().__init__(session)
+        self._source = get_distribution_source() if source is None else source
+        self._install_metadata = (
+            self._read_install_json()
+            if install_metadata is None
+            else install_metadata
+        )
+        self._download = downloader or download_with_retry
+
+    def _read_install_json(self):
+        import awscli
+
+        path = os.path.join(
+            os.path.dirname(os.path.abspath(awscli.__file__)),
+            'data',
+            INSTALL_FILENAME,
+        )
+        if not os.path.isfile(path):
+            return {}
+        with open(path) as f:
+            return json.load(f)
+
+    def _run_main(self, parsed_args, parsed_globals):
+        source = self._source
+        if source not in _SUPPORTED_SOURCES:
+            raise UpdateError(
+                f"Detected distribution source: {source}. "
+                f"`aws update` is only supported on AWS CLI instances "
+                f"installed using an official installer, install script, "
+                f"or the `aws update` command."
+            )
+        uni_print(f"Updating AWS CLI (source: {source})\n")
+        self._no_color = parsed_globals.color == 'off'
+        self._do_update()
+        return 0
+
+    def _do_update(self):
+        raise NotImplementedError
+
+
+class UnixUpdateCommand(BaseUpdateCommand):
+    SCRIPT_URL = f'{_DOWNLOAD_BASE_URL}/v2/install.sh'
+    SYSTEM_INSTALL_DIR = '/usr/local/aws-cli'
+
+    def __init__(self, session, is_elevated=None, runner=None, **kwargs):
+        super().__init__(session, **kwargs)
+        self._is_elevated = (
+            os.geteuid() == 0 if is_elevated is None else is_elevated
+        )
+        self._run_update = runner or self._run_install
+
+    def _do_update(self):
+        install_dir = self._install_metadata.get('install_dir')
+        if not install_dir:
+            raise UpdateError(
+                'Install-time metadata could not be found. Reinstall '
+                'using the install script or an official installer '
+                'and try again.'
+            )
+        bin_dir = self._install_metadata.get('bin_dir')
+        is_system = self._is_system_install(self._install_metadata)
+        if is_system:
+            self._assert_elevated()
+        with tempfile.TemporaryDirectory() as tmp:
+            script_path = os.path.join(tmp, 'install.sh')
+            self._download(self.SCRIPT_URL, script_path)
+            env = os.environ.copy()
+            env['AWS_CLI_DISTRIBUTION_SOURCE_OVERRIDE'] = 'update-exe'
+            if self._no_color:
+                env['NO_COLOR'] = '1'
+            cmd = ['bash', script_path]
+            if is_system:
+                cmd.append('--system')
+            else:
+                env['XDG_DATA_HOME'] = os.path.dirname(install_dir)
+                if bin_dir:
+                    env['XDG_BIN_HOME'] = bin_dir
+                else:
+                    env['XDG_BIN_HOME'] = os.path.join(tmp, 'bin')
+                    env['AWS_CLI_NO_BIN_DIR'] = '1'
+            uni_print('Running install script...\n')
+            try:
+                self._run_update(cmd, env)
+            except subprocess.CalledProcessError as exc:
+                raise UpdateError(
+                    f"install script failed with exit code {exc.returncode}"
+                )
+
+    def _run_install(self, cmd, env):
+        subprocess.run(cmd, env=env, check=True)
+
+    def _is_system_install(self, install_metadata):
+        if 'script_install' in install_metadata:
+            return install_metadata['script_install'].get('system', False)
+        aws_bin = os.path.abspath(sys.argv[0])
+        return aws_bin.startswith(self.SYSTEM_INSTALL_DIR + os.sep)
+
+    def _assert_elevated(self):
+        if not self._is_elevated:
+            raise UpdateError(
+                'Updating a system-wide AWS CLI installation requires root.'
+            )
+
+
+class WindowsUpdateCommand(BaseUpdateCommand):
+    SCRIPT_URL = f'{_DOWNLOAD_BASE_URL}/v2/install.ps1'
+
+    def __init__(
+        self,
+        session,
+        is_elevated=None,
+        runner=None,
+        powershell_path=None,
+        **kwargs,
+    ):
+        super().__init__(session, **kwargs)
+        self._is_elevated = (
+            bool(ctypes.windll.shell32.IsUserAnAdmin())
+            if is_elevated is None
+            else is_elevated
+        )
+        self._run_update = runner or self._run_install
+        self._powershell_path = (
+            self._find_powershell()
+            if powershell_path is None
+            else powershell_path
+        )
+
+    def _do_update(self):
+        is_system = self._is_system_install(self._install_metadata)
+        if is_system:
+            self._assert_elevated()
+
+        tmp = tempfile.mkdtemp()
+        script_path = os.path.join(tmp, 'install.ps1')
+        self._download(self.SCRIPT_URL, script_path)
+
+        wrapper_path = os.path.join(tmp, 'aws-update.cmd')
+        ps_exe = self._powershell_path
+        ps_args = f'-NoProfile -File "{script_path}"'
+        if is_system:
+            ps_args += ' -System'
+
+        with open(wrapper_path, 'w') as f:
+            # Windows acquires a lock when running an exe process, preventing
+            # an update in-place. The workaround is to launch a detached CMD
+            # subprocess and exit the parent early. Use ping to wait before
+            # running the installation to ensure the parent isn't holding onto
+            # the lock.
+            f.write('@echo off\n')
+            f.write('set AWS_CLI_DISTRIBUTION_SOURCE_OVERRIDE=update-exe\n')
+            if self._no_color:
+                f.write('set NO_COLOR=1\n')
+            f.write('ping -n 3 127.0.0.1 >nul 2>&1\n')
+            f.write(f'"{ps_exe}" {ps_args}\n')
+
+        self._run_update(['cmd', '/c', wrapper_path])
+        uni_print(
+            'Update started. This process will exit and the '
+            'update will complete shortly.\n'
+        )
+
+    def _run_install(self, cmd):
+        subprocess.Popen(
+            cmd,
+            creationflags=subprocess.DETACHED_PROCESS
+            | subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
+
+    def _find_powershell(self):
+        path = shutil.which('powershell')
+        if not path:
+            raise UpdateError('powershell.exe not found on PATH.')
+        return path
+
+    def _is_system_install(self, install_metadata):
+        if 'script_install' in install_metadata:
+            return install_metadata['script_install'].get('system', False)
+        # AWS CLI is always installed to 'C:\Program Files\Amazon\AWSCLIV2'
+        # for all users. 'ProgramW6432' always points to 'C:\Program Files'
+        # while 'ProgramFiles' dynamically points to 'C:\Program Files' or
+        # 'C:\Program Files (x86)', depending on the architecture.
+        # Prefer 'ProgramW6432' and only read 'ProgramFiles' as a fallback.
+        program_files = os.environ.get('ProgramW6432') or os.environ.get(
+            'ProgramFiles'
+        )
+        if not program_files:
+            return False
+        canonical = os.path.join(
+            program_files, 'Amazon', 'AWSCLIV2', 'aws.exe'
+        )
+        buf = ctypes.create_unicode_buffer(32768)
+        ctypes.windll.kernel32.GetModuleFileNameW(None, buf, len(buf))
+        return os.path.normcase(buf.value) == os.path.normcase(canonical)
+
+    def _assert_elevated(self):
+        if not self._is_elevated:
+            raise UpdateError(
+                'Updating a system-wide AWS CLI install requires an '
+                'elevated shell. Re-run from an Administrator prompt.'
+            )
+
+
+UpdateCommand = WindowsUpdateCommand if is_windows else UnixUpdateCommand
+
+
+def register_update_command(event_handlers):
+    event_handlers.register(
+        'building-command-table.main', UpdateCommand.add_command
+    )
+
+
+class UpdateError(Exception):
+    pass

--- a/awscli/customizations/update.py
+++ b/awscli/customizations/update.py
@@ -107,9 +107,7 @@ class UnixUpdateCommand(BaseUpdateCommand):
 
     def __init__(self, session, is_elevated=None, runner=None, **kwargs):
         super().__init__(session, **kwargs)
-        self._is_elevated = (
-            os.geteuid() == 0 if is_elevated is None else is_elevated
-        )
+        self._is_elevated = is_elevated
         self._run_update = runner or self._run_install
 
     def _do_update(self):
@@ -159,7 +157,12 @@ class UnixUpdateCommand(BaseUpdateCommand):
         return aws_bin.startswith(self.SYSTEM_INSTALL_DIR + os.sep)
 
     def _assert_elevated(self):
-        if not self._is_elevated:
+        elevated = (
+            os.geteuid() == 0
+            if self._is_elevated is None
+            else self._is_elevated
+        )
+        if not elevated:
             raise UpdateError(
                 'Updating a system-wide AWS CLI installation requires root.'
             )
@@ -177,17 +180,9 @@ class WindowsUpdateCommand(BaseUpdateCommand):
         **kwargs,
     ):
         super().__init__(session, **kwargs)
-        self._is_elevated = (
-            bool(ctypes.windll.shell32.IsUserAnAdmin())
-            if is_elevated is None
-            else is_elevated
-        )
+        self._is_elevated = is_elevated
         self._run_update = runner or self._run_install
-        self._powershell_path = (
-            self._find_powershell()
-            if powershell_path is None
-            else powershell_path
-        )
+        self._powershell_path = powershell_path
 
     def _do_update(self):
         is_system = self._is_system_install(self._install_metadata)
@@ -199,7 +194,7 @@ class WindowsUpdateCommand(BaseUpdateCommand):
         self._download(self.SCRIPT_URL, script_path)
 
         wrapper_path = os.path.join(tmp, 'aws-update.cmd')
-        ps_exe = self._powershell_path
+        ps_exe = self._powershell_path or self._find_powershell()
         ps_args = f'-NoProfile -File "{script_path}"'
         if is_system:
             ps_args += ' -System'
@@ -257,7 +252,12 @@ class WindowsUpdateCommand(BaseUpdateCommand):
         return os.path.normcase(buf.value) == os.path.normcase(canonical)
 
     def _assert_elevated(self):
-        if not self._is_elevated:
+        elevated = (
+            bool(ctypes.windll.shell32.IsUserAnAdmin())
+            if self._is_elevated is None
+            else self._is_elevated
+        )
+        if not elevated:
             raise UpdateError(
                 'Updating a system-wide AWS CLI install requires an '
                 'elevated shell. Re-run from an Administrator prompt.'

--- a/awscli/handlers_registry.py
+++ b/awscli/handlers_registry.py
@@ -677,6 +677,7 @@ PLUGIN_REGISTRY = {
         ('awscli.customizations.history', 'register_history_commands'),
         ('awscli.customizations.devcommands', 'register_dev_commands'),
         ('awscli.customizations.login', 'register_login_cmds'),
+        ('awscli.customizations.update', 'register_update_command'),
     ],
     'building-command-table.polly': [
         ('awscli.customizations.removals', 'register_removals')
@@ -908,5 +909,11 @@ MAIN_COMMAND_TABLE_OPS: list[
         CommandTableOp.RENAME,
         'agenttoolkit',
         'agent-toolkit',
+    ),
+    (
+        CommandTableOp.ADD,
+        'update',
+        'awscli.customizations.update',
+        'UpdateCommand',
     ),
 ]

--- a/exe/assets/install
+++ b/exe/assets/install
@@ -136,6 +136,19 @@ create_bin_symlinks() {
   ln -sf "$CURRENT_AWS_COMPLETER_EXE" "$BIN_AWS_COMPLETER_EXE"
 }
 
+write_install_json() {
+  if [ "${AWS_CLI_SKIP_INSTALL_JSON:-}" = "1" ]; then
+    return 0
+  fi
+  install_json="$INSTALL_DIST_DIR/awscli/data/install.json"
+  cat > "$install_json" <<EOF
+{
+  "install_dir": "$ROOT_INSTALL_DIR",
+  "bin_dir": "$BIN_DIR"
+}
+EOF
+}
+
 die() {
 	err_msg="$1"
 	echo "$err_msg" >&2
@@ -148,6 +161,7 @@ main() {
   check_preexisting_install
   create_install_dir
   create_bin_symlinks
+  write_install_json
   echo "You can now run: $BIN_AWS_EXE --version"
   exit 0
 }

--- a/macpkg/scripts/postinstall
+++ b/macpkg/scripts/postinstall
@@ -26,3 +26,25 @@ if [ "$ID" == "0" ]; then
     sudo ln -sf "$COMPLETER_PATH" "$COMPLETER_LINK"
     sudo echo "$COMPLETER_LINK" >> "$METADATA_PATH"
 fi
+
+INSTALL_JSON="$PATH_TO_INSTALL/awscli/data/install.json"
+if [ "${AWS_CLI_SKIP_INSTALL_JSON:-}" != "1" ]; then
+    if [ "$ID" == "0" ]; then
+    # System install - symlinks were automatically created.
+        cat > "$INSTALL_JSON" <<EOF
+{
+  "install_dir": "$PATH_TO_INSTALL",
+  "bin_dir": "$SYMLINK_DIR"
+}
+EOF
+    else
+    # User install - symlinks weren't automatically created.
+    # No way to know where user will create them or if they'll
+    # exist at all.
+        cat > "$INSTALL_JSON" <<EOF
+{
+  "install_dir": "$PATH_TO_INSTALL"
+}
+EOF
+    fi
+fi

--- a/tests/unit/customizations/test_update.py
+++ b/tests/unit/customizations/test_update.py
@@ -12,6 +12,7 @@ from awscli.customizations.update import (
     UpdateError,
     WindowsUpdateCommand,
 )
+from tests.markers import skip_if_windows
 
 USER_INSTALL = {
     'install_dir': '/home/user/.local/share/aws-cli',
@@ -164,6 +165,7 @@ class TestUnixUpdateCommand:
         with pytest.raises(UpdateError, match='exit code 8'):
             command([], global_args())
 
+    @skip_if_windows
     def test_system_detected_from_binary_path_when_no_metadata(
         self, monkeypatch
     ):
@@ -177,6 +179,7 @@ class TestUnixUpdateCommand:
 
         assert '--system' in cmd
 
+    @skip_if_windows
     def test_user_detected_from_binary_path_when_no_metadata(
         self, monkeypatch
     ):

--- a/tests/unit/customizations/test_update.py
+++ b/tests/unit/customizations/test_update.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import os
 import subprocess
 from argparse import Namespace
 from unittest import mock
@@ -196,6 +197,28 @@ class TestUnixUpdateCommand:
         cmd, _ = self._run(install)
 
         assert '--system' not in cmd
+
+    @skip_if_windows
+    def test_resolves_symlink_before_checking_install_dir(
+        self, monkeypatch, tmp_path
+    ):
+        root = tmp_path.resolve()
+        install_dir = root / 'aws-cli'
+        real_bin = install_dir / 'v2' / 'current' / 'bin' / 'aws'
+        real_bin.parent.mkdir(parents=True)
+        real_bin.touch()
+        link = root / 'bin' / 'aws'
+        link.parent.mkdir()
+        link.symlink_to(real_bin)
+
+        monkeypatch.setattr(
+            UnixUpdateCommand, 'SYSTEM_INSTALL_DIR', str(install_dir)
+        )
+        monkeypatch.setattr(update_module.sys, 'executable', str(link))
+
+        cmd, _ = self._run({'install_dir': str(install_dir)})
+
+        assert '--system' in cmd
 
 
 class TestWindowsUpdateCommand:

--- a/tests/unit/customizations/test_update.py
+++ b/tests/unit/customizations/test_update.py
@@ -1,0 +1,386 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import subprocess
+from argparse import Namespace
+from unittest import mock
+
+import pytest
+
+from awscli.customizations import update as update_module
+from awscli.customizations.update import (
+    UnixUpdateCommand,
+    UpdateError,
+    WindowsUpdateCommand,
+)
+
+USER_INSTALL = {
+    'install_dir': '/home/user/.local/share/aws-cli',
+    'bin_dir': '/home/user/.local/bin',
+    'script_install': {'system': False},
+}
+SYSTEM_INSTALL = {
+    'install_dir': '/usr/local/aws-cli',
+    'bin_dir': '/usr/local/bin',
+    'script_install': {'system': True},
+}
+
+
+def global_args(color='auto'):
+    return Namespace(color=color)
+
+
+def mock_session():
+    session = mock.Mock()
+    session.user_agent_extra = 'aws-cli'
+    return session
+
+
+class TestUnixUpdateCommand:
+    def _command(
+        self,
+        install,
+        source='exe',
+        elevated=True,
+        runner=None,
+        downloader=None,
+    ):
+        return UnixUpdateCommand(
+            mock_session(),
+            source=source,
+            install_metadata=install,
+            downloader=downloader or mock.Mock(),
+            is_elevated=elevated,
+            runner=runner or mock.Mock(),
+        )
+
+    def _run(self, install, color='auto', **kwargs):
+        runner = mock.Mock()
+        command = self._command(install, runner=runner, **kwargs)
+        command([], global_args(color=color))
+        return runner.call_args.args
+
+    @pytest.mark.parametrize('source', ['exe', 'script-exe', 'update-exe'])
+    def test_supported_distribution_source_runs_installer(self, source):
+        runner = mock.Mock()
+        command = self._command(USER_INSTALL, source=source, runner=runner)
+
+        assert command([], global_args()) == 0
+        runner.assert_called_once()
+
+    @pytest.mark.parametrize('source', ['source', 'other', 'pip', ''])
+    def test_unsupported_distribution_source_raises(self, source):
+        runner = mock.Mock()
+        command = self._command(USER_INSTALL, source=source, runner=runner)
+
+        with pytest.raises(UpdateError, match='Detected distribution source'):
+            command([], global_args())
+        runner.assert_not_called()
+
+    def test_missing_install_dir_raises(self):
+        runner = mock.Mock()
+        command = self._command({}, runner=runner)
+
+        with pytest.raises(
+            UpdateError, match='Install-time metadata could not be found'
+        ):
+            command([], global_args())
+        runner.assert_not_called()
+
+    def test_user_install_runs_bash_script_without_system(self):
+        cmd, _ = self._run(USER_INSTALL)
+
+        assert cmd[0] == 'bash'
+        assert cmd[1].endswith('install.sh')
+        assert len(cmd) == 2
+
+    def test_downloads_install_script_to_path_that_is_run(self):
+        downloader = mock.Mock()
+        runner = mock.Mock()
+        command = self._command(
+            USER_INSTALL, downloader=downloader, runner=runner
+        )
+
+        command([], global_args())
+
+        url, dest = downloader.call_args.args
+        assert url == UnixUpdateCommand.SCRIPT_URL
+        assert runner.call_args.args[0] == ['bash', dest]
+
+    def test_color_off_sets_no_color_env(self):
+        _, env = self._run(USER_INSTALL, color='off')
+
+        assert env['NO_COLOR'] == '1'
+
+    @pytest.mark.parametrize('color', ['auto', 'on'])
+    def test_color_not_off_omits_no_color_env(self, color):
+        _, env = self._run(USER_INSTALL, color=color)
+
+        assert 'NO_COLOR' not in env
+
+    def test_user_install_sets_xdg_from_install_dir(self):
+        _, env = self._run(USER_INSTALL)
+
+        assert env['XDG_DATA_HOME'] == '/home/user/.local/share'
+        assert env['XDG_BIN_HOME'] == '/home/user/.local/bin'
+        assert env['AWS_CLI_DISTRIBUTION_SOURCE_OVERRIDE'] == 'update-exe'
+        assert 'AWS_CLI_NO_BIN_DIR' not in env
+
+    def test_missing_bin_dir_uses_throwaway_dir_and_flag(self):
+        install = {
+            'install_dir': '/home/user/.local/share/aws-cli',
+            'script_install': {'system': False},
+        }
+
+        _, env = self._run(install)
+
+        assert env['AWS_CLI_NO_BIN_DIR'] == '1'
+        assert env['XDG_BIN_HOME'].endswith('bin')
+        assert '.local/bin' not in env['XDG_BIN_HOME']
+
+    def test_system_install_passes_system_flag(self):
+        cmd, env = self._run(SYSTEM_INSTALL, elevated=True)
+
+        assert cmd[0] == 'bash'
+        assert cmd[1].endswith('install.sh')
+        assert cmd[2] == '--system'
+        assert len(cmd) == 3
+        assert 'XDG_DATA_HOME' not in env
+        assert 'XDG_BIN_HOME' not in env
+
+    def test_system_install_requires_elevation(self):
+        runner = mock.Mock()
+        command = self._command(SYSTEM_INSTALL, elevated=False, runner=runner)
+
+        with pytest.raises(UpdateError, match='requires root'):
+            command([], global_args())
+        runner.assert_not_called()
+
+    def test_install_script_failure_raises_update_error(self):
+        runner = mock.Mock(
+            side_effect=subprocess.CalledProcessError(8, ['bash'])
+        )
+        command = self._command(USER_INSTALL, runner=runner)
+
+        with pytest.raises(UpdateError, match='exit code 8'):
+            command([], global_args())
+
+    def test_system_detected_from_binary_path_when_no_metadata(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            update_module.sys,
+            'argv',
+            ['/usr/local/aws-cli/v2/current/bin/aws'],
+        )
+
+        cmd, _ = self._run({'install_dir': '/usr/local/aws-cli'})
+
+        assert '--system' in cmd
+
+    def test_user_detected_from_binary_path_when_no_metadata(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            update_module.sys,
+            'argv',
+            ['/home/user/.local/share/aws-cli/v2/current/bin/aws'],
+        )
+        install = {
+            'install_dir': '/home/user/.local/share/aws-cli',
+            'bin_dir': '/home/user/.local/bin',
+        }
+
+        cmd, _ = self._run(install)
+
+        assert '--system' not in cmd
+
+
+class TestWindowsUpdateCommand:
+    def _command(self, install, elevated=True, runner=None, downloader=None):
+        return WindowsUpdateCommand(
+            mock_session(),
+            source='exe',
+            install_metadata=install,
+            downloader=downloader or mock.Mock(),
+            is_elevated=elevated,
+            runner=runner or mock.Mock(),
+            powershell_path='powershell.exe',
+        )
+
+    def _run(self, install, color='auto', **kwargs):
+        runner = mock.Mock()
+        command = self._command(install, runner=runner, **kwargs)
+        command([], global_args(color=color))
+        (cmd,) = runner.call_args.args
+        with open(cmd[-1]) as f:
+            return cmd, f.read()
+
+    def test_spawns_detached_cmd_wrapper(self):
+        cmd, _ = self._run(USER_INSTALL)
+
+        assert cmd[0] == 'cmd'
+        assert cmd[1] == '/c'
+        assert cmd[2].endswith('.cmd')
+        assert len(cmd) == 3
+
+    def test_downloads_install_script_referenced_by_wrapper(self):
+        downloader = mock.Mock()
+        _, wrapper = self._run(USER_INSTALL, downloader=downloader)
+
+        url, dest = downloader.call_args.args
+        assert url == WindowsUpdateCommand.SCRIPT_URL
+        assert f'-File "{dest}"' in wrapper
+
+    def test_wrapper_runs_powershell_without_system(self):
+        _, wrapper = self._run(USER_INSTALL)
+
+        assert 'set AWS_CLI_DISTRIBUTION_SOURCE_OVERRIDE=update-exe' in wrapper
+        assert '"powershell.exe" -NoProfile -File "' in wrapper
+        assert '-System' not in wrapper
+        assert 'set NO_COLOR=1' not in wrapper
+
+    def test_wrapper_passes_system_flag(self):
+        _, wrapper = self._run(SYSTEM_INSTALL, elevated=True)
+
+        assert wrapper.rstrip().endswith('-System')
+
+    def test_wrapper_sets_no_color_when_color_off(self):
+        _, wrapper = self._run(USER_INSTALL, color='off')
+
+        assert 'set NO_COLOR=1' in wrapper
+
+    def test_system_install_requires_elevation(self):
+        runner = mock.Mock()
+        command = self._command(SYSTEM_INSTALL, elevated=False, runner=runner)
+
+        with pytest.raises(UpdateError, match='elevated shell'):
+            command([], global_args())
+        runner.assert_not_called()
+
+    def test_system_detected_from_program_files_when_no_metadata(
+        self, monkeypatch
+    ):
+        program_files = 'C:\\Program Files'
+        monkeypatch.setattr(
+            update_module.os, 'environ', {'ProgramW6432': program_files}
+        )
+        running_exe = update_module.os.path.join(
+            program_files, 'Amazon', 'AWSCLIV2', 'aws.exe'
+        )
+        monkeypatch.setattr(update_module, 'ctypes', _fake_ctypes(running_exe))
+
+        _, wrapper = self._run(
+            {'install_dir': 'C:\\Program Files\\Amazon\\AWSCLIV2'}
+        )
+
+        assert wrapper.rstrip().endswith('-System')
+
+    def test_user_detected_from_program_files_when_no_metadata(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            update_module.os, 'environ', {'ProgramW6432': 'C:\\Program Files'}
+        )
+        running_exe = update_module.os.path.join(
+            'C:\\Users\\me\\AppData\\Local\\Programs',
+            'Amazon',
+            'AWSCLIV2',
+            'aws.exe',
+        )
+        monkeypatch.setattr(update_module, 'ctypes', _fake_ctypes(running_exe))
+
+        _, wrapper = self._run({'install_dir': 'C:\\Users\\me\\AWSCLIV2'})
+
+        assert '-System' not in wrapper
+
+
+def _response(status_code, content=b''):
+    return mock.Mock(status_code=status_code, content=content)
+
+
+class TestDownloadWithRetry:
+    def test_sends_get_request_for_url(self, tmp_path):
+        session = mock.Mock()
+        session.send.return_value = _response(200, b'data')
+
+        update_module.download_with_retry(
+            'https://foo.bar/install.sh',
+            str(tmp_path / 'install.sh'),
+            session=session,
+        )
+
+        request = session.send.call_args.args[0]
+        assert request.method == 'GET'
+        assert request.url == 'https://foo.bar/install.sh'
+
+    def test_writes_response_content_to_dest(self, tmp_path):
+        session = mock.Mock()
+        session.send.return_value = _response(200, b'#!/bin/sh\n')
+        dest = tmp_path / 'install.sh'
+
+        update_module.download_with_retry(
+            'https://foo.bar/install.sh', str(dest), session=session
+        )
+
+        assert dest.read_bytes() == b'#!/bin/sh\n'
+
+    def test_retries_once_then_succeeds(self, tmp_path):
+        session = mock.Mock()
+        session.send.side_effect = [
+            ConnectionError('boom'),
+            _response(200, b'ok'),
+        ]
+        dest = tmp_path / 'install.sh'
+
+        update_module.download_with_retry(
+            'https://foo.bar/install.sh', str(dest), session=session
+        )
+
+        assert dest.read_bytes() == b'ok'
+        assert session.send.call_count == 2
+
+    def test_non_200_status_raises(self, tmp_path):
+        session = mock.Mock()
+        session.send.return_value = _response(404)
+
+        with pytest.raises(UpdateError, match='unexpected HTTP status 404'):
+            update_module.download_with_retry(
+                'https://foo.bar/install.sh',
+                str(tmp_path / 'install.sh'),
+                session=session,
+            )
+
+    def test_raises_after_retries_exhausted(self, tmp_path):
+        session = mock.Mock()
+        session.send.side_effect = ConnectionError('boom')
+
+        with pytest.raises(UpdateError, match='failed to download'):
+            update_module.download_with_retry(
+                'https://foo.bar/install.sh',
+                str(tmp_path / 'install.sh'),
+                retries=1,
+                session=session,
+            )
+        assert session.send.call_count == 2
+
+    def test_honors_retry_count(self, tmp_path):
+        session = mock.Mock()
+        session.send.side_effect = ConnectionError('boom')
+
+        with pytest.raises(UpdateError):
+            update_module.download_with_retry(
+                'https://foo.bar/install.sh',
+                str(tmp_path / 'install.sh'),
+                retries=3,
+                session=session,
+            )
+        assert session.send.call_count == 4
+
+
+def _fake_ctypes(module_filename):
+    buf = mock.MagicMock()
+    buf.value = module_filename
+    buf.__len__.return_value = 32768
+    fake = mock.Mock()
+    fake.create_unicode_buffer.return_value = buf
+    return fake

--- a/tests/unit/customizations/test_update.py
+++ b/tests/unit/customizations/test_update.py
@@ -171,8 +171,8 @@ class TestUnixUpdateCommand:
     ):
         monkeypatch.setattr(
             update_module.sys,
-            'argv',
-            ['/usr/local/aws-cli/v2/current/bin/aws'],
+            'executable',
+            '/usr/local/aws-cli/v2/current/bin/aws',
         )
 
         cmd, _ = self._run({'install_dir': '/usr/local/aws-cli'})
@@ -185,8 +185,8 @@ class TestUnixUpdateCommand:
     ):
         monkeypatch.setattr(
             update_module.sys,
-            'argv',
-            ['/home/user/.local/share/aws-cli/v2/current/bin/aws'],
+            'executable',
+            '/home/user/.local/share/aws-cli/v2/current/bin/aws',
         )
         install = {
             'install_dir': '/home/user/.local/share/aws-cli',

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import contextlib
 import io
+import json
 import logging
 import os
 import platform
@@ -44,6 +45,7 @@ from awscli.clidriver import (
     ServiceOperation,
     construct_cli_error_handlers_chain,
     create_clidriver,
+    get_distribution_source,
     resolve_auto_prompt_mode,
     validate_auto_prompt_args_are_mutually_exclusive,
 )
@@ -1243,6 +1245,67 @@ class TextCreateCLIDriver(unittest.TestCase):
         with contextlib.redirect_stderr(stderr):
             create_clidriver()
         self.assertIn('', stderr.getvalue())
+
+
+class TestGetDistributionSource:
+    @pytest.fixture
+    def data_dir(self, tmp_path, monkeypatch):
+        data = tmp_path / 'data'
+        data.mkdir()
+        monkeypatch.setattr(
+            awscli.clidriver, '__file__', str(tmp_path / 'clidriver.py')
+        )
+        return data
+
+    def _write_json(self, path, contents):
+        path.write_text(json.dumps(contents))
+
+    def test_defaults_to_other_when_no_files(self, data_dir):
+        assert get_distribution_source() == 'other'
+
+    def test_read_from_metadata(self, data_dir):
+        self._write_json(
+            data_dir / 'metadata.json', {'distribution_source': 'source'}
+        )
+
+        assert get_distribution_source() == 'source'
+
+    def test_read_from_install_json(self, data_dir):
+        self._write_json(
+            data_dir / 'install.json', {'distribution_source': 'script-exe'}
+        )
+
+        assert get_distribution_source() == 'script-exe'
+
+    def test_install_json_takes_precedence_over_metadata(self, data_dir):
+        self._write_json(
+            data_dir / 'metadata.json', {'distribution_source': 'exe'}
+        )
+        self._write_json(
+            data_dir / 'install.json', {'distribution_source': 'update-exe'}
+        )
+
+        assert get_distribution_source() == 'update-exe'
+
+    def test_falls_back_to_metadata_when_install_json_lacks_source(
+        self, data_dir
+    ):
+        self._write_json(
+            data_dir / 'install.json', {'install_dir': '/opt/aws-cli'}
+        )
+        self._write_json(
+            data_dir / 'metadata.json', {'distribution_source': 'exe'}
+        )
+
+        assert get_distribution_source() == 'exe'
+
+    def test_falls_back_to_other_when_no_source_field_anywhere(self, data_dir):
+        self._write_json(
+            data_dir / 'install.json', {'install_dir': '/opt/aws-cli'}
+        )
+        self._write_json(data_dir / 'metadata.json', {'version': '2.0.0'})
+
+        assert get_distribution_source() == 'other'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements `aws update` command to download and install the latest AWS CLI v2 version. Also change Linux and macOS post-install scripts to write install-time metadata at `install.json`.

At a high-level, the command does the following:
1. Look for install-time metadata in `install.json` to see if there's a record of the exact install and bin path of the current CLI instance.
  a. Unix should always have it since this PR also introduces post-install changes that ensure `install.json` is written. One caveat is that the bin directory may not have been recorded (if the user manually set up symlinks). In that case, the command skips setting up a symlink. This is fine since the user-created symlink will still point to the install directory that we're writing over.
  b. Windows may not necessarily have it because there's no Windows post-install script that creates one in the case that the MSI was used directly (ie without an install script or `update` command). This is fine because Windows MSIs install to predetermined paths.
2. Check `install.json` to see if the current instance was a system install. If unavailable, then a best effort will be made based on the current CLI path.
3. Download the relevant install script and execute it using parameters determined from previous steps.
  a. Unix updates are straightforward since the OS caches the inode and so it can be updated in-place while the updated exe is still running.
  b. Windows is trickier since the process acquires a lock on the exe. To work around this, the parent process exits early after launching a detached subprocess that handles the install execution.