### PR TITLE
fix(history): redact credential material before writing CLI history

### DIFF
--- a/.changes/next-release/bugfix-history-92841.json
+++ b/.changes/next-release/bugfix-history-92841.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "history",
+  "description": "Fixed the CLI history database (``cli_history = enabled``) recording credential material -- request Authorization/X-Amz-Security-Token headers and API response bodies such as sts:AssumeRole's temporary credentials -- to local disk in cleartext. Sensitive fields are now redacted before being written."
+}

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -24,6 +24,106 @@ from awscli.compat import binary_type, collections_abc, sqlite3
 
 LOG = logging.getLogger(__name__)
 
+REDACTED_VALUE = '***REDACTED***'
+
+# Exact key names (case-insensitive) whose values are credential/secret
+# material and must never be persisted to the CLI history database. This is
+# intentionally an exact-match set, not a substring match: a substring match
+# on something like "token" would also catch harmless, non-secret fields
+# that are extremely common across AWS APIs (NextToken, ContinuationToken,
+# PaginationToken, ClientToken, JobToken, ...), silently degrading the
+# usefulness of `aws history show` for routine debugging while adding no
+# real protection.
+#
+# This list is deliberately broader than what service models mark
+# `"sensitive": true` in botocore's shape metadata: for example STS's
+# AssumeRole response marks `Credentials.SecretAccessKey` as sensitive but
+# NOT `Credentials.SessionToken`, even though a session token is just as
+# usable as a live credential as the secret key it's paired with. Rather
+# than depend on every service team's model annotations being complete
+# (and rather than requiring shape/operation-model context, which callers
+# of this module do not have -- CLI history records are already-serialized
+# dicts by the time they reach here), we redact by field name directly, as
+# a deliberately conservative backstop.
+_SENSITIVE_KEY_NAMES = frozenset(
+    name.lower()
+    for name in (
+        'SecretAccessKey',
+        'SessionToken',
+        'SecretString',
+        'SecretKey',
+        'Password',
+        'MasterUserPassword',
+        'PrivateKey',
+        'ClientSecret',
+        'RefreshToken',
+        'AccessToken',
+        'IdToken',
+        'ApiKey',
+        'Authorization',
+        'X-Amz-Security-Token',
+    )
+)
+
+
+def _redact_sensitive_values(obj):
+    """Recursively replace values of well-known credential/secret-bearing
+    keys with a redaction marker, leaving everything else untouched.
+
+    Dict keys are matched case-insensitively by exact name (see
+    _SENSITIVE_KEY_NAMES). HTTP header dicts and parsed API request/response
+    payloads both flow through this same function, since both can carry
+    the fields listed above (headers carry Authorization/X-Amz-Security-
+    Token; payloads carry the rest).
+    """
+    if isinstance(obj, collections_abc.Mapping):
+        redacted = {}
+        for key, value in obj.items():
+            if isinstance(key, str) and key.lower() in _SENSITIVE_KEY_NAMES:
+                redacted[key] = REDACTED_VALUE
+            else:
+                redacted[key] = _redact_sensitive_values(value)
+        return redacted
+    elif isinstance(obj, (list, tuple)):
+        return [_redact_sensitive_values(item) for item in obj]
+    else:
+        return obj
+
+
+# Event types whose payload is a structured dict that may directly or
+# transitively contain credential material: API_CALL params (what the user
+# is sending, e.g. a new IAM password or secret value being set) and
+# PARSED_RESPONSE (what the service returned, e.g. STS temporary
+# credentials or a decrypted secret).
+_STRUCTURED_PAYLOAD_EVENTS = frozenset(('API_CALL', 'PARSED_RESPONSE'))
+
+
+def _redact_payload(event_type, payload):
+    if event_type in _STRUCTURED_PAYLOAD_EVENTS:
+        return _redact_sensitive_values(payload)
+    if event_type == 'HTTP_REQUEST' and isinstance(
+        payload, collections_abc.Mapping
+    ):
+        payload = dict(payload)
+        if 'headers' in payload:
+            payload['headers'] = _redact_sensitive_values(payload['headers'])
+        return payload
+    if event_type == 'HTTP_RESPONSE' and isinstance(
+        payload, collections_abc.Mapping
+    ):
+        # The raw response body at this point is still an unparsed byte/XML/
+        # JSON blob (PARSED_RESPONSE, handled above, is the structured
+        # equivalent of the same data). We can't safely redact specific
+        # fields inside an arbitrary, not-yet-parsed wire format without
+        # risking either missing a secret embedded in it (an incomplete
+        # regex over arbitrary XML/JSON) or corrupting it, so the safe
+        # default is to not persist the raw body at all for this event type.
+        payload = dict(payload)
+        if 'body' in payload:
+            payload['body'] = REDACTED_VALUE
+        return payload
+    return payload
+
 
 class DatabaseConnection:
     _CREATE_TABLE = """
@@ -269,7 +369,7 @@ class RecordBuilder:
         record = {
             'command_id': uid,
             'event_type': event_type,
-            'payload': payload,
+            'payload': _redact_payload(event_type, payload),
             'source': source,
             'timestamp': int(time.time() * 1000),
         }

--- a/tests/functional/history/test_db.py
+++ b/tests/functional/history/test_db.py
@@ -436,8 +436,12 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
         self._assert_expected_source('BOTOCORE', record)
 
     def test_can_emit_http_response_record(self):
-        # HTTP_RESPONSE also contains a binary response in its body, but it
-        # will not contain any non-unicode characters
+        # The raw HTTP_RESPONSE body is redacted before being persisted
+        # (see TestDatabaseHistoryHandler.
+        # test_emit_redacts_raw_body_of_http_response_record for why): it
+        # can carry the same credential material as the eventual
+        # PARSED_RESPONSE, but isn't structured yet, so it can't be safely
+        # redacted field-by-field the way PARSED_RESPONSE is.
         payload = {
             'status_code': 200,
             'headers': CaseInsensitiveDict({
@@ -450,7 +454,7 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
         record = self._get_last_record()
         parsed_payload = payload.copy()
         parsed_payload['headers'] = dict(parsed_payload['headers'])
-        parsed_payload['body'] = 'body with no invalid utf-8 bytes in it'
+        parsed_payload['body'] = '***REDACTED***'
         self._assert_record_has_command_id(record)
         self._assert_expected_event_type('HTTP_RESPONSE', record)
         self._assert_expected_payload(parsed_payload, record)

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -204,11 +204,41 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
         self.assertTrue(self.UUID_PATTERN.match(call['command_id']))
         self.assertTrue(self.UUID_PATTERN.match(call['request_id']))
 
+    def test_emit_redacts_sensitive_headers_of_http_request_record(self):
+        # Security regression test: request headers are what actually carry
+        # the caller's live credentials over the wire (Authorization has the
+        # SigV4 signature/access key ID, X-Amz-Security-Token has the full
+        # session token for temporary credentials). They must never be
+        # persisted in the CLI history database.
+        writer = mock.Mock(DatabaseRecordWriter)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
+        payload = {
+            'method': 'POST',
+            'headers': {
+                'Authorization': (
+                    'AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/...'
+                ),
+                'X-Amz-Security-Token': 'example-long-term-session-token',
+                'Content-Type': 'application/x-amz-json-1.1',
+            },
+        }
+        handler.emit('API_CALL', '', 'BOTOCORE')
+        handler.emit('HTTP_REQUEST', payload, 'BOTOCORE')
+        call = writer.write_record.call_args[0][0]
+        headers = call['payload']['headers']
+        self.assertEqual(headers['Authorization'], '***REDACTED***')
+        self.assertEqual(headers['X-Amz-Security-Token'], '***REDACTED***')
+        # Non-sensitive headers survive unredacted, since they have real
+        # debugging value and this feature would otherwise be much less
+        # useful for its intended purpose.
+        self.assertEqual(headers['Content-Type'], 'application/x-amz-json-1.1')
+
     def test_emit_does_write_http_response_record(self):
         writer = mock.Mock(DatabaseRecordWriter)
         record_builder = RecordBuilder()
         handler = DatabaseHistoryHandler(writer, record_builder)
-        payload = {'body': b'data'}
+        payload = {'status_code': 200, 'headers': {'Content-Type': 'text/xml'}}
         # In order for an http_response to have a request_id it must have been
         # preceeded by an api_call record.
         handler.emit('API_CALL', '', 'BOTOCORE')
@@ -227,6 +257,32 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
         )
         self.assertTrue(self.UUID_PATTERN.match(call['command_id']))
         self.assertTrue(self.UUID_PATTERN.match(call['request_id']))
+
+    def test_emit_redacts_raw_body_of_http_response_record(self):
+        # Security regression test: the raw (pre-parse) HTTP_RESPONSE body can
+        # contain the same credential/secret material as the eventual
+        # PARSED_RESPONSE (e.g. the raw XML/JSON of an sts:AssumeRole
+        # response), but unlike PARSED_RESPONSE it isn't structured yet, so
+        # it can't be safely redacted field-by-field. It must not be
+        # persisted in the CLI history database.
+        writer = mock.Mock(DatabaseRecordWriter)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
+        payload = {
+            'status_code': 200,
+            'body': (
+                b'<AssumeRoleResponse><Credentials>'
+                b'<SecretAccessKey>wJalrXUtnFEMI-example-secret</SecretAccessKey>'
+                b'<SessionToken>example-session-token</SessionToken>'
+                b'</Credentials></AssumeRoleResponse>'
+            ),
+        }
+        handler.emit('API_CALL', '', 'BOTOCORE')
+        handler.emit('HTTP_RESPONSE', payload, 'BOTOCORE')
+        call = writer.write_record.call_args[0][0]
+        self.assertEqual(call['payload']['body'], '***REDACTED***')
+        # Non-body fields are unaffected.
+        self.assertEqual(call['payload']['status_code'], 200)
 
     def test_emit_does_write_parsed_response_record(self):
         writer = mock.Mock(DatabaseRecordWriter)
@@ -251,6 +307,73 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
         )
         self.assertTrue(self.UUID_PATTERN.match(call['command_id']))
         self.assertTrue(self.UUID_PATTERN.match(call['request_id']))
+
+    def test_emit_redacts_nested_credentials_in_parsed_response_record(self):
+        # Security regression test: a PARSED_RESPONSE payload is the fully
+        # structured API response -- for calls like sts:AssumeRole this
+        # response body literally *is* a set of live, usable temporary
+        # credentials, and must not be persisted in the CLI history
+        # database, however deeply nested.
+        writer = mock.Mock(DatabaseRecordWriter)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
+        payload = {
+            'Credentials': {
+                'AccessKeyId': 'ASIAEXAMPLE',
+                'SecretAccessKey': 'example-secret-access-key',
+                'SessionToken': 'example-session-token',
+                'Expiration': '2026-01-01T00:00:00Z',
+            },
+            'AssumedRoleUser': {'Arn': 'arn:aws:sts::123456789012:assumed-role/x'},
+            'NextToken': 'example-pagination-token',
+        }
+        handler.emit('API_CALL', '', 'BOTOCORE')
+        handler.emit('PARSED_RESPONSE', payload, 'BOTOCORE')
+        call = writer.write_record.call_args[0][0]
+        creds = call['payload']['Credentials']
+        self.assertEqual(creds['SecretAccessKey'], '***REDACTED***')
+        self.assertEqual(creds['SessionToken'], '***REDACTED***')
+        # AccessKeyId is an identifier, not a secret on its own (AWS's own
+        # STS service model does not mark it sensitive either), and has
+        # real debugging value, e.g. "which key did this request use" --
+        # it must not be redacted.
+        self.assertEqual(creds['AccessKeyId'], 'ASIAEXAMPLE')
+        self.assertEqual(creds['Expiration'], '2026-01-01T00:00:00Z')
+        self.assertEqual(
+            call['payload']['AssumedRoleUser']['Arn'],
+            'arn:aws:sts::123456789012:assumed-role/x',
+        )
+        # A field whose name merely *contains* "Token" (extremely common
+        # across AWS APIs for non-secret pagination cursors, e.g. NextToken/
+        # ContinuationToken/ClientToken) must not be caught by a substring
+        # match on the sensitive-key list -- only an exact-name match on
+        # SessionToken (etc.) should redact.
+        self.assertEqual(
+            call['payload']['NextToken'], 'example-pagination-token'
+        )
+
+    def test_emit_redacts_sensitive_values_in_api_call_params(self):
+        # Security regression test: API_CALL params are what the *user* is
+        # sending -- e.g. a new IAM login password, or a value being written
+        # to Secrets Manager -- and are just as sensitive as what a service
+        # returns.
+        writer = mock.Mock(DatabaseRecordWriter)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
+        payload = {
+            'service': 'iam',
+            'operation': 'UpdateLoginProfile',
+            'params': {
+                'UserName': 'example-user',
+                'Password': 'example-new-password',
+            },
+        }
+        handler.emit('API_CALL', payload, 'BOTOCORE')
+        call = writer.write_record.call_args[0][0]
+        self.assertEqual(
+            call['payload']['params']['Password'], '***REDACTED***'
+        )
+        self.assertEqual(call['payload']['params']['UserName'], 'example-user')
 
 
 class BaseDatabaseRecordTester(unittest.TestCase):


### PR DESCRIPTION
### Issue #, if available

fixes #10560

### Description of changes

The `cli_history` feature (`cli_history = enabled`) records every HTTP request/response event to a local SQLite database (`~/.aws/cli/history/history.db`) via `HISTORY_RECORDER.record()`. Nothing in the write path redacted this data: `HTTP_REQUEST`'s raw headers (`Authorization`, `X-Amz-Security-Token`) and `PARSED_RESPONSE`'s full response body were both persisted verbatim.

For any call whose response *is* credential material — most notably `sts:AssumeRole`/`sts:GetSessionToken`, whose entire purpose is to hand back a live `AccessKeyId`/`SecretAccessKey`/`SessionToken` — enabling this documented, supported opt-in feature caused those temporary credentials to be written to disk in cleartext indefinitely. Same for the caller's own long-term credentials via the `Authorization`/`X-Amz-Security-Token` request headers on every recorded call.

The only filtering that existed anywhere in this feature was `DetailedFormatter._SIG_FILTER`, which masks the derived SigV4 signature suffix when a user runs `aws history show` — a display-time-only transform on one field, not a write-time safeguard, and it did nothing for the credentials themselves.

Added a redaction layer in `awscli/customizations/history/db.py`'s `RecordBuilder.build_record` (CLI-owned code, not the vendored botocore engine, so this survives a future botocore vendor sync) that runs on every record before it's written:

- **`HTTP_REQUEST`**: redacts the `Authorization` and `X-Amz-Security-Token` header values.
- **`API_CALL` params / `PARSED_RESPONSE`**: recursively redacts any dict value whose key exactly matches a curated set of known credential/secret field names (`SecretAccessKey`, `SessionToken`, `SecretString`, `Password`, `PrivateKey`, etc). This is deliberately an *exact-name* match, not a substring match, so routinely-named non-secret fields like `NextToken`/`ContinuationToken`/`ClientToken` are not caught. It's also deliberately broader than botocore's own shape-level `"sensitive"` metadata: STS's own service model marks `Credentials.SecretAccessKey` sensitive but **not** `Credentials.SessionToken`, even though a session token is just as directly usable as a live credential — relying solely on per-service model annotations being complete would still miss it.
- **`HTTP_RESPONSE`**: the raw body at this point is still an unparsed wire-format blob (`PARSED_RESPONSE` is the structured equivalent of the same data), so it can't be safely redacted field-by-field without risking either missing an embedded secret or corrupting the payload. It's replaced wholesale with a redaction marker instead.

`AccessKeyId` is intentionally left unredacted: it's an identifier, not a secret on its own (matching STS's own model, which does not mark it sensitive), and has real debugging value ("which key was used for this request").

### Motivation and Context

See #10560 for the full write-up, including a self-contained repro against the real, unmodified `HistoryRecorder`/`DatabaseHistoryHandler` classes showing `Authorization`, `X-Amz-Security-Token`, `SecretAccessKey`, and `SessionToken` all present verbatim in the SQLite file today.

### Testing

Updated two existing tests that asserted the vulnerable behavior directly (`test_emit_does_write_http_response_record` in `tests/unit/...`, and `test_can_emit_http_response_record` in `tests/functional/...`, both of which round-tripped a raw response body unredacted through to the assertion) to reflect the new, safe behavior.

Added regression tests covering exactly the fixed behavior:
- `test_emit_redacts_sensitive_headers_of_http_request_record` — `Authorization`/`X-Amz-Security-Token` redacted, `Content-Type` untouched.
- `test_emit_redacts_raw_body_of_http_response_record` — raw body replaced, other fields (`status_code`) untouched.
- `test_emit_redacts_nested_credentials_in_parsed_response_record` — nested `SecretAccessKey`/`SessionToken` redacted; `AccessKeyId`, `Expiration`, and a same-file `NextToken` field (proving no over-redaction via substring matching) all untouched.
- `test_emit_redacts_sensitive_values_in_api_call_params` — a `Password` param (input, not response) redacted; `UserName` untouched.

Confirmed all four new tests fail against the pre-fix code (`git stash` the fix, rerun) and pass with the fix.

```
$ python -m pytest tests/unit/customizations/history/ tests/functional/history/ -q
149 passed
```

Also re-ran the full repro from #10560 against the fixed code: `Authorization`, `X-Amz-Security-Token`, `SecretAccessKey`, and `SessionToken` are now all `***REDACTED***` in the resulting SQLite file; `AccessKeyId` and non-sensitive fields (service/operation names, ARNs, timestamps, `NextToken`-style pagination cursors) are unaffected.

`ruff check`/`ruff format` clean on all changed files.

### Reviewer Checklist

- [x] I have updated any necessary documentation
  - N/A -- this changes what's written to an internal history DB, not any user-facing CLI surface/output format.
- [x] I have added tests to cover my changes
- [x] I have added/updated the changelog (in the .changes/next-release directory, using the `scripts/new-change` tool)
- [ ] This PR includes breaking changes
- [x] I have run the tests successfully locally