### PR TITLE
Fix UnboundLocalError in OutputStreamFactory.get_pager_stream on popen failure

### DIFF
--- a/.changes/next-release/bugfix-history-10581.json
+++ b/.changes/next-release/bugfix-history-10581.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "history",
+  "description": "Fixed an `UnboundLocalError` raised by `aws history show`/`aws history list` when the configured pager (`AWS_PAGER`/`PAGER`) fails to start (e.g. does not exist), instead of propagating the underlying `OSError`."
+}

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -242,8 +242,8 @@ class OutputStreamFactory:
     @contextlib.contextmanager
     def get_pager_stream(self, preferred_pager=None):
         popen_kwargs = self._get_process_pager_kwargs(preferred_pager)
+        process = self._popen(**popen_kwargs)
         try:
-            process = self._popen(**popen_kwargs)
             yield process.stdin
         except OSError:
             # Ignore IOError since this can commonly be raised when a pager

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -239,6 +239,12 @@ class TestOutputStreamFactory(unittest.TestCase):
         except IOError:
             self.fail('Should not raise IOError')
 
+    def test_propagates_error_when_pager_process_fails_to_start(self):
+        self.popen.side_effect = OSError('No such file or directory')
+        with self.assertRaises(OSError):
+            with self.stream_factory.get_pager_stream():
+                pass
+
 
 class BaseShapeTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Fixes #10581.

`OutputStreamFactory.get_pager_stream` (used by `aws history show`/`aws history list` to pipe output through a pager) wraps both process creation (`self._popen(...)`) and process usage (`yield process.stdin`) in a single `try`/`except OSError: pass`/`finally: process.communicate()` block. The except clause is meant to swallow broken-pipe errors that occur while writing to the pager.

If `self._popen(...)` itself raises `OSError` (e.g. the configured `AWS_PAGER`/`PAGER` binary doesn't exist), `process` is never assigned. The except clause swallows that `OSError`, but the `finally` block's `process.communicate()` then raises `UnboundLocalError: cannot access local variable 'process'` instead of a meaningful error — turning a simple pager-misconfiguration into a confusing crash.

## Fix

Move `process = self._popen(**popen_kwargs)` outside the try block, so:
- A failure to start the pager process propagates as a normal `OSError` (e.g. `FileNotFoundError`), which is clear and actionable.
- The existing broken-pipe-swallowing behavior for `yield process.stdin` is unchanged.

## Test plan

- Added `test_propagates_error_when_pager_process_fails_to_start` to `tests/unit/test_utils.py::TestOutputStreamFactory`, which mocks `popen` to raise `OSError` and asserts it propagates.
  - Verified this test fails with `UnboundLocalError` against the pre-fix code, and passes after the fix.
- Ran `tests/unit/test_utils.py` (55 passed) and `tests/unit/customizations/history/` (117 passed) — no regressions.
- Added a changelog entry under `.changes/next-release/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)