### PR TITLE
Fix s3 recursive download parent-dir escape guard missing bare '..' key

### DIFF
--- a/.changes/next-release/bugfix-s3-10579.json
+++ b/.changes/next-release/bugfix-s3-10579.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Fixed a bug in `s3 cp`/`s3 sync --recursive` where the parent-directory-reference guard failed to detect an S3 key that normalizes to exactly `..` (e.g. `prefix/..`), allowing such objects to bypass the protective warning and crash the download with an unhandled OS error instead of being skipped."
+}

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -324,7 +324,7 @@ class BaseTransferRequestSubmitter(object):
         # Anchor compare_key against '.' (the destination directory root)
         # to avoid false negatives on paths like '/../foo'
         normalized = os.path.normpath('.' + os.path.sep + fileinfo.compare_key)
-        escapes_cwd = normalized.startswith(parent_prefix)
+        escapes_cwd = normalized == '..' or normalized.startswith(parent_prefix)
         if escapes_cwd:
             warning = create_warning(
                 fileinfo.compare_key, "File references a parent directory.")

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -581,6 +581,20 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.assertIsInstance(warning_result, WarningResult)
         self.assert_no_downloads_happened()
 
+    def test_warn_and_ignore_on_bare_parent_reference(self):
+        fileinfo = self.create_file_info('..')
+        future = self.transfer_request_submitter.submit(fileinfo)
+        warning_result = self.result_queue.get()
+        self.assertIsInstance(warning_result, WarningResult)
+        self.assert_no_downloads_happened()
+
+    def test_warn_and_ignore_on_bare_parent_reference_with_prefix(self):
+        fileinfo = self.create_file_info('a/../..')
+        future = self.transfer_request_submitter.submit(fileinfo)
+        warning_result = self.result_queue.get()
+        self.assertIsInstance(warning_result, WarningResult)
+        self.assert_no_downloads_happened()
+
     def test_dry_run(self):
         self.cli_params['dryrun'] = True
         self.transfer_request_submitter = DownloadRequestSubmitter(


### PR DESCRIPTION
## Summary

Fixes #10579.

`_warn_parent_reference` (`awscli/customizations/s3/s3handler.py`), the guard that warns and skips S3 objects during `aws s3 cp`/`aws s3 sync --recursive` when their key would make the local destination escape the target directory, only matched keys that normalize to `'../something'`. Keys that normalize to exactly `'..'` (e.g. a legal S3 key like `prefix/..`) slipped past the check, bypassing the intended warning and causing an unhandled OS error (e.g. `IsADirectoryError`) during the download instead of a graceful skip.

Fix: also treat a normalized path of exactly `'..'` as escaping the destination.

```python
escapes_cwd = normalized == '..' or normalized.startswith(parent_prefix)
```

## Test plan

- Added two unit tests to `tests/unit/customizations/s3/test_s3handler.py`:
  - `test_warn_and_ignore_on_bare_parent_reference` — key `..`
  - `test_warn_and_ignore_on_bare_parent_reference_with_prefix` — key `a/../..`
  - Both fail (hang, since no warning is enqueued) against the pre-fix code, and pass after the fix.
- Ran the full `tests/unit/customizations/s3/test_s3handler.py` suite: 64 passed, no regressions.
- Added a changelog entry under `.changes/next-release/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)