### PR TITLE
Fix UnboundLocalError in aws configure set for nested values

### DIFF
--- a/.changes/next-release/bugfix-configure-51843.json
+++ b/.changes/next-release/bugfix-configure-51843.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "configure",
+  "description": "Fix `UnboundLocalError` in `aws configure set` when adding a nested value to a key that is the last line of the config file or is followed by a comment or blank line"
+}

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -227,6 +227,16 @@ class ConfigFileWriter:
 
     def _update_subattributes(self, index, contents, values, starting_indent):
         index += 1
+        # ``current_indent`` is only assigned for lines that parse as an
+        # option, and ``i`` is only assigned if the loop below runs at all.
+        # Comments, blank lines, or a nested key with nothing after it would
+        # otherwise leave them unbound.  ``None`` never compares equal to
+        # ``starting_indent``, which keeps non-option lines from being
+        # mistaken for the end of the nested block, and seeding ``i`` with
+        # the nested key's own line means values are appended directly after
+        # it when there is nothing following.
+        current_indent = None
+        i = index - 1
         for i in range(index, len(contents)):
             line = contents[i]
             match = self.OPTION_REGEX.search(line)

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -254,6 +254,33 @@ class TestConfigFileWriter(unittest.TestCase):
             '    signature_version = newval\n',
         )
 
+    def test_add_to_nested_with_nothing_after_it(self):
+        original = '[default]\n' 's3 =\n'
+        self.assert_update_config(
+            original,
+            {'__section__': 'default', 's3': {'signature_version': 'newval'}},
+            '[default]\n' 's3 =\n' '    signature_version = newval\n',
+        )
+
+    def test_add_to_nested_followed_by_comment(self):
+        original = '[default]\n' 's3 =\n' '# a comment\n'
+        self.assert_update_config(
+            original,
+            {'__section__': 'default', 's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '# a comment\n'
+            '    signature_version = newval\n',
+        )
+
+    def test_add_to_nested_followed_by_blank_line(self):
+        original = '[default]\n' 's3 =\n' '\n'
+        self.assert_update_config(
+            original,
+            {'__section__': 'default', 's3': {'signature_version': 'newval'}},
+            '[default]\n' 's3 =\n' '\n' '    signature_version = newval\n',
+        )
+
     def test_update_nested_attribute(self):
         original = (
             '[default]\n' 's3 =\n' '    signature_version = originalval\n'


### PR DESCRIPTION
## Issue

Fixes #10554

## Description of changes

`aws configure set <section>.<key>.<subkey> <value>` crashes with an internal `UnboundLocalError` and exit code `255` when the nested parent key is not immediately followed by another indented option line:

```console
$ AWS_CONFIG_FILE=./config aws configure set default.s3.max_concurrent_requests 20

aws: [ERROR]: cannot access local variable 'current_indent' where it is not associated with a value
```

In `ConfigFileWriter._update_subattributes`, `current_indent` is only assigned inside the `if match is not None:` branch, and `i` is only assigned if the `for` loop body runs. Both are read unconditionally afterwards:

```python
if (
    starting_indent == current_indent      # unbound if no line matched yet
    or self.SECTION_REGEX.search(line) is not None
):
    ...
else:
    if starting_indent != current_indent:  # unbound if the range was empty
        self._insert_new_values(i, contents, values, '    ')
```

Comments and blank lines do not match `OPTION_REGEX`, so if one of those directly follows the parent key, `current_indent` is never bound. If the parent key is the last line in the file, `range()` is empty and both `current_indent` and `i` are unbound when the `else:` clause runs.

Three valid config layouts trigger it — all three parse correctly via `botocore.configloader.raw_config_parse`:

```ini
[default]        [default]        [default]
s3 =             s3 =             s3 =
# comment
                                  (blank line)
```

The fix seeds both names before the loop:

```python
current_indent = None
i = index - 1
```

This is behaviour-preserving for every input that previously worked. `current_indent` is read only at those two comparison sites, and `None` never compares equal to `starting_indent` — which is exactly the "this line does not end the nested block" outcome that a stale-but-different indent already produced for comments appearing later within a block. In the `else:` clause the comparison was already unconditionally true whenever it was reached, since an equal indent would have broken out of the loop. Seeding `i` with the nested key's own line makes the values get appended directly after it when nothing follows.

Resulting output for the three cases above:

```ini
[default]                                  [default]
s3 =                                       s3 =
# comment                                      signature_version = newval
    signature_version = newval

[default]
s3 =

    signature_version = newval
```

## Testing

Three regression tests added to `tests/unit/customizations/configure/test_writer.py`, one per layout. Each fails with `UnboundLocalError` on `v2` and passes with the fix.

- `tests/unit/customizations/configure/` and `tests/functional/configure/`: **313 passed**
- `tests/unit/customizations/`: no new failures (the single failure, `test_emr_utils.py::TestEMRutils::test_which_with_existing_command`, reproduces identically on unmodified `v2` in this environment and is unrelated)
- Verified end to end that `aws configure set default.s3.max_concurrent_requests 20` now exits `0`, and that `aws configure get default.s3.max_concurrent_requests` reads the value back.

Both touched files already fail `ruff format --check`/`ruff check` on unmodified `v2`, so I deliberately left the surrounding formatting alone rather than growing the diff; the added lines introduce no new findings.
