### PR TITLE
Use dict comprehension in _get_endpoint_prefix_to_name_mappings

### DIFF
--- a/awscli/customizations/configure/addmodel.py
+++ b/awscli/customizations/configure/addmodel.py
@@ -21,11 +21,10 @@ from awscli.customizations.commands import BasicCommand
 def _get_endpoint_prefix_to_name_mappings(session):
     # Get the mappings of endpoint prefixes to service names from the
     # available service models.
-    prefixes_to_services = {}
-    for service_name in session.get_available_services():
-        service_model = session.get_service_model(service_name)
-        prefixes_to_services[service_model.endpoint_prefix] = service_name
-    return prefixes_to_services
+    return {
+        session.get_service_model(service_name).endpoint_prefix: service_name
+        for service_name in session.get_available_services()
+    }
 
 
 def _get_service_name(session, endpoint_prefix):


### PR DESCRIPTION
## Summary

Fixes #10570

Replaces an empty-dict-then-loop-assignment pattern with a direct dict comprehension.

Pure refactor — no behavior change.

## Test plan

- [x] \`python3 -m pytest tests/unit/customizations/configure/test_addmodel.py -q\` — 6 passed