### PR TITLE
[v2] Fix CreateSession race condition with S3Express multi-file transfers

### DIFF
--- a/.changes/next-release/bugfix-s3-3139.json
+++ b/.changes/next-release/bugfix-s3-3139.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Fixes a race condition where CreateSession is called multiple times across different threads during an S3-Express recursive upload/download."
+}

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -25,6 +25,7 @@ import re
 import secrets
 import socket
 import string
+import threading
 import time
 import uuid
 import warnings
@@ -1483,10 +1484,15 @@ class S3ExpressIdentityCache(IdentityCache):
     def __init__(self, client, credential_cls):
         self._client = client
         self._credential_cls = credential_cls
+        self._lock = threading.Lock()
 
     @functools.lru_cache(maxsize=100)
-    def get_credentials(self, bucket):
+    def _get_credentials_cached(self, bucket):
         return super().get_credentials(bucket=bucket)
+
+    def get_credentials(self, bucket):
+        with self._lock:
+            return self._get_credentials_cached(bucket)
 
     def build_refresh_callback(self, bucket):
         def refresher():


### PR DESCRIPTION
*Description of changes:*

* Fixes a bug where CreateSession is called multiple times during a multi-file S3-transfer command. The bug was a race condition where each thread was calling `get_credentials`, at around the same time. Even though the function is wrapped with `@lru_cache`, it appears that multiple threads are calling it before the first thread completes execution, leading to the race condition.

*Root-cause analysis:*

I created an S3-Express bucket with 15 objects, kept the default config for `s3.max_concurrent_requests=10`, and ran the following command to perform a recursive S3Express download and write debug logs to a file:

```bash
aws s3 cp s3://<BUCKET-NAME>--usw2-az1--x-s3 . --recursive --debug 2>debug.txt   
```

I then ran the following command to find how many CreateSession requests were made:

```
cat debug.txt | grep "createsessionresult xmlns" -i ./debug.txt > debug_search
```

This produced the following results:

```
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
```

This shows 11 total CreateSession requests were made. 1 for the initial ListObjectsV2, and the other 10 are for 10 of the GetObject requests that occur on separate threads (10 threads max). The last 5 GetObject requests did not cause CreateSession calls because their owning threads reused the cached credentials.

The initial 10 GetObject calls invoked `get_credentials` concurrently before the first call completed, which is why `lru_cache` did not serve S3Express credentials from the cache. This aligns with the documentation for `lru_cache` ([source](https://docs.python.org/3/library/functools.html#functools.lru_cache)):

> The cache is threadsafe so that the wrapped function can be used in multiple threads. This means that the underlying data structure will remain coherent during concurrent updates.
>
> It is possible for the wrapped function to be called more than once if another thread makes an additional call before the initial call has been completed and cached.

**After applying the patch, I re-ran the same workflow described above, and produced the following results:**

```
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
b'<?xml version="1.0" encoding="UTF-8"?>\n<CreateSessionResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Credentials><SessionToken>REDACTED</SessionToken><SecretAccessKey>REDACTED</SecretAccessKey><AccessKeyId>REDACTED</AccessKeyId><Expiration>REDACTED</Expiration></Credentials></CreateSessionResult>'
```

These results are expected. One `CreateSession` call for the initial ListObjectsV2, and one `CreateSession` for the S3Transfer client reused by all threads for all `GetObject` calls.

*Description of tests:*

* No test to add currently, but a blackbox test that will be merged in the future will assert the expected behavior (order of HTTP requests and number of `CreateSession` calls).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
