### PR TITLE
fix: Resolve Python 3.12 datetime.utcnow() DeprecationWarning

### DIFF
--- a/awscli/botocore/auth.py
+++ b/awscli/botocore/auth.py
@@ -426,7 +426,7 @@ class SigV4Auth(BaseSigner):
     def add_auth(self, request):
         if self.credentials is None:
             raise NoCredentialsError()
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
@@ -564,7 +564,7 @@ class S3ExpressPostAuth(S3ExpressAuth):
     REQUIRES_IDENTITY_CACHE = True
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}
@@ -825,7 +825,7 @@ class S3SigV4PostAuth(SigV4Auth):
     """
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}

--- a/awscli/botocore/auth.py
+++ b/awscli/botocore/auth.py
@@ -26,6 +26,7 @@ from botocore.compat import (
     HTTPHeaders,
     encodebytes,
     ensure_unicode,
+    get_current_datetime,
     json,
     parse_qs,
     quote,
@@ -426,7 +427,7 @@ class SigV4Auth(BaseSigner):
     def add_auth(self, request):
         if self.credentials is None:
             raise NoCredentialsError()
-        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        datetime_now = get_current_datetime()
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
         # This could be a retry.  Make sure the previous
         # authorization header is removed first.
@@ -564,7 +565,7 @@ class S3ExpressPostAuth(S3ExpressAuth):
     REQUIRES_IDENTITY_CACHE = True
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        datetime_now = get_current_datetime()
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}
@@ -825,7 +826,7 @@ class S3SigV4PostAuth(SigV4Auth):
     """
 
     def add_auth(self, request):
-        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        datetime_now = get_current_datetime()
         request.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
 
         fields = {}

--- a/awscli/botocore/compat.py
+++ b/awscli/botocore/compat.py
@@ -289,6 +289,14 @@ def get_tzinfo_options():
         return (tzlocal,)
 
 
+def get_current_datetime(remove_tzinfo=True):
+    """Retrieve the current timezone in UTC, with or without an explicit timezone."""
+    datetime_now = datetime.datetime.now(datetime.timezone.utc)
+    if remove_tzinfo:
+        datetime_now = datetime_now.replace(tzinfo=None)
+    return datetime_now
+
+
 ########################################################
 #              urllib3 compat backports                #
 ########################################################

--- a/awscli/botocore/crt/auth.py
+++ b/awscli/botocore/crt/auth.py
@@ -56,11 +56,7 @@ class CrtSigV4Auth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        # Use utcnow() because that's what gets mocked by tests, but set
-        # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
-            tzinfo=datetime.timezone.utc
-        )
+        datetime_now = datetime.datetime.now(datetime.timezone.utc)
 
         # Use existing 'X-Amz-Content-SHA256' header if able
         existing_sha256 = self._get_existing_sha256(request)
@@ -254,11 +250,7 @@ class CrtSigV4AsymAuth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        # Use utcnow() because that's what gets mocked by tests, but set
-        # timezone because CRT assumes naive datetime is local time.
-        datetime_now = datetime.datetime.utcnow().replace(
-            tzinfo=datetime.timezone.utc
-        )
+        datetime_now = datetime.datetime.now(datetime.timezone.utc)
 
         # Use existing 'X-Amz-Content-SHA256' header if able
         existing_sha256 = self._get_existing_sha256(request)

--- a/awscli/botocore/crt/auth.py
+++ b/awscli/botocore/crt/auth.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import datetime
 from io import BytesIO
 
 import awscrt.auth
@@ -23,7 +22,13 @@ from botocore.auth import (
     _get_body_as_dict,
     _host_from_url,
 )
-from botocore.compat import HTTPHeaders, parse_qs, urlsplit, urlunsplit
+from botocore.compat import (
+    HTTPHeaders,
+    get_current_datetime,
+    parse_qs,
+    urlsplit,
+    urlunsplit,
+)
 from botocore.exceptions import NoCredentialsError
 from botocore.useragent import register_feature_id
 from botocore.utils import percent_encode_sequence
@@ -56,7 +61,7 @@ class CrtSigV4Auth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        datetime_now = datetime.datetime.now(datetime.timezone.utc)
+        datetime_now = get_current_datetime(remove_tzinfo=False)
 
         # Use existing 'X-Amz-Content-SHA256' header if able
         existing_sha256 = self._get_existing_sha256(request)
@@ -250,7 +255,7 @@ class CrtSigV4AsymAuth(BaseSigner):
         if self.credentials is None:
             raise NoCredentialsError()
 
-        datetime_now = datetime.datetime.now(datetime.timezone.utc)
+        datetime_now = get_current_datetime(remove_tzinfo=False)
 
         # Use existing 'X-Amz-Content-SHA256' header if able
         existing_sha256 = self._get_existing_sha256(request)

--- a/awscli/botocore/endpoint.py
+++ b/awscli/botocore/endpoint.py
@@ -21,6 +21,7 @@ import uuid
 
 from botocore import parsers
 from botocore.awsrequest import create_request_object
+from botocore.compat import get_current_datetime
 from botocore.exceptions import HTTPClientError
 from botocore.history import get_global_history_recorder
 from botocore.hooks import first_non_none_response
@@ -147,7 +148,7 @@ class Endpoint:
     def _calculate_ttl(
         self, response_received_timestamp, date_header, read_timeout
     ):
-        local_timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        local_timestamp = get_current_datetime()
         date_conversion = datetime.datetime.strptime(
             date_header, "%a, %d %b %Y %H:%M:%S %Z"
         )
@@ -164,7 +165,7 @@ class Endpoint:
         has_streaming_input = retries_context.get('has_streaming_input')
         if response_date_header and not has_streaming_input:
             try:
-                response_received_timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+                response_received_timestamp = get_current_datetime()
                 retries_context['ttl'] = self._calculate_ttl(
                     response_received_timestamp,
                     response_date_header,

--- a/awscli/botocore/endpoint.py
+++ b/awscli/botocore/endpoint.py
@@ -147,7 +147,7 @@ class Endpoint:
     def _calculate_ttl(
         self, response_received_timestamp, date_header, read_timeout
     ):
-        local_timestamp = datetime.datetime.utcnow()
+        local_timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         date_conversion = datetime.datetime.strptime(
             date_header, "%a, %d %b %Y %H:%M:%S %Z"
         )
@@ -164,7 +164,7 @@ class Endpoint:
         has_streaming_input = retries_context.get('has_streaming_input')
         if response_date_header and not has_streaming_input:
             try:
-                response_received_timestamp = datetime.datetime.utcnow()
+                response_received_timestamp = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
                 retries_context['ttl'] = self._calculate_ttl(
                     response_received_timestamp,
                     response_date_header,

--- a/awscli/botocore/signers.py
+++ b/awscli/botocore/signers.py
@@ -18,7 +18,7 @@ import weakref
 import botocore
 import botocore.auth
 from botocore.awsrequest import create_request_object, prepare_request_dict
-from botocore.compat import OrderedDict
+from botocore.compat import OrderedDict, get_current_datetime
 from botocore.exceptions import (
     ParamValidationError,
     UnknownClientMethodError,
@@ -717,7 +717,7 @@ class S3PostPresigner:
         policy = {}
 
         # Create an expiration date for the policy
-        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        datetime_now = get_current_datetime()
         expire_date = datetime_now + datetime.timedelta(seconds=expires_in)
         policy['expiration'] = expire_date.strftime(botocore.auth.ISO8601)
 

--- a/awscli/botocore/signers.py
+++ b/awscli/botocore/signers.py
@@ -717,7 +717,7 @@ class S3PostPresigner:
         policy = {}
 
         # Create an expiration date for the policy
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         expire_date = datetime_now + datetime.timedelta(seconds=expires_in)
         policy['expiration'] = expire_date.strftime(botocore.auth.ISO8601)
 

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -633,7 +633,7 @@ class InstanceMetadataFetcher(IMDSFetcher):
             refresh_interval_with_jitter = refresh_interval + random.randint(
                 120, 600
             )
-            current_time = datetime.datetime.utcnow()
+            current_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
             refresh_offset = datetime.timedelta(
                 seconds=refresh_interval_with_jitter
             )

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -42,6 +42,7 @@ import dateutil.parser
 from awscrt.crypto import EC
 from botocore.compat import (
     MD5_AVAILABLE,
+    get_current_datetime,
     get_md5,
     get_tzinfo_options,
     json,
@@ -633,7 +634,7 @@ class InstanceMetadataFetcher(IMDSFetcher):
             refresh_interval_with_jitter = refresh_interval + random.randint(
                 120, 600
             )
-            current_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+            current_time = get_current_datetime()
             refresh_offset = datetime.timedelta(
                 seconds=refresh_interval_with_jitter
             )

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -15,7 +15,7 @@ import collections
 import logging
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import botocore
 
@@ -98,7 +98,7 @@ class Deployer:
         :return:
         """
 
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         description = f"Created by AWS CLI at {now} UTC"
 
         # Each changeset will get a unique name based on time

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -18,7 +18,7 @@ import logging
 import re
 import sys
 import zlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from zlib import error as ZLibError
 
 from awscrt.crypto import RSA, RSASignatureAlgorithm
@@ -570,7 +570,7 @@ class DigestTraverser:
         :param is_backfill: Flag indicating whether to process backfill digests only.
         """
         if end_date is None:
-            end_date = datetime.utcnow()
+            end_date = datetime.now(timezone.utc)
         end_date = normalize_date(end_date)
         start_date = normalize_date(start_date)
         bucket = self.starting_bucket
@@ -1026,7 +1026,7 @@ class CloudTrailValidateLogs(BasicCommand):
         if args.end_time:
             self.end_time = normalize_date(parse_date(args.end_time))
         else:
-            self.end_time = normalize_date(datetime.utcnow())
+            self.end_time = normalize_date(datetime.now(timezone.utc))
         if self.start_time > self.end_time:
             raise ValueError(
                 'Invalid time range specified: start-time must '

--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -159,7 +159,7 @@ class CodeCommitGetCommand(BasicCommand):
         request = AWSRequest()
         request.url = url_to_sign
         request.method = 'GIT'
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         request.context['timestamp'] = now.strftime('%Y%m%dT%H%M%S')
         split = urlsplit(request.url)
         # we don't want to include the port number in the signature

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -16,7 +16,7 @@ import os
 import sys
 import tempfile
 import zipfile
-from datetime import datetime
+from datetime import datetime, timezone
 
 from botocore.exceptions import ClientError
 
@@ -131,7 +131,7 @@ class Push(BasicCommand):
             )
         if not parsed_args.description:
             parsed_args.description = (
-                f'Uploaded by AWS CLI {datetime.utcnow().isoformat()} UTC'
+                f'Uploaded by AWS CLI {datetime.now(timezone.utc).isoformat()} UTC'
             )
 
     def _push(self, params):

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from awscli.arguments import CustomArgument
 from awscli.customizations.commands import BasicCommand
@@ -197,7 +197,7 @@ class QueryArgBuilder:
 
     def __init__(self, current_time=None):
         if current_time is None:
-            current_time = datetime.utcnow()
+            current_time = datetime.now(timezone.utc)
         self.current_time = current_time
 
     def build_query(self, parsed_args):

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -129,7 +129,7 @@ def _generate_policy(params):
     # Called if there is no policy supplied by the user.
     # Creates a policy that provides access for 24 hours.
     delta = datetime.timedelta(hours=24)
-    expires = datetime.datetime.utcnow() + delta
+    expires = datetime.datetime.now(datetime.timezone.utc) + delta
     expires_iso = expires.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     policy = POLICY.format(
         expires=expires_iso, bucket=params['Bucket'], prefix=params['Prefix']

--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -14,7 +14,7 @@ import base64
 import json
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import botocore
 from botocore.model import ServiceId
@@ -105,7 +105,7 @@ class GetTokenCommand(BasicCommand):
     ]
 
     def get_expiration_time(self):
-        token_expiration = datetime.utcnow() + timedelta(
+        token_expiration = datetime.now(timezone.utc) + timedelta(
             minutes=TOKEN_EXPIRATION_MINS
         )
         return token_expiration.strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -10,11 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import functools
 import json
 import re
 import time
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import colorama
 from botocore.utils import datetime2timestamp, parse_timestamp
@@ -266,7 +267,7 @@ class TimestampUtils:
     def __init__(self, now=None):
         self._now = now
         if now is None:
-            self._now = datetime.utcnow
+            self._now = functools.partial(datetime.now, timezone.utc)
 
     def to_epoch_millis(self, timestamp):
         re_match = self._RELATIVE_TIMESTAMP_REGEX.match(timestamp)

--- a/tests/functional/botocore/test_disable_s3_express_auth.py
+++ b/tests/functional/botocore/test_disable_s3_express_auth.py
@@ -32,7 +32,7 @@ class TestDisableS3ExpressAuth:
     def mock_datetime(self):
         with mock.patch('datetime.datetime', spec=True) as mock_dt:
             mock_dt.now.return_value = self.DATE
-            mock_dt.utcnow.return_value = self.DATE
+            mock_dt.now.return_value = self.DATE
             yield mock_dt
 
     def test_disable_s3_express_auth_enabled(

--- a/tests/functional/botocore/test_ec2.py
+++ b/tests/functional/botocore/test_ec2.py
@@ -92,7 +92,7 @@ class TestCopySnapshotCustomization(BaseSessionTest):
             '<snapshotId>%s</snapshotId>\n'
             '</CopySnapshotResponse>\n'
         )
-        self.now = datetime.datetime(2011, 9, 9, 23, 36)
+        self.now = datetime.datetime(2011, 9, 9, 23, 36, tzinfo=datetime.timezone.utc)
         self.datetime_patch = mock.patch.object(
             botocore.auth.datetime,
             'datetime',

--- a/tests/functional/botocore/test_ec2.py
+++ b/tests/functional/botocore/test_ec2.py
@@ -99,7 +99,7 @@ class TestCopySnapshotCustomization(BaseSessionTest):
             mock.Mock(wraps=datetime.datetime),
         )
         self.mocked_datetime = self.datetime_patch.start()
-        self.mocked_datetime.utcnow.return_value = self.now
+        self.mocked_datetime.now.return_value = self.now
 
     def tearDown(self):
         super().tearDown()

--- a/tests/functional/botocore/test_lex.py
+++ b/tests/functional/botocore/test_lex.py
@@ -33,8 +33,8 @@ class TestLex(BaseSessionTest):
 
         timestamp = datetime(2017, 3, 22, 0, 0)
 
-        with mock.patch('botocore.auth.datetime') as _datetime:
-            _datetime.datetime.now.return_value = timestamp
+        with mock.patch('botocore.auth.datetime.datetime') as _datetime:
+            _datetime.now.return_value = timestamp
             self.http_stubber.add_response(body=b'{}')
             with self.http_stubber:
                 self.client.post_content(**params)

--- a/tests/functional/botocore/test_lex.py
+++ b/tests/functional/botocore/test_lex.py
@@ -34,7 +34,7 @@ class TestLex(BaseSessionTest):
         timestamp = datetime(2017, 3, 22, 0, 0)
 
         with mock.patch('botocore.auth.datetime') as _datetime:
-            _datetime.datetime.utcnow.return_value = timestamp
+            _datetime.datetime.now.return_value = timestamp
             self.http_stubber.add_response(body=b'{}')
             with self.http_stubber:
                 self.client.post_content(**params)

--- a/tests/functional/botocore/test_lex.py
+++ b/tests/functional/botocore/test_lex.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from datetime import datetime
+import datetime
 
 from tests import BaseSessionTest, ClientHTTPStubber, mock
 
@@ -31,7 +31,7 @@ class TestLex(BaseSessionTest):
             'inputStream': b'',
         }
 
-        timestamp = datetime(2017, 3, 22, 0, 0)
+        timestamp = datetime.datetime(2017, 3, 22, 0, 0, tzinfo=datetime.timezone.utc)
 
         with mock.patch('botocore.auth.datetime.datetime') as _datetime:
             _datetime.now.return_value = timestamp

--- a/tests/functional/botocore/test_retry.py
+++ b/tests/functional/botocore/test_retry.py
@@ -263,7 +263,7 @@ class TestRetryHeader(BaseRetryTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = datetime_patcher.start()
-        mocked_datetime.utcnow.side_effect = utcnow_side_effects
+        mocked_datetime.now.side_effect = utcnow_side_effects
 
         client = self.session.create_client(
             'dynamodb', self.region, config=client_config

--- a/tests/functional/botocore/test_s3.py
+++ b/tests/functional/botocore/test_s3.py
@@ -38,7 +38,7 @@ from tests import (
 )
 from tests.utils.botocore import get_checksum_cls
 
-DATE = datetime.datetime(2021, 8, 27, 0, 0, 0)
+DATE = datetime.datetime(2021, 8, 27, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
 
 class TestS3BucketValidation(unittest.TestCase):

--- a/tests/functional/botocore/test_s3express.py
+++ b/tests/functional/botocore/test_s3express.py
@@ -108,7 +108,6 @@ class TestS3ExpressAuth:
 class TestS3ExpressIdentityCache:
     def test_default_s3_express_cache(self, default_s3_client, mock_datetime):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
 
         identity_cache = S3ExpressIdentityCache(
             default_s3_client,
@@ -126,7 +125,6 @@ class TestS3ExpressIdentityCache:
         self, default_s3_client, mock_datetime
     ):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
         bucket = 'my_bucket'
 
         identity_cache = S3ExpressIdentityCache(
@@ -151,7 +149,6 @@ class TestS3ExpressIdentityCache:
         self, default_s3_client, mock_datetime
     ):
         mock_datetime.now.return_value = DATE
-        mock_datetime.utcnow.return_value = DATE
         bucket = 'my_bucket'
         other_bucket = 'other_bucket'
 
@@ -204,7 +201,7 @@ class TestS3ExpressRequests:
         )
 
     def test_create_bucket(self, default_s3_client, mock_datetime):
-        mock_datetime.utcnow.return_value = DATE
+        mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
             stubber.add_response()
@@ -228,7 +225,6 @@ class TestS3ExpressRequests:
         self._assert_standard_sigv4_signature(stubber.requests[0].headers)
 
     def test_get_object(self, default_s3_client, mock_datetime):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
@@ -250,7 +246,6 @@ class TestS3ExpressRequests:
     def test_cache_with_multiple_requests(
         self, default_s3_client, mock_datetime
     ):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:
@@ -275,7 +270,6 @@ class TestS3ExpressRequests:
     def test_delete_objects_injects_correct_checksum(
         self, default_s3_client, mock_datetime
     ):
-        mock_datetime.utcnow.return_value = DATE
         mock_datetime.now.return_value = DATE
 
         with ClientHTTPStubber(default_s3_client) as stubber:

--- a/tests/functional/botocore/test_s3express.py
+++ b/tests/functional/botocore/test_s3express.py
@@ -36,7 +36,7 @@ ENDPOINT = "https://s3.us-west-2.amazonaws.com"
 S3EXPRESS_BUCKET = "mytestbucket--usw2-az5--x-s3"
 
 
-DATE = datetime.datetime(2023, 11, 26, 0, 0, 0, tzinfo=tzutc())
+DATE = datetime.datetime(2023, 11, 26, 0, 0, 0, tzinfo=datetime.timezone.utc)
 
 
 CREATE_SESSION_RESPONSE = (

--- a/tests/functional/botocore/test_sts.py
+++ b/tests/functional/botocore/test_sts.py
@@ -33,8 +33,8 @@ class TestSTSPresignedUrl(BaseSessionTest):
 
     def test_presigned_url_contains_no_content_type(self):
         timestamp = datetime(2017, 3, 22, 0, 0)
-        with mock.patch('botocore.auth.datetime') as _datetime:
-            _datetime.datetime.now.return_value = timestamp
+        with mock.patch('botocore.auth.datetime.datetime') as _datetime:
+            _datetime.now.return_value = timestamp
             url = self.client.generate_presigned_url('get_caller_identity', {})
 
         # There should be no 'content-type' in x-amz-signedheaders

--- a/tests/functional/botocore/test_sts.py
+++ b/tests/functional/botocore/test_sts.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import datetime
 import re
-from datetime import datetime
 
 from botocore.config import Config
 from botocore.stub import Stubber
@@ -32,7 +32,7 @@ class TestSTSPresignedUrl(BaseSessionTest):
         self.stubber.activate()
 
     def test_presigned_url_contains_no_content_type(self):
-        timestamp = datetime(2017, 3, 22, 0, 0)
+        timestamp = datetime.datetime(2017, 3, 22, 0, 0, tzinfo=datetime.timezone.utc)
         with mock.patch('botocore.auth.datetime.datetime') as _datetime:
             _datetime.now.return_value = timestamp
             url = self.client.generate_presigned_url('get_caller_identity', {})

--- a/tests/functional/botocore/test_sts.py
+++ b/tests/functional/botocore/test_sts.py
@@ -34,7 +34,7 @@ class TestSTSPresignedUrl(BaseSessionTest):
     def test_presigned_url_contains_no_content_type(self):
         timestamp = datetime(2017, 3, 22, 0, 0)
         with mock.patch('botocore.auth.datetime') as _datetime:
-            _datetime.datetime.utcnow.return_value = timestamp
+            _datetime.datetime.now.return_value = timestamp
             url = self.client.generate_presigned_url('get_caller_identity', {})
 
         # There should be no 'content-type' in x-amz-signedheaders

--- a/tests/functional/dsql/test_generate_db_auth_token.py
+++ b/tests/functional/dsql/test_generate_db_auth_token.py
@@ -50,7 +50,7 @@ class TestGenerateDBConnectAuthToken(BaseTestGenerateDBConnectAuthToken):
         clock = datetime.datetime(2024, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             stdout, _, _ = self.run_cmd(command, expected_rc=0)
 
         # Expected hashes are always the same as session variables come from the BaseAwsCommandParamsTest class
@@ -79,7 +79,7 @@ class TestGenerateDBConnectAuthToken(BaseTestGenerateDBConnectAuthToken):
         clock = datetime.datetime(2024, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             stdout, _, _ = self.run_cmd(command, expected_rc=252)
 
 
@@ -92,7 +92,7 @@ class TestGenerateDBConnectAdminAuthToken(BaseTestGenerateDBConnectAuthToken):
         clock = datetime.datetime(2024, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             stdout, _, _ = self.run_cmd(command, expected_rc=0)
 
         # Expected hashes are always the same as session variables come from the BaseAwsCommandParamsTest class

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -31,7 +31,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestBundleInstance, self).setUp()
-        # This mocks out datetime.datetime.utcnow() so that it always
+        # This mocks out datetime.datetime.now() so that it always
         # returns the same datetime object.  This is because this value
         # is embedded into the policy file that is generated and we
         # don't what the policy or its signature to change each time
@@ -42,7 +42,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(2013, 8, 9)
+        mocked_datetime.now.return_value = datetime.datetime(2013, 8, 9, tzinfo=datetime.timezone.utc)
 
     def tearDown(self):
         super(TestBundleInstance, self).tearDown()

--- a/tests/functional/ec2instanceconnect/test_opentunnel.py
+++ b/tests/functional/ec2instanceconnect/test_opentunnel.py
@@ -409,7 +409,7 @@ def request_params_for_describe_eice():
 def datetime_utcnow_patch():
     clock = datetime.datetime(2020, 1, 1, 1, 1, 1, tzinfo=tzutc())
     with mock.patch('datetime.datetime') as dt:
-        dt.utcnow.return_value = clock
+        dt.now.return_value = clock
         yield dt
 
 

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -78,7 +78,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_get_token(self, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        mock_datetime.now.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         response = self.run_get_token(cmd)
         self.assertEqual(
@@ -96,7 +96,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_query_nested_object(self, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        mock_datetime.now.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         cmd += ' --query status'
         response = self.run_get_token(cmd)
@@ -119,7 +119,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_output_text(self, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        mock_datetime.now.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         cmd += ' --output text'
         stdout, _, _ = self.run_cmd(cmd)
@@ -129,7 +129,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_output_table(self, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        mock_datetime.now.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         cmd += ' --output table'
         stdout, _, _ = self.run_cmd(cmd)

--- a/tests/functional/logs/test_tail.py
+++ b/tests/functional/logs/test_tail.py
@@ -155,7 +155,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
 
     def test_tail_defaults_to_10m(self):
         datetime_mock = mock.Mock(wraps=datetime)
-        datetime_mock.utcnow = mock.Mock(
+        datetime_mock.now = mock.Mock(
             return_value=datetime(1970, 1, 1, 0, 10, 1, tzinfo=tz.tzutc())
         )
         with mock.patch(
@@ -182,7 +182,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
 
     def test_tail_with_relative_since(self):
         datetime_mock = mock.Mock(wraps=datetime)
-        datetime_mock.utcnow = mock.Mock(
+        datetime_mock.now = mock.Mock(
             return_value=datetime(1970, 1, 1, 0, 0, 2, tzinfo=tz.tzutc())
         )
         with mock.patch(

--- a/tests/functional/rds/test_generate_db_auth_token.py
+++ b/tests/functional/rds/test_generate_db_auth_token.py
@@ -50,7 +50,7 @@ class TestGenerateDBAuthToken(BaseAWSCommandParamsTest):
         clock = datetime.datetime(2016, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             stdout, _, _ = self.run_cmd(command, expected_rc=0)
 
         expected = (

--- a/tests/functional/s3/test_presign_command.py
+++ b/tests/functional/s3/test_presign_command.py
@@ -22,7 +22,7 @@ from awscli.testutils import (
     temporary_file,
 )
 
-# Values used to fix time.time() and datetime.datetime.utcnow()
+# Values used to fix time.time() and datetime.datetime.now()
 # so we know the exact values of the signatures generated.
 FROZEN_TIMESTAMP = 1471305652
 DEFAULT_EXPIRES = 3600
@@ -76,7 +76,7 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
     def get_presigned_url_for_cmd(self, cmdline):
         with mock.patch('time.time', FROZEN_TIME):
             with mock.patch('datetime.datetime') as d:
-                d.utcnow = FROZEN_DATETIME
+                d.now = FROZEN_DATETIME
                 stdout = self.assert_params_for_cmd(cmdline, None)[0].strip()
                 return stdout
 

--- a/tests/functional/s3/test_presign_command.py
+++ b/tests/functional/s3/test_presign_command.py
@@ -28,7 +28,7 @@ FROZEN_TIMESTAMP = 1471305652
 DEFAULT_EXPIRES = 3600
 FROZEN_TIME = mock.Mock(return_value=FROZEN_TIMESTAMP)
 FROZEN_DATETIME = mock.Mock(
-    return_value=datetime.datetime(2016, 8, 18, 14, 33, 3, 0)
+    return_value=datetime.datetime(2016, 8, 18, 14, 33, 3, 0, tzinfo=datetime.timezone.utc)
 )
 
 

--- a/tests/integration/customizations/test_codecommit.py
+++ b/tests/integration/customizations/test_codecommit.py
@@ -64,7 +64,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()
         entry_point = AWSCLIEntryPoint(driver)
         rc = entry_point.main('codecommit credential-helper get'.split())
@@ -83,7 +83,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_fips_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()
         entry_point = AWSCLIEntryPoint(driver)
         rc = entry_point.main('codecommit credential-helper get'.split())
@@ -102,7 +102,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_vpc_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()
         entry_point = AWSCLIEntryPoint(driver)
         rc = entry_point.main('codecommit credential-helper get'.split())

--- a/tests/unit/botocore/auth/test_signers.py
+++ b/tests/unit/botocore/auth/test_signers.py
@@ -28,7 +28,7 @@ from tests import mock, unittest
 
 class BaseTestWithFixedDate(unittest.TestCase):
     def setUp(self):
-        self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0)
+        self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0, tzinfo=datetime.timezone.utc)
         self.datetime_patch = mock.patch('botocore.auth.datetime.datetime')
         self.datetime_mock = self.datetime_patch.start()
         self.datetime_mock.now.return_value = self.fixed_date
@@ -409,7 +409,7 @@ class TestSigV4(unittest.TestCase):
             'datetime',
             mock.Mock(wraps=datetime.datetime),
         ) as mock_datetime:
-            original_now = datetime.datetime(2014, 1, 1, 0, 0)
+            original_now = datetime.datetime(2014, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 
             mock_datetime.now.return_value = original_now
             # Go through the add_auth process once. This will attach
@@ -420,7 +420,7 @@ class TestSigV4(unittest.TestCase):
             self.assertIn('20140101', request.headers['Authorization'])
             # Now suppose the utc time becomes the next day all of a sudden
             mock_datetime.now.return_value = datetime.datetime(
-                2014, 1, 2, 0, 0
+                2014, 1, 2, 0, 0, tzinfo=datetime.timezone.utc
             )
             # Smaller methods like the canonical request and string_to_sign
             # should  have the timestamp attached to the request in their
@@ -594,7 +594,7 @@ class TestSigV4Presign(BasePresignTest):
         )
         mocked_datetime = self.datetime_patcher.start()
         mocked_datetime.now.return_value = datetime.datetime(
-            2014, 1, 1, 0, 0
+            2014, 1, 1, 0, 0, tzinfo=datetime.timezone.utc
         )
 
     def tearDown(self):
@@ -811,7 +811,7 @@ class TestS3SigV4Post(BaseS3PresignPostTest):
         )
         mocked_datetime = self.datetime_patcher.start()
         mocked_datetime.now.return_value = datetime.datetime(
-            2014, 1, 1, 0, 0
+            2014, 1, 1, 0, 0, tzinfo=datetime.timezone.utc
         )
 
     def tearDown(self):

--- a/tests/unit/botocore/auth/test_signers.py
+++ b/tests/unit/botocore/auth/test_signers.py
@@ -31,7 +31,7 @@ class BaseTestWithFixedDate(unittest.TestCase):
         self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0)
         self.datetime_patch = mock.patch('botocore.auth.datetime.datetime')
         self.datetime_mock = self.datetime_patch.start()
-        self.datetime_mock.utcnow.return_value = self.fixed_date
+        self.datetime_mock.now.return_value = self.fixed_date
         self.datetime_mock.strptime.return_value = self.fixed_date
 
     def tearDown(self):
@@ -409,9 +409,9 @@ class TestSigV4(unittest.TestCase):
             'datetime',
             mock.Mock(wraps=datetime.datetime),
         ) as mock_datetime:
-            original_utcnow = datetime.datetime(2014, 1, 1, 0, 0)
+            original_now = datetime.datetime(2014, 1, 1, 0, 0)
 
-            mock_datetime.utcnow.return_value = original_utcnow
+            mock_datetime.now.return_value = original_now
             # Go through the add_auth process once. This will attach
             # a timestamp to the request at the beginning of auth.
             auth.add_auth(request)
@@ -419,7 +419,7 @@ class TestSigV4(unittest.TestCase):
             # Ensure the date is in the Authorization header
             self.assertIn('20140101', request.headers['Authorization'])
             # Now suppose the utc time becomes the next day all of a sudden
-            mock_datetime.utcnow.return_value = datetime.datetime(
+            mock_datetime.now.return_value = datetime.datetime(
                 2014, 1, 2, 0, 0
             )
             # Smaller methods like the canonical request and string_to_sign
@@ -593,7 +593,7 @@ class TestSigV4Presign(BasePresignTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(
+        mocked_datetime.now.return_value = datetime.datetime(
             2014, 1, 1, 0, 0
         )
 
@@ -810,7 +810,7 @@ class TestS3SigV4Post(BaseS3PresignPostTest):
             mock.Mock(wraps=datetime.datetime),
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(
+        mocked_datetime.now.return_value = datetime.datetime(
             2014, 1, 1, 0, 0
         )
 

--- a/tests/unit/botocore/auth/test_sigv4.py
+++ b/tests/unit/botocore/auth/test_sigv4.py
@@ -41,7 +41,7 @@ from tests import FreezeTime
 
 SECRET_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
 ACCESS_KEY = 'AKIDEXAMPLE'
-DATE = datetime.datetime(2015, 8, 30, 12, 36, 0)
+DATE = datetime.datetime(2015, 8, 30, 12, 36, 0, tzinfo=datetime.timezone.utc)
 SERVICE = 'service'
 REGION = 'us-east-1'
 

--- a/tests/unit/botocore/test_credentials.py
+++ b/tests/unit/botocore/test_credentials.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import botocore.exceptions
 import botocore.session
@@ -138,7 +138,7 @@ class TestRefreshableCredentials(TestCredentials):
 
     def test_refresh_needed(self):
         # The expiry time was set for 30 minutes ago, so if we
-        # say the current time is utcnow(), then we should need
+        # say the current time is now(), then we should need
         # a refresh.
         self.mock_time.return_value = datetime.now(tzlocal())
         self.assertTrue(self.creds.refresh_needed())
@@ -326,7 +326,7 @@ class TestAssumeRoleCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
@@ -830,7 +830,7 @@ class TestAssumeRoleWithWebIdentityCredentialFetcher(BaseEnvVar):
         self.assertEqual(response, expected_response)
 
     def test_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         cache_key = '793d6e2f27667ab2da104824407e486bfec24a47'
         cache = {
@@ -1019,7 +1019,7 @@ class TestAssumeRoleWithWebIdentityCredentialProvider(unittest.TestCase):
         mock_loader_cls.assert_called_with('/some/path/token.jwt')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
 
         cache_key = 'c29461feeacfbed43017d20612606ff76abc073d'
@@ -2260,7 +2260,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertEqual(expiry_time, '2016-11-06T01:30:00UTC')
 
     def test_assume_role_retrieves_from_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
         self.fake_config['profiles']['development']['role_arn'] = 'myrole'
 
@@ -2289,7 +2289,7 @@ class TestAssumeRoleCredentialProvider(unittest.TestCase):
         self.assertEqual(creds.token, 'baz-cached')
 
     def test_chain_prefers_cache(self):
-        date_in_future = datetime.utcnow() + timedelta(seconds=1000)
+        date_in_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=1000)
         utc_timestamp = date_in_future.isoformat() + 'Z'
 
         # The profile we will be using has a cache entry, but the profile it
@@ -4312,7 +4312,7 @@ def test_login_provider_feature_ids_in_context(client_context):
         ) as mock_fetcher_class,
     ):
         mock_fetcher = mock.Mock()
-        date_in_future = datetime.utcnow() + timedelta(hours=1)
+        date_in_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=1)
         expiry_time = date_in_future.isoformat() + 'Z'
         expected_creds = {
             'access_key': 'test-access-key',

--- a/tests/unit/botocore/test_signers.py
+++ b/tests/unit/botocore/test_signers.py
@@ -684,7 +684,7 @@ class TestS3PostPresigner(BaseSignerTest):
         self.auth.return_value.add_auth = self.add_auth
         self.fixed_credentials = self.credentials.get_frozen_credentials()
 
-        self.datetime_patch = mock.patch('botocore.signers.datetime')
+        self.datetime_patch = mock.patch('botocore.compat.datetime')
         self.datetime_mock = self.datetime_patch.start()
         self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0)
         self.fixed_delta = datetime.timedelta(seconds=3600)

--- a/tests/unit/botocore/test_signers.py
+++ b/tests/unit/botocore/test_signers.py
@@ -688,7 +688,7 @@ class TestS3PostPresigner(BaseSignerTest):
         self.datetime_mock = self.datetime_patch.start()
         self.fixed_date = datetime.datetime(2014, 3, 10, 17, 2, 55, 0)
         self.fixed_delta = datetime.timedelta(seconds=3600)
-        self.datetime_mock.datetime.utcnow.return_value = self.fixed_date
+        self.datetime_mock.datetime.now.return_value = self.fixed_date
         self.datetime_mock.timedelta.return_value = self.fixed_delta
 
     def tearDown(self):
@@ -1141,7 +1141,7 @@ class TestGenerateDBAuthToken(BaseSignerTest):
         clock = datetime.datetime(2016, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             result = generate_db_auth_token(
                 self.client, hostname, port, username
             )

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -3238,7 +3238,7 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
 
     def _get_datetime(self, dt=None, offset=None, offset_func=operator.add):
         if dt is None:
-            dt = datetime.datetime.utcnow()
+            dt = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         if offset is not None:
             dt = offset_func(dt, offset)
 

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -111,7 +111,7 @@ from dateutil.tz import tzoffset, tzutc
 
 from tests import FreezeTime, RawResponse, create_session, mock, unittest
 
-DATE = datetime.datetime(2021, 12, 10, 00, 00, 00)
+DATE = datetime.datetime(2021, 12, 10, 00, 00, 00, tzinfo=datetime.timezone.utc)
 DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 

--- a/tests/utils/botocore/__init__.py
+++ b/tests/utils/botocore/__init__.py
@@ -579,12 +579,12 @@ class FreezeTime(contextlib.ContextDecorator):
     :param module: reference to imported module to patch (e.g. botocore.auth.datetime)
 
     :type date: datetime.datetime
-    :param date: datetime object specifying the output for utcnow()
+    :param date: datetime object specifying the output for now()
     """
 
     def __init__(self, module, date=None):
         if date is None:
-            date = datetime.datetime.utcnow()
+            date = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         self.date = date
         self.datetime_patcher = mock.patch.object(
             module, 'datetime', mock.Mock(wraps=datetime.datetime)
@@ -592,7 +592,7 @@ class FreezeTime(contextlib.ContextDecorator):
 
     def __enter__(self, *args, **kwargs):
         mock = self.datetime_patcher.start()
-        mock.utcnow.return_value = self.date
+        mock.now.return_value = self.date
 
     def __exit__(self, *args, **kwargs):
         self.datetime_patcher.stop()


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/boto/botocore/pull/3239

*Description of changes:*

Port of botocore PR boto/botocore#3239.

Replace `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)` to resolve the Python 3.12 `DeprecationWarning` while ensuring `datetime` instances remain timezone-unaware for backward compatibility.

Update test mocks from `.utcnow` to `.now` to match the new code paths.

Upstream: https://github.com/boto/botocore/commit/57086ff
Upstream PR: https://github.com/boto/botocore/pull/3239


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
