### PR TITLE
  Reduce session database locking and add AWS_CLI_TELEMETRY_DISABLED

### DIFF
--- a/.changes/next-release/enhancement-telemetry-49821.json
+++ b/.changes/next-release/enhancement-telemetry-49821.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``telemetry``",
+  "description": "Reduce session database locking which could cause slowdowns when the AWS CLI cache directory is on a network filesystem. Also adds the ``AWS_CLI_TELEMETRY_DISABLED`` environment variable to opt out of session id collection entirely."
+}

--- a/awscli/telemetry.py
+++ b/awscli/telemetry.py
@@ -36,7 +36,7 @@ _CACHE_DIR = Path.home() / '.aws' / 'cli' / 'cache'
 _DATABASE_FILENAME = 'session.db'
 _SESSION_LENGTH_SECONDS = 60 * 30
 _SESSION_ID_LENGTH = 12
-# How stale the stored timestamp must be before we write it. Refreshing on every
+# How stale the stored timestamp must be before it is written. Refreshing on every
 # invocation takes a write lock each time, which can cause lock contention.
 _TIMESTAMP_REFRESH_SECONDS = 60
 # How long to wait for a database lock before giving up. Session data is not

--- a/awscli/telemetry.py
+++ b/awscli/telemetry.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import io
+import logging
 import os
 import sqlite3
 import sys
@@ -24,14 +25,27 @@ from pathlib import Path
 from botocore.compat import get_md5
 from botocore.exceptions import MD5UnavailableError
 from botocore.useragent import UserAgentComponent
+from botocore.utils import ensure_boolean
 
 from awscli.compat import is_windows
 from awscli.utils import add_component_to_user_agent_extra
+
+LOG = logging.getLogger(__name__)
 
 _CACHE_DIR = Path.home() / '.aws' / 'cli' / 'cache'
 _DATABASE_FILENAME = 'session.db'
 _SESSION_LENGTH_SECONDS = 60 * 30
 _SESSION_ID_LENGTH = 12
+# How stale the stored timestamp must be before we write it. Refreshing on every
+# invocation takes a write lock each time, which can cause lock contention.
+_TIMESTAMP_REFRESH_SECONDS = 60
+# How long to wait for a database lock before giving up. Session data is not
+# critical, so it's better to skip it than to make the user wait
+_BUSY_TIMEOUT_SECONDS = 0.1
+# Set to "true" to skip collecting session ids entirely. Opting out avoids
+# opening the session database, whose file locking can be expensive when the
+# database lives on a network filesystem.
+_TELEMETRY_DISABLED_ENV_VAR = 'AWS_CLI_TELEMETRY_DISABLED'
 
 
 def _get_checksum():
@@ -83,6 +97,7 @@ class CLISessionDatabaseConnection:
             self._cache_dir / _DATABASE_FILENAME,
             check_same_thread=False,
             isolation_level=None,
+            timeout=_BUSY_TIMEOUT_SECONDS,
         )
         self._ensure_database_setup()
 
@@ -93,6 +108,11 @@ class CLISessionDatabaseConnection:
             # Process timed out waiting for database lock.
             # Return any empty `Cursor` object instead of
             # raising an exception.
+            LOG.debug(
+                'Failed to execute session database query: %s',
+                query,
+                exc_info=True,
+            )
             return sqlite3.Cursor(self._connection)
 
     def _ensure_cache_dir(self):
@@ -130,7 +150,9 @@ class CLISessionDatabaseConnection:
         except sqlite3.Error:
             # This is just a performance enhancement so it is optional. Not all
             # systems will have a sqlite compiled with the WAL enabled.
-            pass
+            LOG.debug(
+                'Failed to enable WAL for session database', exc_info=True
+            )
 
 
 class CLISessionDatabaseWriter:
@@ -182,6 +204,12 @@ class CLISessionDatabaseReader:
 
 
 class CLISessionDatabaseSweeper:
+    _CHECK_EXPIRED = """
+        SELECT 1
+        FROM session
+        WHERE timestamp < ?
+        LIMIT 1
+    """
     _DELETE_RECORDS = """
         DELETE FROM session
         WHERE timestamp < ?
@@ -192,10 +220,22 @@ class CLISessionDatabaseSweeper:
 
     def sweep(self, timestamp):
         try:
+            # A DELETE takes a write lock even when it matches no rows, which
+            # is the common case since expired records are rare. Reads don't
+            # take a write lock, so check for expired records first and only
+            # issue the DELETE when there's something to remove. This matters
+            # on network filesystems (e.g. NFS/EFS) where each lock is a
+            # network round trip.
+            has_expired = self._connection.execute(
+                self._CHECK_EXPIRED, (timestamp,)
+            ).fetchone()
+            if has_expired is None:
+                return
             self._connection.execute(self._DELETE_RECORDS, (timestamp,))
         except Exception:
             # This is just a background cleanup task. No need to
             # handle it or direct to stderr.
+            LOG.debug('Failed to sweep session database', exc_info=True)
             return
 
 
@@ -239,14 +279,23 @@ class CLISessionOrchestrator:
     def session_id(self):
         if (cached_data := self._reader.read(self.cache_key)) is not None:
             # Cache hit, but session id is expired. Generate new id and update.
-            if (
+            is_expired = (
                 cached_data.timestamp + _SESSION_LENGTH_SECONDS
                 < self._timestamp
-            ):
+            )
+            if is_expired:
                 cached_data.session_id = self._session_id
-            # Always update the timestamp to last used.
-            cached_data.timestamp = self._timestamp
-            self._writer.write(cached_data)
+            # Update the timestamp to last used, but only if the stored value
+            # is older than _TIMESTAMP_REFRESH_SECONDS. A session can expire
+            # up to this many seconds earlier than its last actual use, but
+            # avoids a write on every invocation if close together.
+            if (
+                is_expired
+                or self._timestamp - cached_data.timestamp
+                > _TIMESTAMP_REFRESH_SECONDS
+            ):
+                cached_data.timestamp = self._timestamp
+                self._writer.write(cached_data)
             return cached_data.session_id
         # Cache miss, generate and write new record.
         session_id = self._session_id
@@ -296,7 +345,18 @@ def _get_cli_session_orchestrator():
     )
 
 
+def is_telemetry_disabled(env=None):
+    if env is None:
+        env = os.environ
+    return ensure_boolean(env.get(_TELEMETRY_DISABLED_ENV_VAR, 'false'))
+
+
 def register_session_id_event(session, orchestrator_factory=None):
+    if is_telemetry_disabled():
+        # Skip registering the event entirely so we never open the session
+        # database. This lets users avoid the database's file locking, which
+        # can be expensive on network filesystems.
+        return
     if orchestrator_factory is None:
         orchestrator_factory = _get_cli_session_orchestrator
     event_emitter = session.get_component('event_emitter')
@@ -321,7 +381,7 @@ def register_session_id_event(session, orchestrator_factory=None):
             # Ideally, the AWS CLI should never throw if the session id
             # can't be generated since it's not critical for users. Issues
             # with session data should instead be caught server-side.
-            pass
+            LOG.debug('Failed to generate session id', exc_info=True)
         event_emitter.unregister('before-create-client', _inject_session_id)
 
     event_emitter.register('before-create-client', _inject_session_id)

--- a/tests/functional/test_telemetry.py
+++ b/tests/functional/test_telemetry.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import sqlite3
 from unittest.mock import MagicMock, patch
 
@@ -19,6 +20,7 @@ from botocore.session import Session
 
 from awscli.clidriver import create_clidriver
 from awscli.telemetry import (
+    _TIMESTAMP_REFRESH_SECONDS,
     CLISessionData,
     CLISessionDatabaseConnection,
     CLISessionDatabaseReader,
@@ -26,6 +28,7 @@ from awscli.telemetry import (
     CLISessionDatabaseWriter,
     CLISessionGenerator,
     CLISessionOrchestrator,
+    is_telemetry_disabled,
     register_session_id_event,
 )
 from tests.markers import skip_if_windows
@@ -195,6 +198,26 @@ class TestCLISessionDatabaseSweeper:
         # but the `sweep` method catches bare exceptions.
         session_sweeper.sweep({'bad': 'input'})
 
+    def test_sweep_does_not_delete_when_nothing_expired(
+        self, expired_data, session_conn, session_sweeper
+    ):
+        with patch.object(
+            session_conn, 'execute', wraps=session_conn.execute
+        ) as spy:
+            session_sweeper.sweep(1000000000)
+        queries = [call.args[0] for call in spy.call_args_list]
+        assert not any('DELETE' in query for query in queries)
+
+    def test_sweep_deletes_when_expired(
+        self, expired_data, session_conn, session_sweeper
+    ):
+        with patch.object(
+            session_conn, 'execute', wraps=session_conn.execute
+        ) as spy:
+            session_sweeper.sweep(1000000001)
+        queries = [call.args[0] for call in spy.call_args_list]
+        assert any('DELETE' in query for query in queries)
+
 
 class TestCLISessionGenerator:
     def test_generate_session_id(self, session_generator):
@@ -305,8 +328,8 @@ class TestCLISessionOrchestrator:
         session_data_1 = session_reader.read(orchestrator_1.cache_key)
         assert session_data_1.session_id == session_id_1
 
-        # Update the timestamp.
-        patched_time.return_value = 5555555556
+        # Advance past the refresh window so the timestamp is rewritten.
+        patched_time.return_value = 5555555555 + _TIMESTAMP_REFRESH_SECONDS + 1
         orchestrator_2 = CLISessionOrchestrator(
             session_generator, session_writer, session_reader, session_sweeper
         )
@@ -319,8 +342,46 @@ class TestCLISessionOrchestrator:
         assert session_data_2.session_id == session_id_2
         assert session_data_2.session_id == session_data_1.session_id
         # Only timestamp should be updated.
-        assert session_data_2.timestamp == 5555555556
+        assert (
+            session_data_2.timestamp
+            == 5555555555 + _TIMESTAMP_REFRESH_SECONDS + 1
+        )
         assert session_data_2.timestamp != session_data_1.timestamp
+
+    def test_cached_timestamp_not_rewritten_within_refresh_window(
+        self,
+        patched_tty_name,
+        patched_time,
+        patched_stdin,
+        session_sweeper,
+        session_generator,
+        session_reader,
+        session_writer,
+    ):
+        # Rewriting the timestamp takes a write lock, so an invocation within
+        # the refresh window should leave the stored record untouched.
+        patched_stdin.fileno.return_value = None
+
+        orchestrator_1 = CLISessionOrchestrator(
+            session_generator, session_writer, session_reader, session_sweeper
+        )
+        session_id_1 = orchestrator_1.session_id
+        session_data_1 = session_reader.read(orchestrator_1.cache_key)
+
+        # Advance time, but stay inside the refresh window.
+        patched_time.return_value = 5555555555 + _TIMESTAMP_REFRESH_SECONDS - 1
+        orchestrator_2 = CLISessionOrchestrator(
+            session_generator, session_writer, session_reader, session_sweeper
+        )
+        session_id_2 = orchestrator_2.session_id
+        session_data_2 = session_reader.read(orchestrator_2.cache_key)
+
+        # The same session id is still returned to the caller.
+        assert session_id_2 == session_id_1
+        assert session_data_2.session_id == session_data_1.session_id
+        # But the stored timestamp was not rewritten.
+        assert session_data_2.timestamp == session_data_1.timestamp
+        assert session_data_2.timestamp == 5555555555
 
 
 def test_register_session_id_event_injects_sid_on_before_create_client():
@@ -343,6 +404,42 @@ def test_register_session_id_event_injects_sid_on_before_create_client():
     event_emitter.unregister.assert_called_once_with(
         'before-create-client', handler
     )
+
+
+def test_is_telemetry_disabled():
+    assert is_telemetry_disabled({'AWS_CLI_TELEMETRY_DISABLED': 'true'})
+    assert not is_telemetry_disabled({'AWS_CLI_TELEMETRY_DISABLED': 'false'})
+    assert not is_telemetry_disabled({})
+
+
+def test_register_session_id_event_skipped_when_telemetry_disabled():
+    session = MagicMock(Session)
+    event_emitter = MagicMock()
+    session.get_component.return_value = event_emitter
+    orchestrator_factory = MagicMock()
+
+    with patch.dict(os.environ, {'AWS_CLI_TELEMETRY_DISABLED': 'true'}):
+        register_session_id_event(
+            session, orchestrator_factory=orchestrator_factory
+        )
+
+    # No handler is registered, so the session database is never opened.
+    event_emitter.register.assert_not_called()
+    orchestrator_factory.assert_not_called()
+
+
+def test_disabled_telemetry_does_not_create_database(tmp_path):
+    # The whole point of opting out is to avoid the database's file locking,
+    # so ensure no database file is created at all.
+    cache_dir = tmp_path / '.aws' / 'cli' / 'cache'
+    with (
+        patch.dict(os.environ, {'AWS_CLI_TELEMETRY_DISABLED': 'true'}),
+        patch('awscli.telemetry._CACHE_DIR', cache_dir),
+    ):
+        driver = create_clidriver()
+        driver.session.create_client('sts', region_name='us-east-1')
+
+    assert not cache_dir.exists()
 
 
 def test_register_session_id_event_catches_bare_exceptions():


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* CLI v2 stores a "session ID" in a SQLite database in the `~/.aws` directory. This stores a random ID that is rotated every 30 minutes, which allows some services to group command invocations together.

This makes some changes to SQLite usage to reduce lock contention on the database when multiple commands are run on the same host concurrently.
* Only writes the timestamp for the current session every 60 seconds, rather than every invocation.
* The sweeper, which deletes old sessions, first checks if any exists before writing.
* Shortens the lock timeout to 100ms, rather than the default of 5s. Session IDs are best effort.
* Also improves `--debug` logging of SQLite issues.

It also introduces the `AWS_CLI_TELEMETRY_DISABLED` environment variable, which can be set to `true` to disable the session behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
