### PR TITLE
Best-effort auto-close of the SSO login browser tab

### DIFF
--- a/.changes/next-release/enhancement-sso-4703.json
+++ b/.changes/next-release/enhancement-sso-4703.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "sso",
+  "description": "The browser tab opened by ``aws sso login`` for the Authorization Code flow now makes a best-effort attempt to close itself after a successful login. This is a no-op in browsers that block it (e.g. after an interactive login), where the page continues to display a message that the tab can be closed."
+}

--- a/awscli/customizations/sso/index.html
+++ b/awscli/customizations/sso/index.html
@@ -121,8 +121,8 @@
                     </path>
                 </svg>
                 <div class="success-text">
-                    Your credentials have been shared successfully and can be used until your session expires. You can
-                    now close this tab.
+                    Your credentials have been shared successfully and can be used until your session expires. This tab
+                    will try to close automatically&mdash;if it is still open, you can safely close it now.
                 </div>
             </div>
             <div id="error-message" class="error-content hidden">
@@ -146,6 +146,12 @@
                 document.getElementById('success-message').classList.add('hidden');
                 document.getElementById('error-message').classList.remove('hidden');
                 document.getElementById('error-text').innerText = error;
+            } else {
+                // Best-effort tab close. Browsers only allow window.close() on
+                // tabs opened by script or with a single history entry, so this
+                // is a no-op after an interactive login. When it is blocked the
+                // success message above tells the user to close the tab.
+                window.setTimeout(() => window.close(), 300);
             }
         };
     </script>

--- a/tests/unit/customizations/sso/test_utils.py
+++ b/tests/unit/customizations/sso/test_utils.py
@@ -317,6 +317,16 @@ class TestAuthCodeFetcher:
         assert actual_code is None
         assert actual_state is None
 
+    def test_callback_page_attempts_best_effort_close(self):
+        url = self.url + '?code=1234&state=4567'
+
+        http = urllib3.PoolManager()
+        response = http.request("GET", url)
+
+        self.fetcher.get_auth_code_and_state()
+        assert response.status == 200
+        assert b'window.close()' in response.data
+
 
 @mock.patch(
     'awscli.customizations.sso.utils.AuthCodeFetcher._REQUEST_TIMEOUT', 0.1


### PR DESCRIPTION
## Summary

Closes #9585.

After a successful `aws sso login` Authorization Code flow, the local callback page now makes a **best-effort** attempt to close its own browser tab, addressing the tab buildup that several users hit when authenticating frequently.

The change is intentionally small and lives entirely in the served callback page.

## Behavior and caveat

Browsers only permit `window.close()` on a tab that was **opened by script** or that has a **single session-history entry**. `aws sso login` opens the browser via the OS default handler (`webbrowser.open_new_tab`), so:

- **Warm re-auth** (a pure redirect chain, single history entry) → the tab closes automatically. ✅
- **Interactive login** (sign-in form, MFA, "Allow access") → the tab has more than one history entry, so `window.close()` is a **silent no-op**. The page falls back to the existing success message, now reworded to tell the user they can close the tab themselves.

This matches how other CLIs behave (`gcloud`, `az login`, `gh auth` all display a "you may close this window" message rather than reliably closing the OS-opened tab), so the change is additive and cannot regress the current experience. The wording was deliberately made truthful ("This tab will try to close automatically, if it is still open, you can safely close it now") to avoid implying a guarantee the browser may not honor.

A code comment documents the constraint so the `window.close()` call isn't mistaken for dead code later.

## Changes

- `awscli/customizations/sso/index.html`: attempt `window.close()` on a successful (non-error) callback. Reword the success message.
- `tests/unit/customizations/sso/test_utils.py`:  regression test asserting the served callback page includes the close attempt.
- `.changes/next-release/enhancement-sso-4703.json`:  changelog entry.

## Testing

```
python -m pytest tests/unit/customizations/sso/test_utils.py tests/functional/sso/test_login.py
```

All tests pass; `ruff check` is clean.
