### PR TITLE
Add validates models to docs commands

### DIFF
--- a/tests/functional/autoprompt/test_doc.py
+++ b/tests/functional/autoprompt/test_doc.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from awscli.autocomplete import parser
 from awscli.autoprompt.doc import DocsGetter
 from awscli.clidriver import create_clidriver
@@ -18,6 +20,10 @@ from tests.unit.autocomplete import InMemoryIndex
 
 
 class TestDocsGetter(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def _capture_record_property(self, record_property):
+        self._record_property = record_property
+
     def setUp(self):
         self.driver = create_clidriver()
         self.docs_getter = DocsGetter(self.driver)
@@ -52,19 +58,26 @@ class TestDocsGetter(unittest.TestCase):
         )
         self.parser = parser.CLIParser(self.index)
 
+    @pytest.mark.validates_models
     def test_get_service_command_docs(self):
+        self._record_property('aws_service', 'ec2')
         parsed_args = self.parser.parse('aws ec2')
         actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'Amazon EC2'
         self.assertIn(expected_docs, actual_docs)
 
+    @pytest.mark.validates_models
     def test_get_service_operation_docs(self):
+        self._record_property('aws_service', 'ec2')
+        self._record_property('aws_operation', 'DescribeInstances')
         parsed_args = self.parser.parse('aws ec2 describe-instances')
         actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'Describes the specified instances'
         self.assertIn(expected_docs, actual_docs)
 
+    @pytest.mark.validates_models
     def test_get_service_command_docs_with_invalid_service_operation(self):
+        self._record_property('aws_service', 'ec2')
         parsed_args = self.parser.parse('aws ec2 fake')
         actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'Amazon EC2'
@@ -82,7 +95,10 @@ class TestDocsGetter(unittest.TestCase):
         expected_docs = 'The AWS Command Line Interface'
         self.assertIn(expected_docs, actual_docs)
 
+    @pytest.mark.validates_models
     def test_get_service_operation_docs_if_input_is_vanild(self):
+        self._record_property('aws_service', 'ec2')
+        self._record_property('aws_operation', 'DescribeInstances')
         parsed_args = self.parser.parse('aws ec2 describe-instances fake')
         actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'Describes the specified instances'

--- a/tests/functional/botocore/docs/test_alias.py
+++ b/tests/functional/botocore/docs/test_alias.py
@@ -10,13 +10,22 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from tests.functional.botocore.docs import BaseDocsFunctionalTest
 from tests.functional.botocore.test_alias import ALIAS_CASES
 
 
+@pytest.mark.validates_models
 class TestAliasesDocumented(BaseDocsFunctionalTest):
+    @pytest.fixture(autouse=True)
+    def _capture_record_property(self, record_property):
+        self._record_property = record_property
+
     def test_all_aliases_are_documented_correctly(self):
         for case in ALIAS_CASES:
+            self._record_property('aws_service', case['service'])
+            self._record_property('aws_operation', case['operation'])
             content = self.get_docstring_for_method(
                 case['service'], case['operation']
             ).decode('utf-8')

--- a/tests/functional/botocore/docs/test_ec2.py
+++ b/tests/functional/botocore/docs/test_ec2.py
@@ -10,17 +10,28 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from tests.functional.botocore.docs import BaseDocsFunctionalTest
 
 
+@pytest.mark.validates_models
 class TestEc2Docs(BaseDocsFunctionalTest):
+    @pytest.fixture(autouse=True)
+    def _capture_record_property(self, record_property):
+        self._record_property = record_property
+
     def test_documents_encoding_of_user_data(self):
+        self._record_property('aws_service', 'ec2')
+        self._record_property('aws_operation', 'RunInstances')
         docs = self.get_parameter_documentation_from_service(
             'ec2', 'run_instances', 'UserData'
         )
         self.assertIn('base64 encoded automatically', docs.decode('utf-8'))
 
     def test_copy_snapshot_presigned_url_is_autopopulated(self):
+        self._record_property('aws_service', 'ec2')
+        self._record_property('aws_operation', 'CopySnapshot')
         self.assert_is_documented_as_autopopulated_param(
             service_name='ec2',
             method_name='copy_snapshot',
@@ -28,6 +39,8 @@ class TestEc2Docs(BaseDocsFunctionalTest):
         )
 
     def test_copy_snapshot_destination_region_is_autopopulated(self):
+        self._record_property('aws_service', 'ec2')
+        self._record_property('aws_operation', 'CopySnapshot')
         self.assert_is_documented_as_autopopulated_param(
             service_name='ec2',
             method_name='copy_snapshot',
@@ -35,6 +48,8 @@ class TestEc2Docs(BaseDocsFunctionalTest):
         )
 
     def test_idempotency_documented(self):
+        self._record_property('aws_service', 'ec2')
+        self._record_property('aws_operation', 'PurchaseScheduledInstances')
         content = self.get_docstring_for_method(
             'ec2', 'purchase_scheduled_instances'
         )

--- a/tests/functional/botocore/test_endpoint_rulesets.py
+++ b/tests/functional/botocore/test_endpoint_rulesets.py
@@ -314,7 +314,7 @@ def _collect_refs_from_rules(rules):
     return refs
 
 
-@pytest.mark.validates_model
+@pytest.mark.validates_models
 def test_s3_unreferenced_endpoint_ruleset_params():
     """Assert that the set of known S3 endpoint ruleset parameters that are
     not used in the rules hasn't changed. These are set in the

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -92,7 +92,12 @@ def runner_browser():
     )
 
 
+@pytest.mark.validates_models
 class TestHelpOutput(BaseAWSHelpOutputTest):
+    @pytest.fixture(autouse=True)
+    def _capture_record_property(self, record_property):
+        self._record_property = record_property
+
     def test_output(self):
         self.driver.main(['help'])
         # Check for the reference label.
@@ -135,6 +140,8 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
         self.assert_contains('* describe-instances')
 
     def test_operation_help_output(self):
+        self._record_property('aws_service', 'ec2')
+        self._record_property('aws_operation', 'RunInstances')
         self.driver.main(['ec2', 'run-instances', 'help'])
         # Check for the reference label.
         self.assert_contains('.. _cli:aws ec2 run-instances:')
@@ -245,6 +252,8 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
         self.assert_contains('========\nExamples\n========')
 
     def test_add_help_for_dryrun(self):
+        self._record_property('aws_service', 'ec2')
+        self._record_property('aws_operation', 'RunInstances')
         self.driver.main(['ec2', 'run-instances', 'help'])
         self.assert_contains('DryRunOperation')
         self.assert_contains('UnauthorizedOperation')

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 
 import botocore.session
+import pytest
 
 from awscli.clidriver import create_clidriver
 from awscli.testutils import (
@@ -36,6 +37,10 @@ class TestBasicCommandFunctionality(unittest.TestCase):
     the CLI.  They don't test anything exhaustively and they're meant as a smoke
     test to verify basic CLI functionality isn't entirely broken.
     """
+
+    @pytest.fixture(autouse=True)
+    def _capture_record_property(self, record_property):
+        self._record_property = record_property
 
     def put_object(
         self,
@@ -70,7 +75,9 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         self.assertIn('AWS', p.stdout)
         self.assertRegex(p.stdout, r'The\s+AWS\s+Command\s+Line\s+Interface')
 
+    @pytest.mark.validates_models
     def test_service_help_output(self):
+        self._record_property('aws_service', 'ec2')
         p = aws('ec2 help')
         self.assertEqual(p.rc, 0)
         self.assertRegex(p.stdout, r'Amazon\s+EC2')


### PR DESCRIPTION
*Description of changes:*
This PR adds the validates models annotation to a number of docs-based tests and fixes one that had the annotation incorrect

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
