### PR TITLE
Update add-tags-to-resource.rst with corrected CLI command example

### DIFF
--- a/awscli/examples/elasticache/add-tags-to-resource.rst
+++ b/awscli/examples/elasticache/add-tags-to-resource.rst
@@ -4,8 +4,7 @@ The following ``add-tags-to-resource`` example adds up to 10 tags, key-value pai
 
     aws elasticache add-tags-to-resource \
         --resource-name "arn:aws:elasticache:us-east-1:1234567890:cluster:my-mem-cluster" \
-        --tags '{"20150202":15, "ElastiCache":"Service"}'
-
+        --tags Key="APIVersion",Value="20150202" Key="Service",Value="ElastiCache"
 
 Output::
 


### PR DESCRIPTION
***Issue #, if available:***
AWS CLI version: aws-cli/2.36.11

The example cli command throws the following error: 
aws: [ERROR]: An error occurred (ParamValidation): Parameter validation failed:
Unknown parameter in Tags[0]: "20150202", must be one of: Key, Value
Unknown parameter in Tags[0]: "ElastiCache", must be one of: Key, Value

***Description of changes:***
Fix the CLI command example with corrected format

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
