### PR TITLE
[v2] Avoid PSModulePath inheritance during update on Windows

### DIFF
--- a/.changes/next-release/bugfix-update-40840.json
+++ b/.changes/next-release/bugfix-update-40840.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``update``",
+  "description": "Reset PSModulePath before launching new PowerShell console to avoid inheriting an incompatible PSModulePath"
+}

--- a/awscli/customizations/update.py
+++ b/awscli/customizations/update.py
@@ -211,6 +211,10 @@ class WindowsUpdateCommand(BaseUpdateCommand):
             f.write('set AWS_CLI_DISTRIBUTION_SOURCE_OVERRIDE=update-exe\n')
             if self._no_color:
                 f.write('set NO_COLOR=1\n')
+            # Clear the inherited PSModulePath so the launched PowerShell
+            # rebuilds its own default.
+            # https://github.com/aws/aws-cli/issues/10532
+            f.write('set PSModulePath=\n')
             f.write('ping -n 3 127.0.0.1 >nul 2>&1\n')
             f.write(f'"{ps_exe}" {ps_args}\n')
 
@@ -228,10 +232,13 @@ class WindowsUpdateCommand(BaseUpdateCommand):
         )
 
     def _find_powershell(self):
-        path = shutil.which('powershell')
-        if not path:
-            raise UpdateError('powershell.exe not found on PATH.')
-        return path
+        for name in ('powershell', 'pwsh'):
+            path = shutil.which(name)
+            if path:
+                return path
+        raise UpdateError(
+            'Neither powershell.exe nor pwsh.exe was found on PATH.'
+        )
 
     def _is_system_install(self, install_metadata):
         if 'script_install' in install_metadata:

--- a/tests/unit/customizations/test_update.py
+++ b/tests/unit/customizations/test_update.py
@@ -222,7 +222,14 @@ class TestUnixUpdateCommand:
 
 
 class TestWindowsUpdateCommand:
-    def _command(self, install, elevated=True, runner=None, downloader=None):
+    def _command(
+        self,
+        install,
+        elevated=True,
+        runner=None,
+        downloader=None,
+        powershell_path='powershell.exe',
+    ):
         return WindowsUpdateCommand(
             mock_session(),
             source='exe',
@@ -230,7 +237,7 @@ class TestWindowsUpdateCommand:
             downloader=downloader or mock.Mock(),
             is_elevated=elevated,
             runner=runner or mock.Mock(),
-            powershell_path='powershell.exe',
+            powershell_path=powershell_path,
         )
 
     def _run(self, install, color='auto', **kwargs):
@@ -274,6 +281,46 @@ class TestWindowsUpdateCommand:
         _, wrapper = self._run(USER_INSTALL, color='off')
 
         assert 'set NO_COLOR=1' in wrapper
+
+    def test_wrapper_clears_psmodulepath(self):
+        _, wrapper = self._run(USER_INSTALL)
+
+        assert 'set PSModulePath=\n' in wrapper
+
+    def test_prefers_windows_powershell_when_available(self, monkeypatch):
+        def which(name):
+            return {
+                'powershell': 'C:\\powershell.exe',
+                'pwsh': 'C:\\pwsh.exe',
+            }.get(name)
+
+        monkeypatch.setattr(update_module.shutil, 'which', which)
+
+        _, wrapper = self._run(USER_INSTALL, powershell_path=None)
+
+        assert '"C:\\powershell.exe" -NoProfile' in wrapper
+
+    def test_falls_back_to_pwsh_when_windows_powershell_missing(
+        self, monkeypatch
+    ):
+        def which(name):
+            return 'C:\\pwsh.exe' if name == 'pwsh' else None
+
+        monkeypatch.setattr(update_module.shutil, 'which', which)
+
+        _, wrapper = self._run(USER_INSTALL, powershell_path=None)
+
+        assert '"C:\\pwsh.exe" -NoProfile' in wrapper
+
+    def test_raises_when_no_powershell_found(self, monkeypatch):
+        def which(name):
+            return None
+
+        monkeypatch.setattr(update_module.shutil, 'which', which)
+        command = self._command(USER_INSTALL, powershell_path=None)
+
+        with pytest.raises(UpdateError, match='Neither powershell'):
+            command([], global_args())
 
     def test_system_install_requires_elevation(self):
         runner = mock.Mock()


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/10532

Currently, `update` launches a PS5 console via `powershell.exe` when running the install script. This causes an issue where if the `update` command is run within a PS7 console, the PS5 execution inherits PS7's `PSModulePath` env var value, leading to path issues when the install script attempts to run `Get-AuthenticodeSignature`.

This PR fixes the issue by removing `PSModulePath` before launching PS5, letting it rebuild its default `PSModulePath` value. The PR also falls back to `pwsh.exe` (PS7) if `powershell.exe` isn't available when resolving the PowerShell path.