### PR TITLE
fix(text): don't crash on --query lists mixing scalars and objects

### DIFF
--- a/.changes/next-release/bugfix-text-output-mixed-list.json
+++ b/.changes/next-release/bugfix-text-output-mixed-list.json
@@ -1,0 +1,5 @@
+{
+  "category": "``text`` output",
+  "description": "Fix ``AttributeError`` when ``--output text`` renders a list that contains both a scalar and an object, which a ``--query`` multi-select list such as ``[InstanceId, State]`` produces",
+  "type": "bugfix"
+}

--- a/awscli/text.py
+++ b/awscli/text.py
@@ -85,6 +85,11 @@ def _format_dict(scalar_keys, item, identifier, stream):
 def _all_scalar_keys(list_of_dicts):
     keys_seen = set()
     for item_dict in list_of_dicts:
+        if not isinstance(item_dict, dict):
+            # The list is only required to contain *at least* one dict,
+            # so skip over any elements that aren't dicts.  They are
+            # rendered on their own by _format_text.
+            continue
         for key, value in item_dict.items():
             if not isinstance(value, (dict, list)):
                 keys_seen.add(key)

--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -219,6 +219,22 @@ class TestSection(unittest.TestCase):
             'FOO\th\n'
         )
 
+    def test_dicts_mixed_with_scalars(self):
+        # A --query multi-select list such as '[InstanceId, State]'
+        # produces a list holding both a scalar and a dict.
+        self.assert_text_renders_to(
+            ['i-123', dict(Code=16, Name='running')],
+            'i-123\n'
+            '16\trunning\n'
+        )
+
+    def test_dicts_mixed_with_lists(self):
+        self.assert_text_renders_to(
+            [['a', 'b'], dict(Code=16, Name='running')],
+            'a\tb\n'
+            '16\trunning\n'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**What's broken**

`--output text` exits 255 on a `--query` multi-select list that mixes a scalar with an object. `--output json` handles the same data fine.

```
$ aws ec2 describe-instances --output text \
    --query '[Reservations[0].Instances[0].InstanceId, Reservations[0].Instances[0].State]'
AttributeError: 'str' object has no attribute 'items'
```

`[InstanceId, State]` is ordinary JMESPath — `InstanceId` is a string and `State` is an object — so any query of that shape kills the command. Nothing is printed at all.

**Why it happens**

`_format_list` decides a list is "a list of dicts" if *any* element is a dict:

```python
if any(isinstance(el, dict) for el in item):
    all_keys = _all_scalar_keys(item)
```

but `_all_scalar_keys` then calls `.items()` on *every* element, so one non-dict in the list raises. The sibling branch for nested lists already tolerates mixed content (`_partition_list`); this branch did not.

**The fix**

Skip non-dict elements when collecting scalar keys. The loop right below already routes each element through `_format_text`, which renders scalars and nested lists on their own — so the mixed list now prints:

```
i-123
16	running
```

**The test**

`test_dicts_mixed_with_scalars` and `test_dicts_mixed_with_lists` in `tests/unit/test_text.py`. Both fail on `develop` with the `AttributeError` and pass with the fix:

```
$ python -m pytest tests/unit/test_text.py -k dicts_mixed     # before
E   AttributeError: 'str' object has no attribute 'items'
2 failed, 25 deselected

$ python -m pytest tests/unit/test_text.py                    # after
27 passed
```

`tests/unit/test_text.py tests/unit/output/ tests/unit/test_table.py` — 59 passed.
