### PR TITLE
Fix aws ecs deploy not defaulting an empty --cluster to "default"

### DIFF
--- a/.changes/next-release/bugfix-ecs-72910.json
+++ b/.changes/next-release/bugfix-ecs-72910.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ecs",
+  "description": "Fix `aws ecs deploy` falling back to the correct behavior for `--cluster \"\"` (an empty string, e.g. from an unset shell variable) the same way it already does when `--cluster` is omitted, instead of passing the empty string through to the ECS API"
+}

--- a/awscli/customizations/ecs/deploy.py
+++ b/awscli/customizations/ecs/deploy.py
@@ -449,7 +449,7 @@ class ECSClient:
     def get_service_details(self):
         cluster = self._args.cluster
 
-        if cluster is None or '':
+        if not cluster:
             cluster = 'default'
 
         try:

--- a/tests/unit/customizations/ecs/test_ecsclient.py
+++ b/tests/unit/customizations/ecs/test_ecsclient.py
@@ -47,3 +47,40 @@ class TestECSClient(unittest.TestCase):
             create_args[1]['config'].user_agent_extra,
             expected_user_agent_extra,
         )
+
+    def _get_service_details_with_cluster(self, cluster):
+        args = Namespace(cluster=cluster, service='my-service')
+        test_client = ECSClient(
+            self.session, args, self.global_args, ECSDeploy.USER_AGENT_EXTRA
+        )
+        test_client._client = mock.Mock()
+        test_client._client.describe_services.return_value = {
+            'services': [
+                {
+                    'serviceArn': (
+                        'arn:aws:ecs:us-east-1:123456789012:service/my-service'
+                    ),
+                    'serviceName': 'my-service',
+                    'clusterArn': (
+                        'arn:aws:ecs:us-east-1:123456789012:cluster/default'
+                    ),
+                }
+            ]
+        }
+        test_client.get_service_details()
+        return test_client._client.describe_services.call_args[1]['cluster']
+
+    def test_get_service_details_defaults_cluster_when_not_specified(self):
+        used_cluster = self._get_service_details_with_cluster(None)
+        self.assertEqual(used_cluster, 'default')
+
+    def test_get_service_details_defaults_cluster_when_empty_string(self):
+        # A caller may pass an empty string for --cluster (e.g. by
+        # interpolating an unset shell variable), which should be treated
+        # the same as not specifying a cluster at all.
+        used_cluster = self._get_service_details_with_cluster('')
+        self.assertEqual(used_cluster, 'default')
+
+    def test_get_service_details_uses_specified_cluster(self):
+        used_cluster = self._get_service_details_with_cluster('my-cluster')
+        self.assertEqual(used_cluster, 'my-cluster')


### PR DESCRIPTION
## Issue

Fixes #10556

## Description of changes

`ECSClient.get_service_details()` (used by `aws ecs deploy`) defaults an unspecified cluster to `"default"` with:

```python
if cluster is None or '':
    cluster = 'default'
```

This parses as `(cluster is None) or ('')`. The bare `''` literal is always falsy, so it never affects the `or` — the whole condition is silently equivalent to `if cluster is None:`. The `or ''` is dead code.

`--cluster`'s help text says: *"If you do not specify a cluster, the 'default' cluster is assumed."* That's true when `--cluster` is omitted (argparse leaves it `None`), but not when a caller passes `--cluster ""` — e.g. a CI/CD pipeline running `--cluster "$CLUSTER_NAME"` where the variable is unset or empty. In that case `cluster` is `''`, not `None`, so the fallback is skipped and the empty string is sent straight through to `DescribeServices` instead of resolving to the default cluster the command documents.

Fix: `if not cluster:`, which treats `None` and `''` identically and matches the documented behavior in both cases.

```python
>>> args.cluster = ''
>>> ECSClient(session, args, globals, agent).get_service_details()
# before: describe_services(cluster='', ...)
# after:  describe_services(cluster='default', ...)
```

## Testing

`get_service_details()` had **no existing test coverage at all** for the cluster-defaulting behavior (only the `ECSClient` constructor/config was tested in `test_ecsclient.py`). Added three tests to `tests/unit/customizations/ecs/test_ecsclient.py`:
- `--cluster` omitted (`None`) → falls back to `default` (already worked, now covered)
- `--cluster ""` → falls back to `default` (was broken, now fixed)
- `--cluster my-cluster` → passed through unchanged (already worked, now covered)

I confirmed the empty-string test fails with `AssertionError: '' != 'default'` on unmodified `v2` and passes with the fix.

- `tests/unit/customizations/ecs/` + `tests/functional/ecs/`: **275 passed**
- `ruff check` / `ruff format --check` on both touched files: clean
