### PR TITLE
[v2] add AWS_CLI_SESSION_ID_DISABLED environment variable

### DIFF
--- a/.changes/next-release/enhancement-telemetry-49821.json
+++ b/.changes/next-release/enhancement-telemetry-49821.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``telemetry``",
+  "description": "Add the ``AWS_CLI_SESSION_ID_DISABLED`` environment variable to opt out of session id collection."
+}

--- a/awscli/telemetry.py
+++ b/awscli/telemetry.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import io
+import logging
 import os
 import sqlite3
 import sys
@@ -24,15 +25,21 @@ from pathlib import Path
 from botocore.compat import get_md5
 from botocore.exceptions import MD5UnavailableError
 from botocore.useragent import UserAgentComponent
+from botocore.utils import ensure_boolean
 
 from awscli.compat import is_windows
 from awscli.utils import add_component_to_user_agent_extra
+
+LOG = logging.getLogger(__name__)
 
 _CACHE_DIR = Path.home() / '.aws' / 'cli' / 'cache'
 _DATABASE_FILENAME = 'session.db'
 _SESSION_LENGTH_SECONDS = 60 * 30
 _SESSION_ID_LENGTH = 12
-
+# Set to "true" to skip collecting session ids entirely. Opting out avoids
+# opening the session database, whose file locking can be expensive when the
+# database lives on a network filesystem.
+_SESSION_ID_DISABLED_ENV_VAR = 'AWS_CLI_SESSION_ID_DISABLED'
 
 def _get_checksum():
     hashlib_params = {"usedforsecurity": False}
@@ -93,6 +100,11 @@ class CLISessionDatabaseConnection:
             # Process timed out waiting for database lock.
             # Return any empty `Cursor` object instead of
             # raising an exception.
+            LOG.debug(
+                'Failed to execute session database query: %s',
+                query,
+                exc_info=True,
+            )
             return sqlite3.Cursor(self._connection)
 
     def _ensure_cache_dir(self):
@@ -130,7 +142,9 @@ class CLISessionDatabaseConnection:
         except sqlite3.Error:
             # This is just a performance enhancement so it is optional. Not all
             # systems will have a sqlite compiled with the WAL enabled.
-            pass
+            LOG.debug(
+                'Failed to enable WAL for session database', exc_info=True
+            )
 
 
 class CLISessionDatabaseWriter:
@@ -196,6 +210,7 @@ class CLISessionDatabaseSweeper:
         except Exception:
             # This is just a background cleanup task. No need to
             # handle it or direct to stderr.
+            LOG.debug('Failed to sweep session database', exc_info=True)
             return
 
 
@@ -296,7 +311,18 @@ def _get_cli_session_orchestrator():
     )
 
 
+def is_telemetry_disabled(env=None):
+    if env is None:
+        env = os.environ
+    return ensure_boolean(env.get(_SESSION_ID_DISABLED_ENV_VAR, 'false'))
+
+
 def register_session_id_event(session, orchestrator_factory=None):
+    if is_telemetry_disabled():
+        # Skip registering the event entirely so we never open the session
+        # database. This lets users avoid the database's file locking, which
+        # can be expensive on network filesystems.
+        return
     if orchestrator_factory is None:
         orchestrator_factory = _get_cli_session_orchestrator
     event_emitter = session.get_component('event_emitter')
@@ -321,7 +347,7 @@ def register_session_id_event(session, orchestrator_factory=None):
             # Ideally, the AWS CLI should never throw if the session id
             # can't be generated since it's not critical for users. Issues
             # with session data should instead be caught server-side.
-            pass
+            LOG.debug('Failed to generate session id', exc_info=True)
         event_emitter.unregister('before-create-client', _inject_session_id)
 
     event_emitter.register('before-create-client', _inject_session_id)

--- a/tests/functional/test_telemetry.py
+++ b/tests/functional/test_telemetry.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import sqlite3
 from unittest.mock import MagicMock, patch
 
@@ -26,6 +27,7 @@ from awscli.telemetry import (
     CLISessionDatabaseWriter,
     CLISessionGenerator,
     CLISessionOrchestrator,
+    is_telemetry_disabled,
     register_session_id_event,
 )
 from tests.markers import skip_if_windows
@@ -343,6 +345,41 @@ def test_register_session_id_event_injects_sid_on_before_create_client():
     event_emitter.unregister.assert_called_once_with(
         'before-create-client', handler
     )
+
+def test_is_telemetry_disabled():
+    assert is_telemetry_disabled({'AWS_CLI_SESSION_ID_DISABLED': 'true'})
+    assert not is_telemetry_disabled({'AWS_CLI_SESSION_ID_DISABLED': 'false'})
+    assert not is_telemetry_disabled({})
+
+
+def test_register_session_id_event_skipped_when_telemetry_disabled():
+    session = MagicMock(Session)
+    event_emitter = MagicMock()
+    session.get_component.return_value = event_emitter
+    orchestrator_factory = MagicMock()
+
+    with patch.dict(os.environ, {'AWS_CLI_SESSION_ID_DISABLED': 'true'}):
+        register_session_id_event(
+            session, orchestrator_factory=orchestrator_factory
+        )
+
+    # No handler is registered, so the session database is never opened.
+    event_emitter.register.assert_not_called()
+    orchestrator_factory.assert_not_called()
+
+
+def test_disabled_telemetry_does_not_create_database(tmp_path):
+    # The whole point of opting out is to avoid the database's file locking,
+    # so ensure no database file is created at all.
+    cache_dir = tmp_path / '.aws' / 'cli' / 'cache'
+    with (
+        patch.dict(os.environ, {'AWS_CLI_SESSION_ID_DISABLED': 'true'}),
+        patch('awscli.telemetry._CACHE_DIR', cache_dir),
+    ):
+        driver = create_clidriver()
+        driver.session.create_client('sts', region_name='us-east-1')
+
+    assert not cache_dir.exists()
 
 
 def test_register_session_id_event_catches_bare_exceptions():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

CLI v2 stores a "session ID" in a SQLite database in the `~/.aws` directory. This stores a random ID that is rotated every 30 minutes, which allows some services to group command invocations together.

This introduces the `AWS_CLI_SESSION_ID_DISABLED` environment variable, which can be set to `true` to disable the session behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
