### PR TITLE
Fix GovCloud SSO login by adding issuer domain to resolver allowlist

### DIFF
--- a/.changes/next-release/bugfix-sso-41288.json
+++ b/.changes/next-release/bugfix-sso-41288.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``sso``",
+  "description": "Fix SSO login failure in the GovCloud partition by adding the issuer domain ``identitycenter.us-gov.amazonaws.com`` to the SSO start URL resolver allowlist."
+}

--- a/awscli/customizations/sso/resolve.py
+++ b/awscli/customizations/sso/resolve.py
@@ -38,6 +38,7 @@ _AWS_OWNED_EXACT = (
     'identitycenter.amazonaws.com',
     'identitycenter.amazonaws.com.cn',
     'identitycenter.amazonaws.eu',
+    'identitycenter.us-gov.amazonaws.com',
 )
 
 _REGION_PATTERNS = (

--- a/tests/unit/customizations/sso/test_resolve.py
+++ b/tests/unit/customizations/sso/test_resolve.py
@@ -48,6 +48,7 @@ class TestIsAwsOwnedDomain:
             'ssoins-abc123.eusc-de-east-1.portal.amazonaws.eu',
             'ssoins-abc123.portal.eusc-de-east-1.api.amazonwebservices.eu',
             'identitycenter.amazonaws.eu',
+            'identitycenter.us-gov.amazonaws.com',
         ],
     )
     def test_aws_owned_returns_true(self, hostname):
@@ -114,6 +115,7 @@ class TestExtractRegionFromHostname:
             'identitycenter.amazonaws.com',
             'identitycenter.amazonaws.com.cn',
             'identitycenter.amazonaws.eu',
+            'identitycenter.us-gov.amazonaws.com',
             'aws.mycompany.com',
         ],
     )


### PR DESCRIPTION
*Issue #, if available:* #10502

*Description of changes:* `aws sso login` failed in the GovCloud partition when the start URL was the issuer form `identitycenter.us-gov.amazonaws.com`, because it was missing from the SSO resolver allowlist. The resolver treated it as a vanity URL and attempted DNS resolution, which fails since the issuer host has no DNS record.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
