### PR TITLE
Fix start-anchored validation and escaping in ddb lexer and codeartifact npm login

### DIFF
--- a/.changes/next-release/bugfix-codeartifact-37928.json
+++ b/.changes/next-release/bugfix-codeartifact-37928.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "codeartifact",
+  "description": "Fix ``aws codeartifact login --tool npm`` so that the ``--namespace`` scope name is validated in full. Previously only the start of the name was checked, allowing invalid scope names through to ``npm config set``."
+}

--- a/.changes/next-release/bugfix-ddb-64481.json
+++ b/.changes/next-release/bugfix-ddb-64481.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ddb",
+  "description": "Fix ``aws ddb`` expression parsing so that an escaped backslash in a quoted string or identifier resolves to a single backslash instead of two."
+}

--- a/.changes/next-release/bugfix-ddb-66340.json
+++ b/.changes/next-release/bugfix-ddb-66340.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ddb",
+  "description": "Fix ``aws ddb`` expression parsing so that a base64 literal is validated in full. Previously trailing invalid characters, e.g. ``b\"AAAA!!!!\"``, were accepted and silently discarded, producing a truncated binary value."
+}

--- a/.changes/next-release/bugfix-ddb-88856.json
+++ b/.changes/next-release/bugfix-ddb-88856.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ddb",
+  "description": "Fix the ``start``/``end`` offsets reported for quoted tokens in ``aws ddb`` expression errors so the offending token is underlined correctly."
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -478,7 +478,7 @@ class NpmLogin(BaseLogin):
     @classmethod
     def get_scope(cls, namespace):
         # Regex for valid scope name
-        valid_scope_name = re.compile('^(@[a-z0-9-~][a-z0-9-._~]*)')
+        valid_scope_name = re.compile(r'\A@[a-z0-9-~][a-z0-9-._~]*\Z')
 
         if namespace is None:
             return namespace

--- a/awscli/customizations/dynamodb/lexer.py
+++ b/awscli/customizations/dynamodb/lexer.py
@@ -145,24 +145,22 @@ class Lexer:
 
     def _consume_quoted_identifier(self):
         start = self._position
-        lexeme = self._consume_until("'").replace("\\'", "'")
-        token_len = self._position - start
+        lexeme = self._consume_until("'")
         return {
             'type': 'identifier',
             'value': lexeme,
             'start': start,
-            'end': token_len,
+            'end': self._offset(),
         }
 
     def _consume_string_literal(self):
         start = self._position
-        lexeme = self._consume_until('"').replace('\\"', '"')
-        token_len = self._position - start
+        lexeme = self._consume_until('"')
         return {
             'type': 'literal',
             'value': lexeme,
             'start': start,
-            'end': token_len,
+            'end': self._offset(),
         }
 
     def _consume_base64_string(self):
@@ -170,8 +168,11 @@ class Lexer:
         raw_string = self._consume_string_literal()
 
         # Python will simply ignore invalid characters, so we have to
-        # validate manually.
-        if raw_string['value'] and not VALID_BASE64.match(raw_string['value']):
+        # validate manually.  This has to match the *entire* string,
+        # otherwise trailing invalid characters are silently dropped.
+        if raw_string['value'] and not VALID_BASE64.fullmatch(
+            raw_string['value']
+        ):
             message = 'Invalid base64 string b"%s"'
             raise LexerError(
                 message=message % raw_string['value'],
@@ -297,15 +298,25 @@ class Lexer:
             self._current = self._chars[self._position]
         return self._current
 
+    def _offset(self):
+        # ``_next`` leaves ``_position`` on the final character once the
+        # end of the expression is reached, so consuming the last
+        # character of an expression would otherwise report an offset
+        # one short of the true end.
+        if self._current is None:
+            return self._length
+        return self._position
+
     def _consume_until(self, delimiter):
-        # Consume until the delimiter is reached,
-        # allowing for the delimiter to be escaped with "\".
+        # Consume until the delimiter is reached, allowing for the
+        # delimiter and the escape character itself to be escaped
+        # with "\".
         start = self._position
         buff = ''
         self._next()
         while self._current != delimiter:
-            if self._current == '\\':
-                buff += '\\'
+            escaped = self._current == '\\'
+            if escaped:
                 self._next()
             if self._current is None:
                 # We're at the EOF.
@@ -314,6 +325,11 @@ class Lexer:
                     position=start,
                     expression=self._expression,
                 )
+            if escaped and self._current not in (delimiter, '\\'):
+                # Not a recognized escape sequence, so the backslash is
+                # preserved verbatim.  An escaped delimiter or an
+                # escaped backslash resolves to just that character.
+                buff += '\\'
             buff += self._current
             self._next()
         # Skip the closing delimiter.

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -1081,6 +1081,21 @@ class TestNpmLogin(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.test_subject.get_scope(f'.{self.namespace}')
 
+    def test_get_scope_invalid_trailing_characters(self):
+        # The namespace has to be valid in its entirety and not just at
+        # its start, otherwise invalid scope names are handed off to
+        # ``npm config set``.
+        invalid_namespaces = [
+            f'{self.namespace} with spaces',
+            f'{self.namespace}!!!',
+            f'{self.namespace}/../..',
+            f'{self.namespace}\nregistry=http://example.com',
+        ]
+        for namespace in invalid_namespaces:
+            with self.subTest(namespace=namespace):
+                with self.assertRaises(ValueError):
+                    self.test_subject.get_scope(namespace)
+
     def test_get_scope_without_prefix(self):
         expected_value = f'@{self.namespace}'
         scope = self.test_subject.get_scope(f'@{self.namespace}')

--- a/tests/unit/customizations/dynamodb/test_lexer.py
+++ b/tests/unit/customizations/dynamodb/test_lexer.py
@@ -31,6 +31,13 @@ STRING_TOKENS = ['and', 'between', 'in', 'or', 'not']
         ("'f\\'oo'", [{'type': 'identifier', 'value': "f'oo"}]),
         ('"spam"', [{'type': 'literal', 'value': 'spam'}]),
         ('"s\\"pam"', [{'type': 'literal', 'value': 's"pam'}]),
+        # An escaped backslash resolves to a single backslash.
+        (r'"C:\\path"', [{'type': 'literal', 'value': 'C:\\path'}]),
+        (r"'C:\\path'", [{'type': 'identifier', 'value': 'C:\\path'}]),
+        (r'"trailing\\"', [{'type': 'literal', 'value': 'trailing\\'}]),
+        # A backslash that does not escape the delimiter or another
+        # backslash is preserved verbatim.
+        (r'"a\nb"', [{'type': 'literal', 'value': 'a\\nb'}]),
         ('100', [{'type': 'literal', 'value': Decimal('100')}]),
         ('-100', [{'type': 'literal', 'value': Decimal('-100')}]),
         ('1.01', [{'type': 'literal', 'value': Decimal('1.01')}]),
@@ -133,10 +140,33 @@ def test_lexer_empty_error():
         ('b"&"', 'b"&"\n^'),
         # Invalid padding
         ('b"898989;;"', 'b"898989;;"\n^'),
+        # Invalid characters anywhere in the string must be rejected,
+        # not just at its start.  Otherwise base64 decoding silently
+        # discards them and yields a truncated value.
+        ('b"AAAA!!!!"', 'b"AAAA!!!!"\n^'),
+        ('b"AAAA AAAA"', 'b"AAAA AAAA"\n^'),
     ],
 )
 def test_lexer_error(expression, error_part):
     LexTester().assert_lex_error(expression, error_part)
+
+
+@pytest.mark.parametrize(
+    "expression,expected_lexeme",
+    [
+        ("'foo'", "'foo'"),
+        ('"foo"', '"foo"'),
+        ("bar = 'foo'", "'foo'"),
+        ('bar = "foo"', '"foo"'),
+    ],
+)
+def test_quoted_token_offsets(expression, expected_lexeme):
+    # ``start``/``end`` are offsets into the expression and are used to
+    # underline the offending token in error messages, so slicing the
+    # expression with them has to produce the token's source text.
+    tokens = list(Lexer().tokenize(expression))
+    token = next(t for t in tokens if t['type'] in ('identifier', 'literal'))
+    assert expression[token['start'] : token['end']] == expected_lexeme
 
 
 class LexTester:


### PR DESCRIPTION
Fixes #10543.

Four defects, all of the same shape: a validation or unescaping step that only handles the *start* of a string.

### 1. `ddb`: base64 literals were validated with `re.match`

`re.match` anchors only at the beginning, so `b"AAAA!!!!"` passed validation. `base64.b64decode` discards out-of-alphabet characters by default, so the literal then decoded to a silently truncated value and was written to DynamoDB with no error. The comment above the check says this is precisely what the manual validation exists to prevent. Now uses `fullmatch`.

The check did work when the invalid characters came first (`b"!!!!AAAA"` was correctly rejected), which is likely why it went unnoticed.

```
# before                                    # after
data = b"AAAA!!!!"                          data = b"AAAA!!!!"
  -> Binary(b'\x00\x00\x00')                  -> LexerError: Invalid base64 string
```

### 2. `ddb`: escaped backslashes were never unescaped

`_consume_until` preserved `\X` verbatim and the callers only stripped `\"` / `\'`, so `"C:\\path"` lexed to `C:\\path` rather than `C:\path`, with no way to express a single literal backslash.

Unescaping now happens while consuming the string. A backslash escaping neither the delimiter nor another backslash is still preserved verbatim, so sequences like `\n` are unchanged.

### 3. `ddb`: token `end` was a length rather than an offset

`_consume_quoted_identifier` / `_consume_string_literal` set `'end': token_len`. `exceptions.py` computes `token['end'] - token['start']` to size the `^^^` underline in error messages, so for any quoted token not at offset 0 this went negative and the underline was mis-sized. For `bar = "foo"` the literal reported `start=6, end=4`.

`_next` deliberately leaves `_position` on the final character at end of input, so a small `_offset()` helper covers the case where the closing quote is the last character. I left `_next` itself alone — changing it also shifts the caret position in several existing lexer error tests, which is a separate judgement call and didn't belong in this change.

### 4. `codeartifact`: npm scope name was validated with a start-anchored regex

`NpmLogin.get_scope` used `'^(@[a-z0-9-~][a-z0-9-._~]*)'`, so validation stopped at the first character outside the allowed set and accepted everything after it. Namespaces such as `foo bar`, `foo!!!`, or one containing a newline were passed through to `npm config set` as a scope name. Now anchored with `\A`/`\Z`, matching how `SwiftLogin.get_scope` in the same file already validates its scope.

The existing test only covered an invalid *leading* character, which the start-anchored pattern did catch; added coverage for invalid characters elsewhere in the name.

### Testing

- 11 new test cases. I confirmed each one fails against the unpatched code and passes with the fix — the source changes were stashed and the new tests re-run to verify they were not vacuous.
- `tests/unit/customizations` passes: 3265 passed, 1 skipped. (One unrelated pre-existing failure, `test_which_with_existing_command`, which looks for a `python` binary on `PATH` — this machine only has `python3`.)
- `ruff` output on the touched files is unchanged from baseline.
- Changelog entries added with `scripts/new-change`.

I did not run the full `tests/functional` suite locally, only the `codeartifact` functional tests.

Happy to split the `codeartifact` fix into its own PR if you'd prefer to keep the components separate — it's an independent commit.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
