### PR TITLE
Update information about maintenance mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,12 +18,12 @@ Jump to:
 AWS CLI v1 is in Maintenance Mode
 ------------------------------------------
 
-We `announced <https://github.com/aws/aws-cli/issues/10536/>`__
+We `announced <https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/>`__
 the upcoming **end-of-support for the AWS CLI v1**. We recommend
 that you migrate to
 `AWS CLI v2 <https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html>`__.
 For dates, additional details, and information on how to migrate,
-please refer to the linked announcement.
+please refer to the linked blog post, our `update regarding dependency versions <https://aws.amazon.com/blogs/developer/aws-cli-v1-maintenance-mode-announcing-changes-to-dependency-updates/>`__, and our recent `GitHub announcement <https://github.com/aws/aws-cli/issues/10536>`__.
 
 Getting Started
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,10 @@ Jump to:
 -  `More Resources <#more-resources>`__
 
 
-Entering Maintenance Mode on July 15, 2026
+AWS CLI v1 is in Maintenance Mode
 ------------------------------------------
 
-We `announced <https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/>`__
+We `announced <https://github.com/aws/aws-cli/issues/10536/>`__
 the upcoming **end-of-support for the AWS CLI v1**. We recommend
 that you migrate to
 `AWS CLI v2 <https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html>`__.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Updated the section title to reflect we are currently in maintenance mode, and changed the link from the old blog post to the GitHub announcement.  I considered leaving the blog post link in, but it technically has incorrect dates, the GitHub issue does link to the blog, and mirrors all other information with better wording.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
