### PR TITLE
Compile s3 --include/--exclude patterns once per transfer

### DIFF
--- a/.changes/next-release/enhancement-s3-49636.json
+++ b/.changes/next-release/enhancement-s3-49636.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "s3",
+  "description": "Compile ``--include``/``--exclude`` filter patterns once per transfer instead of re-normalizing and re-matching them for every file, reducing client-side filter evaluation time by roughly 40%."
+}

--- a/awscli/customizations/s3/filters.py
+++ b/awscli/customizations/s3/filters.py
@@ -13,6 +13,7 @@
 import fnmatch
 import logging
 import os
+import re
 
 from awscli.customizations.s3.utils import split_s3_bucket_key
 
@@ -94,6 +95,7 @@ class Filter:
         self._original_patterns = patterns
         self.patterns = self._full_path_patterns(patterns, rootdir)
         self.dst_patterns = self._full_path_patterns(patterns, dst_rootdir)
+        self._compiled_cache = {}
 
     def _full_path_patterns(self, original_patterns, rootdir):
         # We need to transform the patterns into patterns that have
@@ -119,14 +121,24 @@ class Filter:
         before it.
         """
         for file_info in file_infos:
+            patterns, dst_patterns = self._compiled_patterns(
+                file_info.src_type
+            )
             file_path = file_info.src
+            # ``fnmatch.fnmatch`` normcases both of its arguments on every
+            # call.  The pattern side is already normcased when it is
+            # compiled, so only the path has to be normcased here, and only
+            # once for all of the patterns.
+            norm_file_path = os.path.normcase(file_path)
             file_status = (file_info, True)
-            for pattern, dst_pattern in zip(self.patterns, self.dst_patterns):
-                current_file_status = self._match_pattern(pattern, file_info)
+            for pattern, dst_pattern in zip(patterns, dst_patterns):
+                current_file_status = self._match_pattern(
+                    pattern, file_info, norm_file_path
+                )
                 if current_file_status is not None:
                     file_status = current_file_status
                 dst_current_file_status = self._match_pattern(
-                    dst_pattern, file_info
+                    dst_pattern, file_info, norm_file_path
                 )
                 if dst_current_file_status is not None:
                     file_status = dst_current_file_status
@@ -138,15 +150,37 @@ class Filter:
             if file_status[1]:
                 yield file_info
 
-    def _match_pattern(self, pattern, file_info):
+    def _compiled_patterns(self, src_type):
+        # The patterns are fixed for the duration of a transfer, so the
+        # separator normalization and the fnmatch -> regex translation are
+        # done once per source type rather than once per file.
+        compiled = self._compiled_cache.get(src_type)
+        if compiled is None:
+            compiled = (
+                self._compile_patterns(self.patterns, src_type),
+                self._compile_patterns(self.dst_patterns, src_type),
+            )
+            self._compiled_cache[src_type] = compiled
+        return compiled
+
+    def _compile_patterns(self, patterns, src_type):
+        compiled = []
+        for pattern_type, pattern in patterns:
+            if src_type == 'local':
+                path_pattern = pattern.replace('/', os.sep)
+            else:
+                path_pattern = pattern.replace(os.sep, '/')
+            regex = re.compile(
+                fnmatch.translate(os.path.normcase(path_pattern))
+            )
+            compiled.append((pattern_type, path_pattern, regex))
+        return compiled
+
+    def _match_pattern(self, pattern, file_info, norm_file_path):
         file_status = None
         file_path = file_info.src
-        pattern_type = pattern[0]
-        if file_info.src_type == 'local':
-            path_pattern = pattern[1].replace('/', os.sep)
-        else:
-            path_pattern = pattern[1].replace(os.sep, '/')
-        is_match = fnmatch.fnmatch(file_path, path_pattern)
+        pattern_type, path_pattern, regex = pattern
+        is_match = regex.match(norm_file_path) is not None
         if is_match and pattern_type == 'include':
             file_status = (file_info, True)
             LOG.debug("%s matched include filter: %s", file_path, path_pattern)

--- a/tests/unit/customizations/s3/test_filters.py
+++ b/tests/unit/customizations/s3/test_filters.py
@@ -244,6 +244,33 @@ class FiltersTest(unittest.TestCase):
         for filtered_file in filtered:
             self.assertFalse('.txt' in filtered_file.src)
 
+    def test_reuses_filter_across_src_types(self):
+        # Patterns are compiled per source type and cached, so a filter
+        # reused across source types has to keep giving each type its own
+        # separator normalization rather than the first one it saw.
+        exclude_filter = self.create_filter([['exclude', '*.txt']])
+        for _ in range(2):
+            local = list(exclude_filter.call(self.local_files))
+            self.assertEqual(
+                [os.path.basename(f.src) for f in local],
+                ['test.jpg', 'test.jpg'],
+            )
+            s3 = list(exclude_filter.call(self.s3_files))
+            self.assertEqual(
+                [f.src for f in s3], ['bucket/test.jpg', 'bucket/key/test.jpg']
+            )
+
+    def test_repeated_calls_are_stable(self):
+        # The compiled-pattern cache must not accumulate or mutate state
+        # between calls.
+        include_filter = self.create_filter(
+            [['exclude', '*'], ['include', '*.jpg']]
+        )
+        first = [f.src for f in include_filter.call(self.local_files)]
+        second = [f.src for f in include_filter.call(self.local_files)]
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Split out of #10545 at @aemous's request — this is half 2 of 2. The other half is #10551 (deferring the docutils imports); the two are independent and touch disjoint files.

`Filter._match_pattern` ran `pattern.replace('/', os.sep)` for every file for every pattern, and `fnmatch.fnmatch` normcased *both* the path and the pattern on every call before its internal cache lookup. All of that is constant across a transfer.

Patterns are now separator-normalized and translated to a compiled regex once per source type, and the path is normcased once per file instead of once per pattern.

Profiling 50k files against 6 patterns showed only 0.19s of the original 1.68s was actual regex matching — the rest was repeated setup:

```
                          ncalls  tottime
_match_pattern            600000    0.388
fnmatch.fnmatch           600000    0.274
fnmatchcase               600000    0.202
re.Pattern.match          600000    0.192   <- the only necessary work
posixpath.normcase       1200000    0.166
str.replace               600000    0.057
```

End to end:

```
100k files, 2 patterns    3.30 -> 2.12 us/file   (-36%)
100k files, 6 patterns    9.94 -> 5.99 us/file   (-40%)
```

Worth being clear about the scope of that number: this is client-side filter evaluation only. On a real `aws s3 sync` the network dominates, so this matters most for large listings where most files are filtered out — it is not a 40% reduction in overall sync time.

`self.patterns` / `self.dst_patterns` keep their existing shape and contents, since tests and external callers read them.

### Testing

- `tests/unit/customizations/s3`, `tests/functional/s3`: 996 passed.
- Behaviour equivalence was checked with a differential test running the old and new matching over 400 randomized pattern/path combinations (mixed `local`/`s3` source types, spaces, case variation, glob metacharacters in filenames): 0 mismatches.
- Two tests added covering filter reuse across source types and stability across repeated calls. Unlike a bug fix, these pass against both the old and new implementation by design — they are refactor guards, not proof of the change.
- `ruff` output on the touched files is unchanged from baseline.

I did not run the full `tests/functional` suite locally.

---

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
