### PR TITLE
Use shutil.which in PosixHelpRenderer._exists_on_path

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -14,6 +14,7 @@ import logging
 import os
 import platform
 import shlex
+import shutil
 import sys
 from subprocess import PIPE, Popen
 
@@ -162,12 +163,7 @@ class PosixHelpRenderer(PagingHelpRenderer):
     def _exists_on_path(self, name):
         # Since we're only dealing with POSIX systems, we can
         # ignore things like PATHEXT.
-        return any(
-            [
-                os.path.exists(os.path.join(p, name))
-                for p in os.environ.get('PATH', '').split(os.pathsep)
-            ]
-        )
+        return shutil.which(name) is not None
 
 
 class WindowsHelpRenderer(PagingHelpRenderer):


### PR DESCRIPTION
## Summary

Fixes #10566

Replaces a manual PATH-walking reimplementation with the stdlib \`shutil.which\`.

Pure refactor — no behavior change.

## Test plan

- [x] \`python3 -m pytest tests/unit/test_help.py -q\` — 22 passed