### PR TITLE
Defer docutils imports and precompile s3 include/exclude patterns

### DIFF
--- a/.changes/next-release/enhancement-s3-49636.json
+++ b/.changes/next-release/enhancement-s3-49636.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "s3",
+  "description": "Compile ``--include``/``--exclude`` filter patterns once per transfer instead of re-normalizing and re-matching them for every file, reducing client-side filter evaluation time by roughly 40%."
+}

--- a/.changes/next-release/enhancement-startup-22805.json
+++ b/.changes/next-release/enhancement-startup-22805.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "startup",
+  "description": "Defer importing ``docutils`` until help output is actually rendered. It was previously imported on every CLI invocation, along with ``pygments`` and ``PIL``, even for commands that never render help."
+}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -65,11 +65,6 @@ from awscli.errorhandler import (
 )
 from awscli.formatter import get_formatter
 from awscli.handlers_registry import MAIN_COMMAND_TABLE_OPS
-from awscli.help import (
-    OperationHelpCommand,
-    ProviderHelpCommand,
-    ServiceHelpCommand,
-)
 from awscli.lazy_emitter import LazyInitEmitter
 from awscli.logger import (
     disable_crt_logging,
@@ -534,6 +529,10 @@ class CLIDriver:
         )
 
     def create_help_command(self):
+        # Imported here because the help machinery pulls in docutils,
+        # which is only needed when help is actually requested.
+        from awscli.help import ProviderHelpCommand
+
         cli_data = self._get_cli_data()
         return ProviderHelpCommand(
             self.session,
@@ -769,6 +768,8 @@ class ServiceCommand(CLICommand):
             command_obj.lineage = self.lineage + [command_obj]
 
     def create_help_command(self):
+        from awscli.help import ServiceHelpCommand
+
         command_table = self._get_command_table()
         return ServiceHelpCommand(
             session=self.session,
@@ -964,6 +965,8 @@ class ServiceOperation:
             )
 
     def create_help_command(self):
+        from awscli.help import OperationHelpCommand
+
         return OperationHelpCommand(
             self._session,
             operation_model=self._operation_model,

--- a/awscli/customizations/s3/filters.py
+++ b/awscli/customizations/s3/filters.py
@@ -13,6 +13,7 @@
 import fnmatch
 import logging
 import os
+import re
 
 from awscli.customizations.s3.utils import split_s3_bucket_key
 
@@ -94,6 +95,7 @@ class Filter:
         self._original_patterns = patterns
         self.patterns = self._full_path_patterns(patterns, rootdir)
         self.dst_patterns = self._full_path_patterns(patterns, dst_rootdir)
+        self._compiled_cache = {}
 
     def _full_path_patterns(self, original_patterns, rootdir):
         # We need to transform the patterns into patterns that have
@@ -119,14 +121,24 @@ class Filter:
         before it.
         """
         for file_info in file_infos:
+            patterns, dst_patterns = self._compiled_patterns(
+                file_info.src_type
+            )
             file_path = file_info.src
+            # ``fnmatch.fnmatch`` normcases both of its arguments on every
+            # call.  The pattern side is already normcased when it is
+            # compiled, so only the path has to be normcased here, and only
+            # once for all of the patterns.
+            norm_file_path = os.path.normcase(file_path)
             file_status = (file_info, True)
-            for pattern, dst_pattern in zip(self.patterns, self.dst_patterns):
-                current_file_status = self._match_pattern(pattern, file_info)
+            for pattern, dst_pattern in zip(patterns, dst_patterns):
+                current_file_status = self._match_pattern(
+                    pattern, file_info, norm_file_path
+                )
                 if current_file_status is not None:
                     file_status = current_file_status
                 dst_current_file_status = self._match_pattern(
-                    dst_pattern, file_info
+                    dst_pattern, file_info, norm_file_path
                 )
                 if dst_current_file_status is not None:
                     file_status = dst_current_file_status
@@ -138,15 +150,37 @@ class Filter:
             if file_status[1]:
                 yield file_info
 
-    def _match_pattern(self, pattern, file_info):
+    def _compiled_patterns(self, src_type):
+        # The patterns are fixed for the duration of a transfer, so the
+        # separator normalization and the fnmatch -> regex translation are
+        # done once per source type rather than once per file.
+        compiled = self._compiled_cache.get(src_type)
+        if compiled is None:
+            compiled = (
+                self._compile_patterns(self.patterns, src_type),
+                self._compile_patterns(self.dst_patterns, src_type),
+            )
+            self._compiled_cache[src_type] = compiled
+        return compiled
+
+    def _compile_patterns(self, patterns, src_type):
+        compiled = []
+        for pattern_type, pattern in patterns:
+            if src_type == 'local':
+                path_pattern = pattern.replace('/', os.sep)
+            else:
+                path_pattern = pattern.replace(os.sep, '/')
+            regex = re.compile(
+                fnmatch.translate(os.path.normcase(path_pattern))
+            )
+            compiled.append((pattern_type, path_pattern, regex))
+        return compiled
+
+    def _match_pattern(self, pattern, file_info, norm_file_path):
         file_status = None
         file_path = file_info.src
-        pattern_type = pattern[0]
-        if file_info.src_type == 'local':
-            path_pattern = pattern[1].replace('/', os.sep)
-        else:
-            path_pattern = pattern[1].replace(os.sep, '/')
-        is_match = fnmatch.fnmatch(file_path, path_pattern)
+        pattern_type, path_pattern, regex = pattern
+        is_match = regex.match(norm_file_path) is not None
         if is_match and pattern_type == 'include':
             file_status = (file_info, True)
             LOG.debug("%s matched include filter: %s", file_path, path_pattern)

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -20,11 +20,6 @@ import webbrowser
 from subprocess import PIPE, Popen
 
 from botocore.exceptions import ProfileNotFound
-from docutils.core import publish_string
-from docutils.writers import (
-    html4css1,
-    manpage,
-)
 
 from awscli import (
     _DEFAULT_BASE_REMOTE_URL,
@@ -239,6 +234,9 @@ class PosixHelpRenderer(PosixPagingHelpRenderer):
     """
 
     def _convert_doc_content(self, contents):
+        from docutils.core import publish_string
+        from docutils.writers import manpage
+
         settings_overrides = self._DEFAULT_DOCUTILS_SETTINGS_OVERRIDES.copy()
         settings_overrides["report_level"] = 3
         man_contents = publish_string(
@@ -265,6 +263,9 @@ class PosixBrowserHelpRenderer(BrowserHelpRenderer):
     """
 
     def _convert_doc_content(self, contents):
+        from docutils.core import publish_string
+        from docutils.writers import manpage
+
         settings_overrides = self._DEFAULT_DOCUTILS_SETTINGS_OVERRIDES.copy()
         settings_overrides["report_level"] = 3
         man_contents = publish_string(
@@ -310,6 +311,8 @@ class WindowsHelpRenderer(WindowsPagingHelpRenderer):
     """Render help content on a Windows platform."""
 
     def _convert_doc_content(self, contents):
+        from docutils.core import publish_string
+
         text_output = publish_string(
             contents,
             writer=TextWriter(),
@@ -322,6 +325,9 @@ class WindowsBrowserHelpRenderer(BrowserHelpRenderer):
     """Render help content in the browser on a Windows platform."""
 
     def _convert_doc_content(self, contents):
+        from docutils.core import publish_string
+        from docutils.writers import html4css1
+
         text_output = publish_string(
             contents,
             writer=html4css1.Writer(),

--- a/awscli/topictags.py
+++ b/awscli/topictags.py
@@ -22,8 +22,6 @@
 import json
 import os
 
-import docutils.core
-
 
 class TopicTagDB:
     """This class acts like a database for the tags of all available topics.
@@ -182,7 +180,10 @@ class TopicTagDB:
 
     def _add_tag_and_values_from_content(self, topic_name, content):
         # Retrieves tags and values and adds from content of topic file
-        # to the dictionary.
+        # to the dictionary.  Imported here because docutils is only
+        # needed when the topic index is (re)generated or queried.
+        import docutils.core
+
         doctree = docutils.core.publish_doctree(content).asdom()
         fields = doctree.getElementsByTagName('field')
         for field in fields:

--- a/tests/unit/customizations/s3/test_filters.py
+++ b/tests/unit/customizations/s3/test_filters.py
@@ -244,6 +244,33 @@ class FiltersTest(unittest.TestCase):
         for filtered_file in filtered:
             self.assertFalse('.txt' in filtered_file.src)
 
+    def test_reuses_filter_across_src_types(self):
+        # Patterns are compiled per source type and cached, so a filter
+        # reused across source types has to keep giving each type its own
+        # separator normalization rather than the first one it saw.
+        exclude_filter = self.create_filter([['exclude', '*.txt']])
+        for _ in range(2):
+            local = list(exclude_filter.call(self.local_files))
+            self.assertEqual(
+                [os.path.basename(f.src) for f in local],
+                ['test.jpg', 'test.jpg'],
+            )
+            s3 = list(exclude_filter.call(self.s3_files))
+            self.assertEqual(
+                [f.src for f in s3], ['bucket/test.jpg', 'bucket/key/test.jpg']
+            )
+
+    def test_repeated_calls_are_stable(self):
+        # The compiled-pattern cache must not accumulate or mutate state
+        # between calls.
+        include_filter = self.create_filter(
+            [['exclude', '*'], ['include', '*.jpg']]
+        )
+        first = [f.src for f in include_filter.call(self.local_files)]
+        second = [f.src for f in include_filter.call(self.local_files)]
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two independent changes, both removing constant work that was being redone on every invocation or every file. No behaviour change in either.

### 1. Defer `docutils` imports until help is actually rendered

`awscli/help.py` imported `docutils.core` and the `html4css1`/`manpage` writers at module scope, and `awscli/topictags.py` imported `docutils.core`. Because `awscli/customizations/commands.py` subclasses `HelpCommand`, that whole chain was pulled in during customization registration on **every** CLI invocation — including `pygments` and `PIL` via the docutils rst directives — even for commands that never render help.

Every use is inside a method, so the imports move into them.

Measured with 25 subprocess runs of `aws --version` per arm, alternating between arms three times to control for machine drift:

```
before   min 246-255ms
after    min 232-240ms
```

About 14ms (~6%) off every invocation. I'm quoting min-of-25 rather than the mean because run-to-run noise on this machine is ±20ms, which is larger than the effect — sequential (non-interleaved) runs initially suggested a bigger win than the interleaved A/B supports.

Checked by hand that help still renders: `aws help`, `aws s3 help`, `aws ec2 describe-instances help`, `aws help topics`, and `TopicTagDB.scan` still parses topic source files.

### 2. Compile s3 `--include`/`--exclude` patterns once per transfer

`Filter._match_pattern` ran `pattern.replace('/', os.sep)` for every file for every pattern, and `fnmatch.fnmatch` normcased *both* the path and the pattern on every call before its internal cache lookup. All of that is constant across a transfer.

Patterns are now separator-normalized and translated to a compiled regex once per source type, and the path is normcased once per file instead of once per pattern.

Profiling 50k files against 6 patterns showed only 0.19s of the original 1.68s was actual regex matching — the rest was repeated setup:

```
                          ncalls  tottime
_match_pattern            600000    0.388
fnmatch.fnmatch           600000    0.274
fnmatchcase               600000    0.202
re.Pattern.match          600000    0.192   <- the only necessary work
posixpath.normcase       1200000    0.166
str.replace               600000    0.057
```

End to end:

```
100k files, 2 patterns    3.30 -> 2.12 us/file   (-36%)
100k files, 6 patterns    9.94 -> 5.99 us/file   (-40%)
```

Worth being clear about the scope of that number: this is client-side filter evaluation only. On a real `aws s3 sync` the network dominates, so this matters most for large listings where most files are filtered out — it is not a 40% reduction in overall sync time.

`self.patterns` / `self.dst_patterns` keep their existing shape and contents, since tests and external callers read them.

### Testing

- `tests/unit/customizations/s3`, `tests/functional/s3`, `tests/functional/docs`, `test_help.py`, `test_topictags.py`, `test_clidriver.py`: 12963 passed, 3 skipped.
- Behaviour equivalence for the filter change was checked with a differential test running the old and new matching over 400 randomized pattern/path combinations (mixed `local`/`s3` source types, spaces, case variation, glob metacharacters in filenames): 0 mismatches.
- Two tests added covering filter reuse across source types and stability across repeated calls. Unlike a bug fix, these pass against both the old and new implementation by design — they are refactor guards, not proof of the change.
- `ruff` output on the touched files is unchanged from baseline.

I did not run the full `tests/functional` suite locally.

Happy to split these into two PRs if you'd prefer them reviewed separately.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
