### PR TITLE
[v2] Fix bug with response_checksum_validation not being respected when using CRT

### DIFF
--- a/awscli/customizations/s3/factory.py
+++ b/awscli/customizations/s3/factory.py
@@ -13,6 +13,7 @@
 import logging
 
 import awscrt.s3
+from botocore import UNSIGNED
 from botocore.client import Config
 from botocore.httpsession import DEFAULT_CA_BUNDLE
 from s3transfer.crt import (
@@ -114,9 +115,11 @@ class TransferManagerFactory:
 
     def _create_crt_transfer_manager(self, params, runtime_config):
         self._acquire_crt_s3_process_lock()
+        serializer_client = self._create_serializer_client(params)
         return CRTTransferManager(
             self._create_crt_client(params, runtime_config),
-            self._create_crt_request_serializer(params),
+            self._create_crt_request_serializer(params, serializer_client),
+            client=serializer_client,
         )
 
     def _create_crt_client(self, params, runtime_config):
@@ -154,13 +157,26 @@ class TransferManagerFactory:
 
         return create_s3_crt_client(**create_crt_client_kwargs)
 
-    def _create_crt_request_serializer(self, params):
+    def _create_serializer_client(self, params):
+        client_kwargs = {
+            'region_name': self._resolve_region(params),
+            'endpoint_url': params.get('endpoint_url'),
+        }
+        user_provided_config = self._session.get_default_client_config()
+        if 'config' in client_kwargs:
+            user_provided_config = client_kwargs['config']
+        client_config = Config(signature_version=UNSIGNED)
+        if user_provided_config:
+            client_config = user_provided_config.merge(client_config)
+        client_kwargs['config'] = client_config
+        return self._session.create_client(
+            service_name='s3', **client_kwargs
+        )
+
+    def _create_crt_request_serializer(self, params, client):
         return BotocoreCRTRequestSerializer(
             self._session,
-            {
-                'region_name': self._resolve_region(params),
-                'endpoint_url': params.get('endpoint_url'),
-            },
+            client=client,
         )
 
     def _create_classic_transfer_manager(

--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -202,7 +202,9 @@ def _get_crt_throughput_target_gbps(provided_throughput_target_bytes=None):
 
 
 class CRTTransferManager:
-    def __init__(self, crt_s3_client, crt_request_serializer, osutil=None):
+    def __init__(
+        self, crt_s3_client, crt_request_serializer, osutil=None, client=None
+    ):
         """A transfer manager interface for Amazon S3 on CRT s3 client.
 
         :type crt_s3_client: awscrt.s3.S3Client
@@ -216,12 +218,16 @@ class CRTTransferManager:
         :type osutil: s3transfer.utils.OSUtils
         :param osutil: OSUtils object to use for os-related behavior when
             using with transfer manager.
+
+        :type client: botocore.client.BaseClient
+        :param client: The botocore client used for
+            serializing requests and resolving client configuration.
         """
         if osutil is None:
             self._osutil = OSUtils()
         self._crt_s3_client = crt_s3_client
         self._s3_args_creator = S3ClientArgsCreator(
-            crt_request_serializer, self._osutil
+            crt_request_serializer, self._osutil, client
         )
         self._crt_exception_translator = (
             crt_request_serializer.translate_crt_exception
@@ -449,7 +455,7 @@ class BaseCRTRequestSerializer:
 
 
 class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
-    def __init__(self, session, client_kwargs=None):
+    def __init__(self, session, client_kwargs=None, client=None):
         """Serialize CRT HTTP request using botocore logic
         It also takes into account configuration from both the session
         and any keyword arguments that could be passed to
@@ -460,12 +466,19 @@ class BotocoreCRTRequestSerializer(BaseCRTRequestSerializer):
         :type client_kwargs: Optional[Dict[str, str]])
         :param client_kwargs: The kwargs for the botocore
             s3 client initialization.
+
+        :type client: Optional[botocore.client.BaseClient]
+        :param client: A pre-configured botocore S3 client. If provided,
+            session and client_kwargs are ignored for client creation.
         """
         self._session = session
-        if client_kwargs is None:
-            client_kwargs = {}
-        self._resolve_client_config(session, client_kwargs)
-        self._client = session.create_client(**client_kwargs)
+        if client is not None:
+            self._client = client
+        else:
+            if client_kwargs is None:
+                client_kwargs = {}
+            self._resolve_client_config(session, client_kwargs)
+            self._client = session.create_client(**client_kwargs)
         self._client.meta.events.register(
             'request-created.s3.*', self._capture_http_request
         )
@@ -715,9 +728,10 @@ class CRTTransferCoordinator:
 
 
 class S3ClientArgsCreator:
-    def __init__(self, crt_request_serializer, os_utils):
+    def __init__(self, crt_request_serializer, os_utils, client=None):
         self._request_serializer = crt_request_serializer
         self._os_utils = os_utils
+        self._client = client
 
     def get_make_request_args(
         self, request_type, call_args, coordinator, future, on_done_after_calls
@@ -819,7 +833,14 @@ class S3ClientArgsCreator:
     ):
         recv_filepath = None
         on_body = None
-        checksum_config = awscrt.s3.S3ChecksumConfig(validate_response=True)
+        validate = not (
+            self._client is not None
+            and self._client.meta.config.response_checksum_validation
+            == 'when_required'
+        )
+        checksum_config = awscrt.s3.S3ChecksumConfig(
+            validate_response=validate
+        )
         if isinstance(call_args.fileobj, str):
             final_filepath = call_args.fileobj
             recv_filepath = self._os_utils.get_temp_filename(final_filepath)

--- a/tests/functional/s3transfer/test_crt.py
+++ b/tests/functional/s3transfer/test_crt.py
@@ -16,6 +16,8 @@ import threading
 import time
 from concurrent.futures import Future
 
+from botocore import UNSIGNED
+from botocore.config import Config
 from botocore.session import Session
 from s3transfer.subscribers import BaseSubscriber
 
@@ -720,3 +722,34 @@ class TestCRTTransferManager(unittest.TestCase):
         )
         with self.assertRaises(awscrt.exceptions.AwsCrtError):
             future.result()
+
+    def test_download_checksum_validation_disabled_when_required(self):
+        session = Session()
+        session.set_config_variable('region', self.region)
+        client = session.create_client(
+            's3',
+            config=Config(
+                signature_version=UNSIGNED,
+                response_checksum_validation='when_required',
+            ),
+        )
+        request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
+            session, client=client
+        )
+        transfer_manager = s3transfer.crt.CRTTransferManager(
+            crt_s3_client=self.s3_crt_client,
+            crt_request_serializer=request_serializer,
+            client=client,
+        )
+        future = transfer_manager.download(
+            self.bucket, self.key, self.filename, {}, [self.record_subscriber]
+        )
+        future.result()
+
+        callargs_kwargs = self.s3_crt_client.make_request.call_args[1]
+        self.assertEqual(
+            callargs_kwargs['checksum_config'],
+            self._get_expected_download_checksum_config(
+                validate_response=False
+            ),
+        )


### PR DESCRIPTION
*Description of changes:*

* Updated vendored s3transfer so that `response_checksum_validation` is respected when using CRT client to perform S3 downloads.
* Added a regression test to cover this new behavior.

*Description of tests:*

* Ran and passed all tests (see GitHub Actions).
* Verified that regression test fails without the fix, and passes with the fix.
* Performed manual integration tests and verified the expected headers in the debug logs (results below)

*Manual integration test results:*

**Without fix (response_checksum_validation=when_required)**

```
GET
/tox.ini

amz-sdk-invocation-id:REDACTED
amz-sdk-request:attempt=1
content-length:0
host:REDACTED
if-match:"REDACTED"
range:bytes=0-33481
x-amz-checksum-mode:enabled
x-amz-content-sha256:UNSIGNED-PAYLOAD
x-amz-date:20260730T202516Z
x-amz-security-token:REDACTED

amz-sdk-invocation-id;amz-sdk-request;content-length;host;if-match;range;x-amz-checksum-mode;x-amz-content-sha256;x-amz-date;x-amz-security-token
UNSIGNED-PAYLOAD
```

**Without fix (response_checksum_validation=when_supported)**

```
GET
/tox.ini

amz-sdk-invocation-id:REDACTED
amz-sdk-request:attempt=1
content-length:0
host:REDACTED
if-match:"REDACTED"
range:bytes=0-33481
x-amz-checksum-mode:enabled
x-amz-content-sha256:UNSIGNED-PAYLOAD
x-amz-date:20260730T202857Z
x-amz-security-token:REDACTED

amz-sdk-invocation-id;amz-sdk-request;content-length;host;if-match;range;x-amz-checksum-mode;x-amz-content-sha256;x-amz-date;x-amz-security-token
UNSIGNED-PAYLOAD
```

**With fix (response_checksum_validation=when_required)**

```
GET
/tox.ini

amz-sdk-invocation-id:REDACTED
amz-sdk-request:attempt=1
content-length:0
host:REDACTED
range:bytes=0-8388607
x-amz-content-sha256:UNSIGNED-PAYLOAD
x-amz-date:20260730T202352Z
x-amz-security-token:REDACTED

amz-sdk-invocation-id;amz-sdk-request;content-length;host;range;x-amz-content-sha256;x-amz-date;x-amz-security-token
UNSIGNED-PAYLOAD
```

**With fix (response_checksum_validation=when_supported)**

```
GET
/tox.ini

amz-sdk-invocation-id:REDACTED
amz-sdk-request:attempt=1
content-length:0
host:REDACTED
if-match:"REDACTED"
range:bytes=0-33481
x-amz-checksum-mode:enabled
x-amz-content-sha256:UNSIGNED-PAYLOAD
x-amz-date:20260730T203001Z
x-amz-security-token:REDACTED

amz-sdk-invocation-id;amz-sdk-request;content-length;host;if-match;range;x-amz-checksum-mode;x-amz-content-sha256;x-amz-date;x-amz-security-token
UNSIGNED-PAYLOAD
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
