### PR TITLE
Fix ShorthandParseSyntaxError message showing literal placeholder instead of caret

### DIFF
--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -93,7 +93,7 @@ class ShorthandParseSyntaxError(ShorthandParseError):
     def _construct_msg(self):
         return (
             f"Expected: '{self.expected}', received: '{self.actual}' "
-            f"for input:\n" "{self._error_location()}"
+            f"for input:\n{self._error_location()}"
         )
 
 

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -174,6 +174,15 @@ def test_error_parsing(expr):
         shorthand.ShorthandParser().parse(expr)
 
 
+def test_error_parsing_message_includes_caret():
+    """Error message should include the caret pointing at the parse failure position."""
+    with pytest.raises(shorthand.ShorthandParseError) as exc_info:
+        shorthand.ShorthandParser().parse("a=b,c==d")
+    msg = str(exc_info.value)
+    assert "a=b,c==d" in msg
+    assert "^" in msg
+
+
 @pytest.mark.parametrize(
     "expr", (
         # starting with " but unclosed, then repeated \


### PR DESCRIPTION
The _construct_msg method in ShorthandParseSyntaxError was missing an  prefix on the last string fragment, so {self._error_location()} was printed literally instead of showing the caret. This made shorthand parsing errors much harder to diagnose — the carets were the main way to locate the mistake in long expressions.

Also adds a test asserting the message content includes both the input and the caret.