### PR TITLE
fix(table): don't crash on --query lists mixing scalars and objects

### DIFF
--- a/.changes/next-release/bugfix-table-output-mixed-list.json
+++ b/.changes/next-release/bugfix-table-output-mixed-list.json
@@ -1,0 +1,5 @@
+{
+  "category": "``table`` output",
+  "description": "Fix ``ValueError`` when ``--output table`` renders a list that contains both a scalar and an object, which a ``--query`` multi-select list such as ``[InstanceId, State]`` produces",
+  "type": "bugfix"
+}

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -137,10 +137,27 @@ class TableFormatter(FullyBufferedFormatter):
         if title is not None:
             self.table.new_section(title, indent_level=indent_level)
         if isinstance(current, list):
-            if isinstance(current[0], dict):
+            if all(isinstance(el, dict) for el in current):
                 self._build_sub_table_from_list(current, indent_level, title)
             else:
-                for item in current:
+                # The elements don't all share a shape, so a dict can't be
+                # rendered as a row alongside them.  Give it a section of
+                # its own, and start a new one for whatever follows it.
+                needs_new_section = False
+                for i, item in enumerate(current):
+                    if isinstance(item, dict):
+                        if i > 0:
+                            self.table.new_section(
+                                title, indent_level=indent_level
+                            )
+                        self._build_sub_table_from_dict(item, indent_level)
+                        needs_new_section = True
+                        continue
+                    if needs_new_section:
+                        self.table.new_section(
+                            title, indent_level=indent_level
+                        )
+                        needs_new_section = False
                     if self._scalar_type(item):
                         self.table.add_row([item])
                     elif all(self._scalar_type(el) for el in item):

--- a/tests/unit/output/test_table_formatter.py
+++ b/tests/unit/output/test_table_formatter.py
@@ -362,6 +362,41 @@ JMESPATH_FILTERED_RESPONSE_DICT_TABLE = """\
 """
 
 
+# A --query multi-select list such as '[InstanceId, State]' returns a list
+# holding both a scalar and an object.
+MIXED_SCALAR_FIRST = ["i-123", {"Code": 16, "Name": "running"}]
+
+MIXED_SCALAR_FIRST_TABLE = """\
+---------------------
+|   OperationName   |
++-------------------+
+|  i-123            |
++-------------------+
+|   OperationName   |
++-------+-----------+
+| Code  |   Name    |
++-------+-----------+
+|  16   |  running  |
++-------+-----------+
+"""
+
+MIXED_DICT_FIRST = [{"Code": 16, "Name": "running"}, "i-123"]
+
+MIXED_DICT_FIRST_TABLE = """\
+---------------------
+|   OperationName   |
++-------+-----------+
+| Code  |   Name    |
++-------+-----------+
+|  16   |  running  |
++-------+-----------+
+|   OperationName   |
++-------------------+
+|  i-123            |
++-------------------+
+"""
+
+
 class Object(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
@@ -425,3 +460,11 @@ class TestTableFormatter(unittest.TestCase):
     def test_jmespath_filtered_dict_response(self):
         self.assert_data_renders_to(data=JMESPATH_FILTERED_RESPONSE_DICT,
                                     table=JMESPATH_FILTERED_RESPONSE_DICT_TABLE)
+
+    def test_mixed_list_with_leading_scalar(self):
+        self.assert_data_renders_to(data=MIXED_SCALAR_FIRST,
+                                    table=MIXED_SCALAR_FIRST_TABLE)
+
+    def test_mixed_list_with_leading_dict(self):
+        self.assert_data_renders_to(data=MIXED_DICT_FIRST,
+                                    table=MIXED_DICT_FIRST_TABLE)


### PR DESCRIPTION
**What's broken**

`--output table` exits 255 on a `--query` multi-select list that mixes a scalar with an object. `--output json` handles the same data fine.

```
$ aws ec2 describe-instances --output table \
    --query '[Reservations[0].Instances[0].InstanceId, Reservations[0].Instances[0].State]'
ValueError: Row should have 1 elements, instead it has 2
```

When the column counts happen to line up it's quieter but worse — the object's **keys** are printed as a data row and the values are dropped:

```
$ aws ... --output table --query '[[a, b], State]'
+----+-----+
|  a |  b  |
| Code | Name |     <- the 16 / "running" values are gone
+----+-----+
```

**Why it happens**

`_build_table` decided how to treat a list from `current[0]` alone. If element 0 isn't a dict, every element falls to the row branch — and a dict passes `all(self._scalar_type(el) for el in item)` there, because that iterates the dict's *keys*. It's then added as a row of keys, which either loses the values or trips `Section.add_row`'s column-count check.

**The fix**

Route on whether *every* element is a dict rather than just the first, and give a dict inside a mixed list a section of its own (the same thing `_build_sub_table_from_list` already does per element). Homogeneous lists of dicts and lists of lists take exactly the path they did before.

```
|  i-123            |
+-------------------+
|   OperationName   |
+-------+-----------+
| Code  |   Name    |
+-------+-----------+
|  16   |  running  |
```

**The test**

`test_mixed_list_with_leading_scalar` and `test_mixed_list_with_leading_dict` in `tests/unit/output/test_table_formatter.py`. Both fail on `develop` and pass with the fix:

```
$ python -m pytest tests/unit/output/test_table_formatter.py -k mixed_list   # before
E   ValueError: Row should have 1 elements, instead it has 2
2 failed, 9 deselected

$ python -m pytest tests/unit                                                # after
2876 passed, 1 skipped
```
