### PR TITLE
Defer docutils imports until help is rendered

### DIFF
--- a/.changes/next-release/enhancement-startup-22805.json
+++ b/.changes/next-release/enhancement-startup-22805.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "startup",
+  "description": "Defer importing ``docutils`` until help output is actually rendered. It was previously imported on every CLI invocation, along with ``pygments`` and ``PIL``, even for commands that never render help."
+}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -65,11 +65,6 @@ from awscli.errorhandler import (
 )
 from awscli.formatter import get_formatter
 from awscli.handlers_registry import MAIN_COMMAND_TABLE_OPS
-from awscli.help import (
-    OperationHelpCommand,
-    ProviderHelpCommand,
-    ServiceHelpCommand,
-)
 from awscli.lazy_emitter import LazyInitEmitter
 from awscli.logger import (
     disable_crt_logging,
@@ -534,6 +529,10 @@ class CLIDriver:
         )
 
     def create_help_command(self):
+        # Imported here because the help machinery pulls in docutils,
+        # which is only needed when help is actually requested.
+        from awscli.help import ProviderHelpCommand
+
         cli_data = self._get_cli_data()
         return ProviderHelpCommand(
             self.session,
@@ -769,6 +768,8 @@ class ServiceCommand(CLICommand):
             command_obj.lineage = self.lineage + [command_obj]
 
     def create_help_command(self):
+        from awscli.help import ServiceHelpCommand
+
         command_table = self._get_command_table()
         return ServiceHelpCommand(
             session=self.session,
@@ -964,6 +965,8 @@ class ServiceOperation:
             )
 
     def create_help_command(self):
+        from awscli.help import OperationHelpCommand
+
         return OperationHelpCommand(
             self._session,
             operation_model=self._operation_model,

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -20,11 +20,6 @@ import webbrowser
 from subprocess import PIPE, Popen
 
 from botocore.exceptions import ProfileNotFound
-from docutils.core import publish_string
-from docutils.writers import (
-    html4css1,
-    manpage,
-)
 
 from awscli import (
     _DEFAULT_BASE_REMOTE_URL,
@@ -239,6 +234,9 @@ class PosixHelpRenderer(PosixPagingHelpRenderer):
     """
 
     def _convert_doc_content(self, contents):
+        from docutils.core import publish_string
+        from docutils.writers import manpage
+
         settings_overrides = self._DEFAULT_DOCUTILS_SETTINGS_OVERRIDES.copy()
         settings_overrides["report_level"] = 3
         man_contents = publish_string(
@@ -265,6 +263,9 @@ class PosixBrowserHelpRenderer(BrowserHelpRenderer):
     """
 
     def _convert_doc_content(self, contents):
+        from docutils.core import publish_string
+        from docutils.writers import manpage
+
         settings_overrides = self._DEFAULT_DOCUTILS_SETTINGS_OVERRIDES.copy()
         settings_overrides["report_level"] = 3
         man_contents = publish_string(
@@ -310,6 +311,8 @@ class WindowsHelpRenderer(WindowsPagingHelpRenderer):
     """Render help content on a Windows platform."""
 
     def _convert_doc_content(self, contents):
+        from docutils.core import publish_string
+
         text_output = publish_string(
             contents,
             writer=TextWriter(),
@@ -322,6 +325,9 @@ class WindowsBrowserHelpRenderer(BrowserHelpRenderer):
     """Render help content in the browser on a Windows platform."""
 
     def _convert_doc_content(self, contents):
+        from docutils.core import publish_string
+        from docutils.writers import html4css1
+
         text_output = publish_string(
             contents,
             writer=html4css1.Writer(),

--- a/awscli/topictags.py
+++ b/awscli/topictags.py
@@ -22,8 +22,6 @@
 import json
 import os
 
-import docutils.core
-
 
 class TopicTagDB:
     """This class acts like a database for the tags of all available topics.
@@ -182,7 +180,10 @@ class TopicTagDB:
 
     def _add_tag_and_values_from_content(self, topic_name, content):
         # Retrieves tags and values and adds from content of topic file
-        # to the dictionary.
+        # to the dictionary.  Imported here because docutils is only
+        # needed when the topic index is (re)generated or queried.
+        import docutils.core
+
         doctree = docutils.core.publish_doctree(content).asdom()
         fields = doctree.getElementsByTagName('field')
         for field in fields:


### PR DESCRIPTION
Split out of #10545 at @aemous's request — this is half 1 of 2. The other half is #10552 (s3 filter precompilation); the two are independent and touch disjoint files.

`awscli/help.py` imported `docutils.core` and the `html4css1`/`manpage` writers at module scope, and `awscli/topictags.py` imported `docutils.core`. Because `awscli/customizations/commands.py` subclasses `HelpCommand`, that whole chain was pulled in during customization registration on **every** CLI invocation — including `pygments` and `PIL` via the docutils rst directives — even for commands that never render help.

Every use is inside a method, so the imports move into them.

Measured with 25 subprocess runs of `aws --version` per arm, alternating between arms three times to control for machine drift:

```
before   min 246-255ms
after    min 232-240ms
```

About 14ms (~6%) off every invocation. I'm quoting min-of-25 rather than the mean because run-to-run noise on this machine is ±20ms, which is larger than the effect — sequential (non-interleaved) runs initially suggested a bigger win than the interleaved A/B supports.

Checked by hand that help still renders: `aws help`, `aws s3 help`, `aws ec2 describe-instances help`, `aws help topics`, and `TopicTagDB.scan` still parses topic source files.

### Testing

- `tests/unit/test_help.py`, `tests/unit/test_topictags.py`, `tests/unit/test_clidriver.py`, `tests/functional/docs`: 11967 passed, 3 skipped.
- `ruff` output on the touched files is unchanged from baseline.

I did not run the full `tests/functional` suite locally.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
