### PR TITLE
Fix CodeDeploy install when service is missing

### DIFF
--- a/awscli/customizations/codedeploy/systems.py
+++ b/awscli/customizations/codedeploy/systems.py
@@ -66,7 +66,8 @@ class Windows(System):
                 '-Name', 'codedeployagent'
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
+            text=True
         )
         (output, error) = process.communicate()
         not_found = (
@@ -102,7 +103,8 @@ class Windows(System):
                 '-Name', 'codedeployagent'
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
+            text=True
         )
         (output, error) = process.communicate()
         if "Running" not in output:
@@ -118,7 +120,8 @@ class Windows(System):
                 '-Name', 'codedeployagent'
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
+            text=True
         )
         (output, error) = process.communicate()
         not_found = (
@@ -139,7 +142,8 @@ class Windows(System):
                 'call', 'uninstall', '/nointeractive'
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
+            text=True
         )
         (output, error) = process.communicate()
         if process.returncode != 0:
@@ -202,7 +206,8 @@ class Linux(System):
         process = subprocess.Popen(
             ['service', 'codedeploy-agent', 'stop'],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
+            text=True
         )
         (output, error) = process.communicate()
         if process.returncode != 0 and params.not_found_msg not in error:

--- a/tests/unit/customizations/codedeploy/test_systems.py
+++ b/tests/unit/customizations/codedeploy/test_systems.py
@@ -88,7 +88,8 @@ class TestWindows(unittest.TestCase):
                     '-Name', 'codedeployagent'
                 ],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
             ),
             mock.call().communicate(),
             mock.call(
@@ -98,7 +99,8 @@ class TestWindows(unittest.TestCase):
                     '-Name', 'codedeployagent'
                 ],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
             ),
             mock.call().communicate()
         ])
@@ -134,7 +136,8 @@ class TestWindows(unittest.TestCase):
                     '-Name', 'codedeployagent'
                 ],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
             ),
             mock.call().communicate(),
             mock.call(
@@ -144,10 +147,37 @@ class TestWindows(unittest.TestCase):
                     'call', 'uninstall', '/nointeractive'
                 ],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
             ),
             mock.call().communicate()
         ])
+
+    def test_install_service_not_found(self):
+        not_found = (
+            "Cannot find any service with service name 'codedeployagent'"
+        )
+        stop_process = mock.MagicMock()
+        stop_process.communicate.return_value = ('', not_found)
+        stop_process.returncode = 1
+
+        get_process = mock.MagicMock()
+        get_process.communicate.return_value = ('Running', '')
+        get_process.returncode = 0
+
+        self.popen.side_effect = [stop_process, get_process]
+        self.windows.install(self.params)
+
+    def test_uninstall_service_not_found(self):
+        not_found = (
+            "Cannot find any service with service name 'codedeployagent'"
+        )
+        process = mock.MagicMock()
+        process.communicate.return_value = ('', not_found)
+        process.returncode = 1
+        self.popen.return_value = process
+        self.windows.uninstall(self.params)
+        self.assertEqual(self.popen.call_count, 1)
 
 
 class TestLinux(unittest.TestCase):
@@ -248,7 +278,8 @@ class TestUbuntu(TestLinux):
             mock.call(
                 ['service', 'codedeploy-agent', 'stop'],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
             ),
             mock.call().communicate()
         ])
@@ -274,13 +305,34 @@ class TestUbuntu(TestLinux):
             mock.call(
                 ['service', 'codedeploy-agent', 'stop'],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
             ),
             mock.call().communicate()
         ])
         self.check_call.assert_has_calls([
             mock.call(['dpkg', '-r', 'codedeploy-agent'])
         ])
+
+    def test_install_service_not_found(self):
+        process = mock.MagicMock()
+        process.communicate.return_value = (
+            '', 'codedeploy-agent: unrecognized service'
+        )
+        process.returncode = 1
+        self.popen.return_value = process
+        self.ubuntu.install(self.params)
+
+    def test_uninstall_service_not_found(self):
+        process = mock.MagicMock()
+        process.communicate.return_value = (
+            '', 'codedeploy-agent: unrecognized service'
+        )
+        process.returncode = 1
+        self.popen.return_value = process
+        self.ubuntu.uninstall(self.params)
+        self.assertEqual(self.popen.call_count, 1)
+
 
 class TestRHEL(TestLinux):
     def setUp(self):
@@ -316,7 +368,8 @@ class TestRHEL(TestLinux):
             mock.call(
                 ['service', 'codedeploy-agent', 'stop'],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
             ),
             mock.call().communicate()
         ])
@@ -341,13 +394,34 @@ class TestRHEL(TestLinux):
             mock.call(
                 ['service', 'codedeploy-agent', 'stop'],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                text=True
             ),
             mock.call().communicate()
         ])
         self.check_call.assert_has_calls([
             mock.call(['yum', '-y', 'erase', 'codedeploy-agent'])
         ])
+
+    def test_install_service_not_found(self):
+        process = mock.MagicMock()
+        process.communicate.return_value = (
+            '', 'Redirecting to /bin/systemctl stop  codedeploy-agent.service'
+        )
+        process.returncode = 1
+        self.popen.return_value = process
+        self.rhel.install(self.params)
+
+    def test_uninstall_service_not_found(self):
+        process = mock.MagicMock()
+        process.communicate.return_value = (
+            '', 'Redirecting to /bin/systemctl stop  codedeploy-agent.service'
+        )
+        process.returncode = 1
+        self.popen.return_value = process
+        self.rhel.uninstall(self.params)
+        self.assertEqual(self.popen.call_count, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
*Issue #10576

Fixes a TypeError that occurred when installing or uninstalling the
CodeDeploy agent on a host where the agent service does not exist.

Subprocess output was returned as bytes while the service status checks
compared it against string values. The subprocess calls now use text mode
so the output is returned as strings.

Added regression tests to ensure the service-not-found case is handled
without raising a TypeError.

