### PR TITLE
Error on empty CA bundle value

### DIFF
--- a/.changes/next-release/bugfix-TLS-12458.json
+++ b/.changes/next-release/bugfix-TLS-12458.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "TLS",
-  "description": "Return a configuration error when the CA bundle value (--ca-bundle, ca_bundle, AWS_CA_BUNDLE, or REQUESTS_CA_BUNDLE) resolves to an empty string."
+  "description": "Return a configuration error when the CA bundle value (--ca-bundle, ca_bundle, AWS_CA_BUNDLE, or REQUESTS_CA_BUNDLE) resolves to an empty or whitespace-only string."
 }

--- a/.changes/next-release/bugfix-TLS-12458.json
+++ b/.changes/next-release/bugfix-TLS-12458.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "TLS",
+  "description": "Return a configuration error when the CA bundle value (--ca-bundle, ca_bundle, AWS_CA_BUNDLE, or REQUESTS_CA_BUNDLE) resolves to an empty string."
+}

--- a/awscli/botocore/endpoint.py
+++ b/awscli/botocore/endpoint.py
@@ -21,7 +21,7 @@ import uuid
 
 from botocore import parsers
 from botocore.awsrequest import create_request_object
-from botocore.exceptions import HTTPClientError
+from botocore.exceptions import HTTPClientError, InvalidConfigError
 from botocore.history import get_global_history_recorder
 from botocore.hooks import first_non_none_response
 from botocore.httpchecksum import handle_checksum_body
@@ -441,7 +441,21 @@ class EndpointCreator:
         # First, if verify is not None, then the user explicitly specified
         # a value so this automatically wins.
         if verify is not None:
-            return verify
+            return self._validate_verify_value(verify)
         # Otherwise use the value from REQUESTS_CA_BUNDLE, or default to
         # True if the env var does not exist.
-        return os.environ.get('REQUESTS_CA_BUNDLE', True)
+        return self._validate_verify_value(
+            os.environ.get('REQUESTS_CA_BUNDLE', True)
+        )
+
+    def _validate_verify_value(self, verify):
+        if isinstance(verify, str) and not verify:
+            raise InvalidConfigError(
+                error_msg=(
+                    'Invalid CA bundle: the configured value (ca_bundle, '
+                    'AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolved '
+                    'to an empty string. Provide a valid path to a CA bundle '
+                    'file.'
+                )
+            )
+        return verify

--- a/awscli/botocore/endpoint.py
+++ b/awscli/botocore/endpoint.py
@@ -449,13 +449,13 @@ class EndpointCreator:
         )
 
     def _validate_verify_value(self, verify):
-        if isinstance(verify, str) and not verify:
+        if isinstance(verify, str) and not verify.strip():
             raise InvalidConfigError(
                 error_msg=(
                     'Invalid CA bundle: the configured value (ca_bundle, '
                     'AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolved '
-                    'to an empty string. Provide a valid path to a CA bundle '
-                    'file.'
+                    'to an empty or whitespace-only string. Provide a valid '
+                    'path to a CA bundle file.'
                 )
             )
         return verify

--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -146,13 +146,13 @@ def create_s3_crt_client(
         S3RequestTlsMode.ENABLED if use_ssl else S3RequestTlsMode.DISABLED
     )
     if verify is not None:
-        if isinstance(verify, str) and not verify:
+        if isinstance(verify, str) and not verify.strip():
             raise InvalidConfigError(
                 error_msg=(
                     'Invalid CA bundle: the configured value (ca_bundle, '
                     'AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolved '
-                    'to an empty string. Provide a valid path to a CA bundle '
-                    'file.'
+                    'to an empty or whitespace-only string. Provide a valid '
+                    'path to a CA bundle file.'
                 )
             )
         tls_ctx_options = TlsContextOptions()

--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -42,7 +42,7 @@ from awscrt.s3 import (
 from botocore import UNSIGNED
 from botocore.compat import urlsplit
 from botocore.config import Config
-from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import InvalidConfigError, NoCredentialsError
 from botocore.useragent import register_feature_id
 from botocore.utils import ArnParser, InvalidArnException, is_s3express_bucket
 from s3transfer.constants import FULL_OBJECT_CHECKSUM_ARGS, MB
@@ -146,6 +146,15 @@ def create_s3_crt_client(
         S3RequestTlsMode.ENABLED if use_ssl else S3RequestTlsMode.DISABLED
     )
     if verify is not None:
+        if isinstance(verify, str) and not verify:
+            raise InvalidConfigError(
+                error_msg=(
+                    'Invalid CA bundle: the configured value (ca_bundle, '
+                    'AWS_CA_BUNDLE, REQUESTS_CA_BUNDLE, or verify) resolved '
+                    'to an empty string. Provide a valid path to a CA bundle '
+                    'file.'
+                )
+            )
         tls_ctx_options = TlsContextOptions()
         if verify:
             tls_ctx_options.override_default_trust_store_from_path(

--- a/tests/unit/botocore/test_endpoint.py
+++ b/tests/unit/botocore/test_endpoint.py
@@ -23,6 +23,7 @@ from botocore.exceptions import (
     ConnectionClosedError,
     EndpointConnectionError,
     HTTPClientError,
+    InvalidConfigError,
 )
 from botocore.httpsession import URLLib3Session
 from botocore.model import (
@@ -466,6 +467,26 @@ class TestEndpointCreator(unittest.TestCase):
         session_args = self.mock_session.call_args[1]
         # /path/cacerts.pem wins over the value from the env var.
         self.assertEqual(session_args.get('verify'), '/path/cacerts.pem')
+
+    def test_empty_verify_value_raises(self):
+        with self.assertRaises(InvalidConfigError):
+            self.creator.create_endpoint(
+                self.service_model,
+                region_name='us-west-2',
+                endpoint_url='https://example.com',
+                verify='',
+                http_session_cls=self.mock_session,
+            )
+
+    def test_empty_cert_bundle_env_var_raises(self):
+        self.environ['REQUESTS_CA_BUNDLE'] = ''
+        with self.assertRaises(InvalidConfigError):
+            self.creator.create_endpoint(
+                self.service_model,
+                region_name='us-west-2',
+                endpoint_url='https://example.com',
+                http_session_cls=self.mock_session,
+            )
 
     def test_can_specify_max_pool_conns(self):
         self.creator.create_endpoint(

--- a/tests/unit/botocore/test_endpoint.py
+++ b/tests/unit/botocore/test_endpoint.py
@@ -478,6 +478,16 @@ class TestEndpointCreator(unittest.TestCase):
                 http_session_cls=self.mock_session,
             )
 
+    def test_whitespace_verify_value_raises(self):
+        with self.assertRaises(InvalidConfigError):
+            self.creator.create_endpoint(
+                self.service_model,
+                region_name='us-west-2',
+                endpoint_url='https://example.com',
+                verify='   ',
+                http_session_cls=self.mock_session,
+            )
+
     def test_empty_cert_bundle_env_var_raises(self):
         self.environ['REQUESTS_CA_BUNDLE'] = ''
         with self.assertRaises(InvalidConfigError):

--- a/tests/unit/s3transfer/test_crt.py
+++ b/tests/unit/s3transfer/test_crt.py
@@ -14,7 +14,11 @@ import io
 
 import pytest
 from botocore.credentials import Credentials, ReadOnlyCredentials
-from botocore.exceptions import ClientError, NoCredentialsError
+from botocore.exceptions import (
+    ClientError,
+    InvalidConfigError,
+    NoCredentialsError,
+)
 from botocore.session import Session
 from s3transfer.constants import GB
 from s3transfer.exceptions import TransferNotDoneError
@@ -366,6 +370,18 @@ class TestCreateS3CRTClient:
     def test_always_enables_s3express(self, mock_s3_crt_client):
         s3transfer.crt.create_s3_crt_client('us-west-2')
         assert mock_s3_crt_client.call_args[1]['enable_s3express'] is True
+
+    def test_empty_verify_value_raises(self, mock_s3_crt_client):
+        with pytest.raises(InvalidConfigError):
+            s3transfer.crt.create_s3_crt_client('us-west-2', verify='')
+
+    def test_verify_false_disables_verification(self, mock_s3_crt_client):
+        with (
+            mock.patch('s3transfer.crt.TlsContextOptions') as mock_tls_options,
+            mock.patch('s3transfer.crt.ClientTlsContext'),
+        ):
+            s3transfer.crt.create_s3_crt_client('us-west-2', verify=False)
+        assert mock_tls_options.return_value.verify_peer is False
 
     @pytest.mark.parametrize(
         'fio_options,should_stream,disk_throughput,direct_io',

--- a/tests/unit/s3transfer/test_crt.py
+++ b/tests/unit/s3transfer/test_crt.py
@@ -375,6 +375,10 @@ class TestCreateS3CRTClient:
         with pytest.raises(InvalidConfigError):
             s3transfer.crt.create_s3_crt_client('us-west-2', verify='')
 
+    def test_whitespace_verify_value_raises(self, mock_s3_crt_client):
+        with pytest.raises(InvalidConfigError):
+            s3transfer.crt.create_s3_crt_client('us-west-2', verify='   ')
+
     def test_verify_false_disables_verification(self, mock_s3_crt_client):
         with (
             mock.patch('s3transfer.crt.TlsContextOptions') as mock_tls_options,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The CLI now errors when a CA bundle value (`--ca-bundle`, the `ca_bundle` profile setting, `AWS_CA_BUNDLE`, or `REQUESTS_CA_BUNDLE`) resolves to an empty string.

An empty string is not a valid value for these settings, which are defined as paths to a CA bundle.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
