### PR TITLE
Refactor ec2 run-instances _fix_args to use a param map

### DIFF
--- a/awscli/customizations/ec2/runinstances.py
+++ b/awscli/customizations/ec2/runinstances.py
@@ -97,29 +97,26 @@ def _fix_args(params, **kwargs):
         'SecondaryPrivateIpAddressCount',
         'AssociatePublicIpAddress'
     ]
+    # Simple top-level params that just get renamed and moved into the
+    # NetworkInterfaces structure verbatim.
+    simple_param_map = {
+        'SubnetId': 'SubnetId',
+        'SecurityGroupIds': 'Groups',
+        'Ipv6AddressCount': 'Ipv6AddressCount',
+        'Ipv6Addresses': 'Ipv6Addresses',
+        'EnablePrimaryIpv6': 'PrimaryIpv6',
+    }
     if 'NetworkInterfaces' in params:
         interface = params['NetworkInterfaces'][0]
         if any(param in interface for param in network_interface_params):
-            if 'SubnetId' in params:
-                interface['SubnetId'] = params['SubnetId']
-                del params['SubnetId']
-            if 'SecurityGroupIds' in params:
-                interface['Groups'] = params['SecurityGroupIds']
-                del params['SecurityGroupIds']
+            for src_key, dest_key in simple_param_map.items():
+                if src_key in params:
+                    interface[dest_key] = params.pop(src_key)
             if 'PrivateIpAddress' in params:
                 ip_addr = {'PrivateIpAddress': params['PrivateIpAddress'],
                            'Primary': True}
                 interface['PrivateIpAddresses'] = [ip_addr]
                 del params['PrivateIpAddress']
-            if 'Ipv6AddressCount' in params:
-                interface['Ipv6AddressCount'] = params['Ipv6AddressCount']
-                del params['Ipv6AddressCount']
-            if 'Ipv6Addresses' in params:
-                interface['Ipv6Addresses'] = params['Ipv6Addresses']
-                del params['Ipv6Addresses']
-            if 'EnablePrimaryIpv6' in params:
-                interface['PrimaryIpv6'] = params['EnablePrimaryIpv6']
-                del params['EnablePrimaryIpv6']
 
 
 EVENTS = [


### PR DESCRIPTION
## Summary

Fixes #10562

`_fix_args` in `awscli/customizations/ec2/runinstances.py` moved several scalar top-level params (`SubnetId`, `SecurityGroupIds`, `Ipv6AddressCount`, `Ipv6Addresses`, `EnablePrimaryIpv6`) into the `NetworkInterfaces[0]` structure via six nearly-identical `if key in params: interface[dest] = params[key]; del params[key]` blocks.

This replaces those blocks with a declarative `simple_param_map` (source key -> destination key) and a loop, keeping the `PrivateIpAddress` case as the one special-cased transform (it needs to be wrapped into a `PrivateIpAddresses` list, not just renamed).

Pure refactor — no behavior change.

## Test plan

- [x] `python3 -m pytest tests/functional/ec2/test_run_instances.py -q` — 23 passed