### PR TITLE
fix: update Python 3 compatibility for setup.py and tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def read(*parts):
 
 def find_version(*file_paths):
     version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+    version_match = re.search(r"^__version__\s*=\s*['\"]([^'\"]*)['\"]",
                               version_file, re.M)
     if version_match:
         return version_match.group(1)
@@ -81,8 +81,8 @@ if 'py2exe' in sys.argv:
             'optimize': 0,
             'skip_archive': True,
             'dll_excludes': ['crypt32.dll'],
-            'packages': ['docutils', 'urllib', 'httplib', 'HTMLParser',
-                         'awscli', 'ConfigParser', 'xml.etree', 'pipes'],
+            'packages': ['docutils', 'urllib', 'http.client', 'html.parser',
+                         'awscli', 'configparser', 'xml.etree', 'pipes'],
         }
     }
     setup_options['console'] = ['bin/aws']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -277,7 +277,7 @@ class HTTPRequest(object):
         return not self.__eq__(other)
 
 
-# CaseInsensitiveDict from requests that must be serializble.
+# CaseInsensitiveDict from requests that must be serializable.
 class CaseInsensitiveDict(collections_abc.MutableMapping):
     def __init__(self, data=None, **kwargs):
         self._store = dict()
@@ -320,7 +320,7 @@ class CaseInsensitiveDict(collections_abc.MutableMapping):
 
     # Copy is required
     def copy(self):
-        return CaseInsensitiveDict(self._store.values())
+        return CaseInsensitiveDict(dict(self._store.values()))
 
     def __repr__(self):
         return str(dict(self.items()))

--- a/tests/unit/test_setup.py
+++ b/tests/unit/test_setup.py
@@ -1,0 +1,68 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+
+def load_setup_module(argv=None):
+    setup_path = Path(__file__).parents[2] / "setup.py"
+    spec = importlib.util.spec_from_file_location(
+        "awscli_setup",
+        setup_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+
+    if argv is None:
+        argv = ["setup.py"]
+
+    with (
+        mock.patch.object(sys, "argv", argv),
+        mock.patch.dict(sys.modules, {"py2exe": mock.Mock()}),
+        mock.patch("setuptools.setup"),
+    ):
+        spec.loader.exec_module(module)
+
+    return module
+
+
+class TestFindVersion:
+    def test_finds_version_without_spaces_around_equals(self):
+        setup_module = load_setup_module()
+
+        with mock.patch.object(
+            setup_module,
+            "read",
+            return_value="__version__='1.2.3'",
+        ):
+            assert setup_module.find_version(
+                "awscli",
+                "__init__.py",
+            ) == "1.2.3"
+
+    def test_finds_version_with_multiple_spaces_around_equals(self):
+        setup_module = load_setup_module()
+
+        with mock.patch.object(
+            setup_module,
+            "read",
+            return_value="__version__  =  '1.2.3'",
+        ):
+            assert setup_module.find_version(
+                "awscli",
+                "__init__.py",
+            ) == "1.2.3"
+
+
+class TestPy2ExeOptions:
+    def test_uses_python3_package_names(self):
+        setup_module = load_setup_module(["setup.py", "py2exe"])
+
+        packages = setup_module.setup_options["options"]["py2exe"]["packages"]
+
+        assert "http.client" in packages
+        assert "html.parser" in packages
+        assert "configparser" in packages
+
+        assert "httplib" not in packages
+        assert "HTMLParser" not in packages
+        assert "ConfigParser" not in packages

--- a/tests/unit/test_tests_init.py
+++ b/tests/unit/test_tests_init.py
@@ -1,0 +1,19 @@
+from tests import CaseInsensitiveDict
+
+
+class TestCaseInsensitiveDict:
+    def test_copy_returns_independent_dictionary(self):
+        original = CaseInsensitiveDict({
+            "Content-Type": "application/json",
+            "X-Test": "value",
+        })
+
+        copied = original.copy()
+
+        assert copied == original
+        assert copied is not original
+
+        copied["X-Test"] = "changed"
+
+        assert original["X-Test"] == "value"
+        assert copied["X-Test"] == "changed"


### PR DESCRIPTION
## Summary

This PR improves Python 3 compatibility by updating `CaseInsensitiveDict.copy()`, relaxing the version parsing regex in `setup.py`, replacing legacy `py2exe` package names, and adding tests for the updated behavior.

### Changes

- Update `CaseInsensitiveDict.copy()` to construct a new instance from a `dict` instead of a raw `dict_values` view.
- Fix the `serializable` typo in the `CaseInsensitiveDict` comment.
- Relax the version parsing regex in `setup.py` to support flexible whitespace around `=`.
- Replace legacy Python 2 `py2exe` package names with their Python 3 equivalents (`http.client`, `html.parser`, and `configparser`).
- Add unit tests covering the updated version parsing, Python 3 package names, and `CaseInsensitiveDict.copy()` behavior.

### Testing

```bash
python -m pytest tests/unit/test_setup.py tests/unit/test_tests_init.py -v
python setup.py --version
```
All added tests passed.

Fixes #10492