### PR TITLE
Simplify find_service_and_method_in_event_name index checks

### DIFF
--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -124,13 +124,7 @@ def find_service_and_method_in_event_name(event_name):
     event.service.operation.
     """
     split_event = event_name.split('.')[1:]
-    service_name = None
-    if len(split_event) > 0:
-        service_name = split_event[0]
-
-    operation_name = None
-    if len(split_event) > 1:
-        operation_name = split_event[1]
+    service_name, operation_name = (split_event + [None, None])[:2]
     return service_name, operation_name
 
 


### PR DESCRIPTION
## Summary

Fixes #10564

Replaces manual \`len(split_event) > 0\` / \`len(split_event) > 1\` checks with a pad-and-unpack pattern for safely destructuring a list of 0-2 elements.

Pure refactor — no behavior change.

## Test plan

- [x] \`python3 -m pytest tests/unit/test_utils.py -q\` — 54 passed