### PR TITLE
Add the issuer domain for EUSC

### DIFF
--- a/.changes/next-release/bugfix-sso-31940.json
+++ b/.changes/next-release/bugfix-sso-31940.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``sso``",
+  "description": "Fix SSO login failure in the EUSC partition by adding the issuer domain ``identitycenter.amazonaws.eu`` to the SSO start URL resolver allowlist."
+}

--- a/awscli/customizations/sso/resolve.py
+++ b/awscli/customizations/sso/resolve.py
@@ -37,6 +37,7 @@ _AWS_OWNED_SUFFIXES = (
 _AWS_OWNED_EXACT = (
     'identitycenter.amazonaws.com',
     'identitycenter.amazonaws.com.cn',
+    'identitycenter.amazonaws.eu',
 )
 
 _REGION_PATTERNS = (

--- a/tests/unit/customizations/sso/test_resolve.py
+++ b/tests/unit/customizations/sso/test_resolve.py
@@ -47,6 +47,7 @@ class TestIsAwsOwnedDomain:
             'ssoins-abc123.portal.cn-north-1.app.amazonwebservices.com.cn',
             'ssoins-abc123.eusc-de-east-1.portal.amazonaws.eu',
             'ssoins-abc123.portal.eusc-de-east-1.api.amazonwebservices.eu',
+            'identitycenter.amazonaws.eu',
         ],
     )
     def test_aws_owned_returns_true(self, hostname):
@@ -112,6 +113,7 @@ class TestExtractRegionFromHostname:
             'd-abc123.awsapps.cn',
             'identitycenter.amazonaws.com',
             'identitycenter.amazonaws.com.cn',
+            'identitycenter.amazonaws.eu',
             'aws.mycompany.com',
         ],
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* AWS-EUSC SSO login failed on CLI 2.35.13+ because the EUSC issuer domain `identitycenter.amazonaws.eu` was missing from the SSO start URL resolver allowlist. The resolver treated it as a vanity URL and attempted DNS resolution, which failed. PR #10465 added the EUSC portal suffix forms but not the issuer form. This adds it to `_AWS_OWNED_EXACT`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
