### PR TITLE
Simplify _construct_result in emr createdefaultroles

### DIFF
--- a/awscli/customizations/emr/createdefaultroles.py
+++ b/awscli/customizations/emr/createdefaultroles.py
@@ -208,20 +208,16 @@ class CreateDefaultRoles(Command):
     def _construct_result(self, ec2_response, ec2_policy,
                           emr_response, emr_policy,
                           emr_autoscaling_response, emr_autoscaling_policy):
-        result = []
-        self._construct_role_and_role_policy_structure(
-            result, ec2_response, ec2_policy)
-        self._construct_role_and_role_policy_structure(
-            result, emr_response, emr_policy)
-        self._construct_role_and_role_policy_structure(
-            result, emr_autoscaling_response, emr_autoscaling_policy)
-        return result
-
-    def _construct_role_and_role_policy_structure(
-            self, list, response, policy):
-        if response is not None and response['Role'] is not None:
-            list.append({'Role': response['Role'], 'RolePolicy': policy})
-            return list
+        responses_and_policies = (
+            (ec2_response, ec2_policy),
+            (emr_response, emr_policy),
+            (emr_autoscaling_response, emr_autoscaling_policy),
+        )
+        return [
+            {'Role': response['Role'], 'RolePolicy': policy}
+            for response, policy in responses_and_policies
+            if response is not None and response['Role'] is not None
+        ]
 
     def check_if_role_exists(self, role_name, parsed_globals):
         parameters = {'RoleName': role_name}


### PR DESCRIPTION
## Summary

Fixes #10572

Replaces a mutating helper — whose parameter was literally named \`list\`, shadowing the builtin — with a list comprehension over the response/policy pairs.

Pure refactor — no behavior change.

## Test plan

- [x] \`python3 -m pytest tests/unit/customizations/emr/test_create_default_role.py -q\` — 13 passed