### PR TITLE
Parallelize CloudTrail log validation

### DIFF
--- a/.changes/next-release/feature-cloudtrail-10516.json
+++ b/.changes/next-release/feature-cloudtrail-10516.json
@@ -1,0 +1,5 @@
+{
+  "category": "``cloudtrail validate-logs``",
+  "description": "Parallelize log file download and hash verification with a configurable ``--concurrent-requests`` limit. Fixes `#10516 <https://github.com/aws/aws-cli/issues/10516>`__.",
+  "type": "feature"
+}

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -18,7 +18,9 @@ import logging
 import re
 import sys
 import zlib
+from concurrent.futures import ThreadPoolExecutor
 from datetime import timedelta
+from threading import Lock
 from zlib import error as ZLibError
 
 import rsa
@@ -38,6 +40,13 @@ from awscli.utils import create_nested_client
 LOG = logging.getLogger(__name__)
 DATE_FORMAT = '%Y%m%dT%H%M%SZ'
 DISPLAY_DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+DEFAULT_CONCURRENT_REQUESTS = 10
+
+_LOG_VALID = 'valid'
+_LOG_INVALID_FORMAT = 'invalid-format'
+_LOG_INVALID_HASH = 'invalid-hash'
+_LOG_MISSING = 'missing'
+_LOG_TRAILING_DATA = 'trailing-data'
 
 
 def format_date(date):
@@ -201,11 +210,13 @@ class S3ClientProvider:
         self._get_bucket_location_region = get_bucket_location_region
         self._client_cache = {}
         self._region_cache = {}
+        self._lock = Lock()
 
     def get_client(self, bucket_name):
         """Creates an S3 client that can work with the given bucket name"""
-        region_name = self._get_bucket_region(bucket_name)
-        return self._create_client(region_name)
+        with self._lock:
+            region_name = self._get_bucket_region(bucket_name)
+            return self._create_client(region_name)
 
     def _get_bucket_region(self, bucket_name):
         """Returns the region of a bucket"""
@@ -975,6 +986,16 @@ class CloudTrailValidateLogs(BasicCommand):
             'action': 'store_true',
             'help_text': 'Display verbose log validation information',
         },
+        {
+            'name': 'concurrent-requests',
+            'cli_type_name': 'integer',
+            'default': DEFAULT_CONCURRENT_REQUESTS,
+            'help_text': (
+                'Maximum number of concurrent log file downloads. The '
+                f'default is {DEFAULT_CONCURRENT_REQUESTS}. Set this value '
+                'to 1 to download log files sequentially.'
+            ),
+        },
     ]
 
     def __init__(self, session):
@@ -988,6 +1009,7 @@ class CloudTrailValidateLogs(BasicCommand):
         self.s3_client_provider = None
         self.cloudtrail_client = None
         self.account_id = None
+        self.concurrent_requests = DEFAULT_CONCURRENT_REQUESTS
         self._source_region = None
         self._valid_digests = 0
         self._invalid_digests = 0
@@ -1016,6 +1038,12 @@ class CloudTrailValidateLogs(BasicCommand):
         self.s3_bucket = args.s3_bucket
         self.s3_prefix = args.s3_prefix
         self.account_id = args.account_id
+        self.concurrent_requests = args.concurrent_requests
+        if self.concurrent_requests < 1:
+            raise ValueError(
+                'Invalid value for concurrent-requests: must be a positive '
+                'integer'
+            )
         self.start_time = normalize_date(parse_date(args.start_time))
         if args.end_time:
             self.end_time = normalize_date(parse_date(args.end_time))
@@ -1063,43 +1091,44 @@ class CloudTrailValidateLogs(BasicCommand):
         )
         self._write_startup_text()
 
-        digests = traverser.traverse_digests(
-            self.start_time, self.end_time, is_backfill=False
-        )
-        for digest in digests:
-            # Only valid digests are yielded and only valid digests can adjust
-            # the found times that are reported in the CLI output summary.
-            self._track_found_times(digest)
-
-            self._valid_digests += 1
-
-            self._write_status(
-                f'Digest file\ts3://{digest["digestS3Bucket"]}/{digest["digestS3Object"]}\tvalid'
+        with ThreadPoolExecutor(
+            max_workers=self.concurrent_requests
+        ) as executor:
+            digests = traverser.traverse_digests(
+                self.start_time, self.end_time, is_backfill=False
             )
+            for digest in digests:
+                # Only valid digests are yielded and only valid digests can
+                # adjust the found times that are reported in the CLI output
+                # summary.
+                self._track_found_times(digest)
 
-            if not digest['logFiles']:
-                continue
-            for log in digest['logFiles']:
-                self._download_log(log)
+                self._valid_digests += 1
 
-        backfill_digests = traverser.traverse_digests(
-            self.start_time, self.end_time, is_backfill=True
-        )
-        for digest in backfill_digests:
-            # Only valid digests are yielded and only valid digests can adjust
-            # the found times that are reported in the CLI output summary.
-            self._track_found_times(digest)
+                self._write_status(
+                    f'Digest file\ts3://{digest["digestS3Bucket"]}/{digest["digestS3Object"]}\tvalid'
+                )
 
-            self._valid_backfill_digests += 1
+                if digest['logFiles']:
+                    self._download_logs(digest['logFiles'], executor)
 
-            self._write_status(
-                f'(backfill) Digest file\ts3://{digest["digestS3Bucket"]}/{digest["digestS3Object"]}\tvalid'
+            backfill_digests = traverser.traverse_digests(
+                self.start_time, self.end_time, is_backfill=True
             )
+            for digest in backfill_digests:
+                # Only valid digests are yielded and only valid digests can
+                # adjust the found times that are reported in the CLI output
+                # summary.
+                self._track_found_times(digest)
 
-            if not digest['logFiles']:
-                continue
-            for log in digest['logFiles']:
-                self._download_log(log)
+                self._valid_backfill_digests += 1
+
+                self._write_status(
+                    f'(backfill) Digest file\ts3://{digest["digestS3Bucket"]}/{digest["digestS3Object"]}\tvalid'
+                )
+
+                if digest['logFiles']:
+                    self._download_logs(digest['logFiles'], executor)
 
         self._write_summary_text()
 
@@ -1120,8 +1149,22 @@ class CloudTrailValidateLogs(BasicCommand):
         if not self._found_end_time or latest_end_time > self._found_end_time:
             self._found_end_time = latest_end_time
 
+    def _download_logs(self, logs, executor):
+        if self.concurrent_requests == 1 or len(logs) == 1:
+            results = [self._download_log(log) for log in logs]
+        else:
+            futures = [
+                executor.submit(self._download_log, log) for log in logs
+            ]
+            # Resolve futures in input order so status output remains
+            # deterministic even when downloads complete out of order.
+            results = [future.result() for future in futures]
+
+        for log, result in zip(logs, results):
+            self._record_log_result(log, result)
+
     def _download_log(self, log):
-        """Download a log, decompress, and compare SHA256 checksums"""
+        """Download and validate one log without mutating command state."""
         try:
             # Create a client that can work with this bucket.
             client = self.s3_client_provider.get_client(log['s3Bucket'])
@@ -1137,21 +1180,31 @@ class CloudTrailValidateLogs(BasicCommand):
             if remaining_data:
                 rolling_hash.update(remaining_data)
             if gzip_inflater.unused_data:
-                self._on_log_trailing_data(log)
-                return
+                return _LOG_TRAILING_DATA
             computed_hash = rolling_hash.hexdigest()
             if computed_hash != log['hashValue']:
-                self._on_log_invalid(log)
-            else:
-                self._valid_logs += 1
-                self._write_status(
-                    f'Log file\ts3://{log["s3Bucket"]}/{log["s3Object"]}\tvalid'
-                )
+                return _LOG_INVALID_HASH
+            return _LOG_VALID
         except ClientError as e:
             if e.response['Error']['Code'] != 'NoSuchKey':
                 raise
-            self._on_missing_log(log)
+            return _LOG_MISSING
         except Exception:
+            return _LOG_INVALID_FORMAT
+
+    def _record_log_result(self, log, result):
+        if result == _LOG_VALID:
+            self._valid_logs += 1
+            self._write_status(
+                f'Log file\ts3://{log["s3Bucket"]}/{log["s3Object"]}\tvalid'
+            )
+        elif result == _LOG_INVALID_HASH:
+            self._on_log_invalid(log)
+        elif result == _LOG_MISSING:
+            self._on_missing_log(log)
+        elif result == _LOG_TRAILING_DATA:
+            self._on_log_trailing_data(log)
+        else:
             self._on_invalid_log_format(log)
 
     def _write_status(self, message, is_error=False):

--- a/tests/functional/cloudtrail/test_validation.py
+++ b/tests/functional/cloudtrail/test_validation.py
@@ -446,6 +446,16 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         self.assertIn('start-time must occur before end-time', stderr)
 
+    def test_ensures_concurrent_requests_is_positive(self):
+        stdout, stderr, rc = self.run_cmd(
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} "
+            f"--start-time {START_TIME_ARG} --concurrent-requests 0",
+            255,
+        )
+        self.assertIn(
+            'concurrent-requests: must be a positive integer', stderr
+        )
+
     def test_fails_when_digest_not_from_same_location_as_json_contents(self):
         key_provider, digest_provider, validator = create_scenario(['gap'], [])
 

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -16,7 +16,9 @@ import gzip
 import hashlib
 import json
 from argparse import Namespace
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
+from threading import Event
 
 import rsa
 from botocore.exceptions import ClientError
@@ -1564,15 +1566,82 @@ class TestCloudTrailCommand(BaseAWSCommandParamsTest):
             s3_prefix='prefix',
             end_time=None,
             account_id=None,
+            concurrent_requests=4,
         )
         command.handle_args(args)
         self.assertEqual('abc', command.trail_arn)
         self.assertEqual(True, command.is_verbose)
         self.assertEqual('bucket', command.s3_bucket)
         self.assertEqual('prefix', command.s3_prefix)
+        self.assertEqual(4, command.concurrent_requests)
         self.assertEqual(start_date, command.start_time.strftime(DATE_FORMAT))
         self.assertIsNotNone(command.end_time)
         self.assertGreater(command.end_time, command.start_time)
+
+    def test_rejects_non_positive_concurrent_requests(self):
+        command = CloudTrailValidateLogs(mock.Mock())
+        args = Namespace(
+            trail_arn='abc',
+            verbose=False,
+            start_time=START_DATE.strftime(DATE_FORMAT),
+            s3_bucket='bucket',
+            s3_prefix=None,
+            end_time=None,
+            account_id=None,
+            concurrent_requests=0,
+        )
+        with self.assertRaisesRegex(ValueError, 'must be a positive integer'):
+            command.handle_args(args)
+
+    def test_downloads_logs_concurrently_and_records_in_input_order(self):
+        command = CloudTrailValidateLogs(mock.Mock())
+        command.concurrent_requests = 2
+        command.is_verbose = True
+        command.s3_client_provider = mock.Mock()
+        client = command.s3_client_provider.get_client.return_value
+        second_completed = Event()
+        logs = [
+            {
+                's3Bucket': 'bucket',
+                's3Object': 'first',
+                'hashValue': hashlib.sha256(b'{}').hexdigest(),
+            },
+            {
+                's3Bucket': 'bucket',
+                's3Object': 'second',
+                'hashValue': 'invalid-hash',
+            },
+        ]
+
+        def get_object(Bucket, Key):
+            if Key == 'first':
+                if not second_completed.wait(timeout=2):
+                    raise AssertionError('log downloads did not overlap')
+            else:
+                second_completed.set()
+            return {'Body': BytesIO(gzip.compress(b'{}'))}
+
+        client.get_object.side_effect = get_object
+        command._write_status = mock.Mock()
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            command._download_logs(logs, executor)
+
+        self.assertEqual(
+            command.s3_client_provider.get_client.call_args_list,
+            [mock.call('bucket'), mock.call('bucket')],
+        )
+        self.assertEqual(1, command._valid_logs)
+        self.assertEqual(1, command._invalid_logs)
+        self.assertEqual(
+            command._write_status.call_args_list,
+            [
+                mock.call('Log file\ts3://bucket/first\tvalid'),
+                mock.call(
+                    "Log file\ts3://bucket/second\tINVALID: hash value doesn't match",
+                    True,
+                ),
+            ],
+        )
 
 
 class TestS3ClientProvider(BaseAWSCommandParamsTest):


### PR DESCRIPTION
## Description

Parallelize CloudTrail log file download and SHA-256 verification within each validated digest. Digest-chain traversal and signature verification remain sequential.

The implementation uses a bounded thread pool with a default of 10 workers and adds `--concurrent-requests` to configure the limit. Passing `--concurrent-requests 1` retains sequential downloads. Validation results are applied on the main thread in digest order so verbose output, counters, and exit behavior remain deterministic.

The shared S3 client provider cache is protected during concurrent access.

## Testing

- `pytest -q tests/unit/customizations/cloudtrail tests/functional/cloudtrail` (118 passed)
- `ruff check` on modified Python files
- `ruff format --check` on modified Python files
- `isort --check-only` on modified Python files

Fixes #10516

Generated by AI tools, and reviewed by Ali Satwat Khan.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
