### PR TITLE
Drop redundant list() wrapper around sorted()

### DIFF
--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -206,8 +206,8 @@ class TableFormatter(FullyBufferedFormatter):
             current_headers, current_more = self._group_scalar_keys(item)
             headers.update(current_headers)
             more.update(current_more)
-        headers = list(sorted(headers))
-        more = list(sorted(more))
+        headers = sorted(headers)
+        more = sorted(more)
         return headers, more
 
     def _group_scalar_keys(self, current):

--- a/awscli/text.py
+++ b/awscli/text.py
@@ -88,7 +88,7 @@ def _all_scalar_keys(list_of_dicts):
         for key, value in item_dict.items():
             if not isinstance(value, (dict, list)):
                 keys_seen.add(key)
-    return list(sorted(keys_seen))
+    return sorted(keys_seen)
 
 
 def _partition_dict(item_dict, scalar_keys):


### PR DESCRIPTION
## Summary

Fixes #10568

\`sorted()\` already returns a \`list\`, so \`list(sorted(...))\` in \`formatter.py\` and \`text.py\` was a needless no-op call.

Pure refactor — no behavior change.

## Test plan

- [x] \`python3 -m pytest tests/unit/test_text.py tests/unit/output/test_table_formatter.py tests/unit/output/test_text_output.py -q\` — 36 passed