### PR TITLE
fix: resume token hint no longer affected by --query in text formatter

### DIFF
--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -248,7 +248,7 @@ class TextFormatter(Formatter):
                 if response.resume_token:
                     # Tell the user about the next token so they can continue
                     # if they want.
-                    self._format_response(
+                    text.format_text(
                         {'NextToken': {'NextToken': response.resume_token}},
                         stream,
                     )


### PR DESCRIPTION
## Description

When using \--output text\ with \--query\ on paginated commands, the resume token hint (NEXTTOKEN) was incorrectly processed through the JMESPath query expression, resulting in a spurious \None\ line being printed.

The resume token hint is pagination metadata, not part of the result set, so it should bypass \--query\ filtering.

## Fix

Call \	ext.format_text\ directly instead of \_format_response\ when rendering the resume token hint, since \_format_response\ applies the \--query\ filter.

## Related

Fixes #10449

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.