### PR TITLE
Fix ec2 run-instances not validating --no-associate-public-ip-address against --network-interfaces

### DIFF
--- a/.changes/next-release/bugfix-ec2-55884.json
+++ b/.changes/next-release/bugfix-ec2-55884.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ec2",
+  "description": "Fix `aws ec2 run-instances --network-interfaces ... --no-associate-public-ip-address` silently overwriting AssociatePublicIpAddress in the user-supplied network interface instead of raising the documented error for mixing --network-interfaces with scalar options"
+}

--- a/awscli/customizations/ec2/runinstances.py
+++ b/awscli/customizations/ec2/runinstances.py
@@ -81,18 +81,20 @@ def _check_args(parsed_args, **kwargs):
     # raise an error.
     arg_dict = vars(parsed_args)
     if arg_dict['network_interfaces']:
+        msg = (
+            'Mixing the --network-interfaces option '
+            'with the simple, scalar options is '
+            'not supported.'
+        )
         for key in (
             'secondary_private_ip_addresses',
             'secondary_private_ip_address_count',
             'associate_public_ip_address',
         ):
             if arg_dict[key]:
-                msg = (
-                    'Mixing the --network-interfaces option '
-                    'with the simple, scalar options is '
-                    'not supported.'
-                )
                 raise ParamValidationError(msg)
+        if arg_dict['no_associate_public_ip_address'] is False:
+            raise ParamValidationError(msg)
 
 
 def _fix_args(params, **kwargs):

--- a/tests/functional/ec2/test_run_instances.py
+++ b/tests/functional/ec2/test_run_instances.py
@@ -299,6 +299,24 @@ class TestRunInstances(BaseAWSCommandParamsTest):
         }
         self.assert_run_instances_call(args, result)
 
+    def test_network_interfaces_with_associate_public_ip_address_errors(self):
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--network-interfaces DeviceIndex=0 '
+        args += '--associate-public-ip-address'
+        self.run_cmd(self.prefix + args, expected_rc=252)
+
+    def test_network_interfaces_with_no_associate_public_ip_address_errors(self):
+        # Regression test: --no-associate-public-ip-address is a separate
+        # argparse dest (no_associate_public_ip_address) from
+        # --associate-public-ip-address (associate_public_ip_address), so
+        # it must be checked on its own. Previously this silently
+        # overwrote AssociatePublicIpAddress inside the user-supplied
+        # --network-interfaces structure instead of raising.
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--network-interfaces DeviceIndex=0 '
+        args += '--no-associate-public-ip-address'
+        self.run_cmd(self.prefix + args, expected_rc=252)
+
     def test_ipv6_address_count_and_associate_public_ip_address(self):
         args = ' --associate-public-ip-address'
         args += ' --ipv6-address-count 5 --image-id ami-foobar --count 1'


### PR DESCRIPTION
## Summary

Fixes #10558.

`--no-associate-public-ip-address` and `--associate-public-ip-address` are two independent argparse destinations (`no_associate_public_ip_address` / `associate_public_ip_address`) — they only share a `group_name` for help-text grouping, not a `dest`. `_check_args()` in `awscli/customizations/ec2/runinstances.py` only ever checked `associate_public_ip_address` when validating that `--network-interfaces` isn't mixed with the scalar options, so `--no-associate-public-ip-address` silently bypassed the check and overwrote `AssociatePublicIpAddress` inside the user's own `--network-interfaces` JSON instead of raising the documented `ParamValidationError`.

This adds the missing check for `no_associate_public_ip_address is False` (its "flag was explicitly passed" state, since it's a `store_false` action defaulting to `True`).

## Test plan

- [x] Added `test_network_interfaces_with_no_associate_public_ip_address_errors` (regression test for the bug) and `test_network_interfaces_with_associate_public_ip_address_errors` (locks in existing correct behavior) to `tests/functional/ec2/test_run_instances.py`
- [x] `python -m pytest tests/functional/ec2/ tests/unit/customizations/ec2/` — 108 passed
- [x] Added changelog entry under `.changes/next-release/`