### PR TITLE
feat(user-agent): Attribute the Kiro IDE agent

### DIFF
--- a/.changes/next-release/enhancement-UserAgent-53908.json
+++ b/.changes/next-release/enhancement-UserAgent-53908.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "User Agent",
+  "description": "Expose ``is_agentic_caller`` so callers can detect the agentic callers already reported in the User-Agent."
+}

--- a/awscli/botocore/useragent.py
+++ b/awscli/botocore/useragent.py
@@ -170,6 +170,23 @@ def _agentic_env_var_is_set(env_var, expected_value):
     return value == expected_value
 
 
+def is_agentic_caller():
+    """Return True if the current process appears to be driven by a known
+    agentic caller (e.g. Claude Code, Gemini CLI, Codex).
+
+    Detection uses the same environment-variable signals that populate the
+    ``AGENTIC_CALLER_*`` metrics in the User-Agent header, so callers that
+    want to adapt their behavior for agents stay in sync with what the SDK
+    already reports.
+    """
+    return any(
+        _agentic_env_var_is_set(env_var, expected_value)
+        for env_var, _feature_id, expected_value in (
+            _USERAGENT_AGENTIC_CALLER_ENV_VAR_MAPPINGS
+        )
+    )
+
+
 def _register_agentic_caller_env_features():
     for (
         env_var,

--- a/tests/unit/botocore/test_useragent.py
+++ b/tests/unit/botocore/test_useragent.py
@@ -22,6 +22,7 @@ from botocore.useragent import (
     UserAgentComponent,
     UserAgentComponentSizeConfig,
     UserAgentString,
+    is_agentic_caller,
     register_feature_id,
     sanitize_user_agent_string_component,
 )
@@ -76,6 +77,40 @@ def clear_agentic_caller_env(monkeypatch):
 def test_sanitize_ua_string_component(raw_str, allow_hash, expected_str):
     actual_str = sanitize_user_agent_string_component(raw_str, allow_hash)
     assert actual_str == expected_str
+
+
+def test_is_agentic_caller_false_when_no_env_set():
+    # clear_agentic_caller_env fixture unsets all agentic caller env vars.
+    assert is_agentic_caller() is False
+
+
+@pytest.mark.parametrize(
+    'env_var, value',
+    [
+        ('CLAUDECODE', '1'),
+        ('GEMINI_CLI', '1'),
+        ('CODEX_THREAD_ID', 'some-thread-id'),
+        ('KIRO_SESSION_ID', 'some-session-id'),
+        ('OPENCODE', 'anything'),
+        ('CURSOR_AGENT', '1'),
+        ('PI_CODING_AGENT', 'true'),
+    ],
+)
+def test_is_agentic_caller_true_when_env_set(monkeypatch, env_var, value):
+    monkeypatch.setenv(env_var, value)
+    assert is_agentic_caller() is True
+
+
+def test_is_agentic_caller_false_when_value_does_not_match(monkeypatch):
+    # CLAUDECODE only counts when it equals '1'.
+    monkeypatch.setenv('CLAUDECODE', '0')
+    assert is_agentic_caller() is False
+
+
+def test_is_agentic_caller_false_when_env_empty(monkeypatch):
+    # An env var expecting any non-empty value must not match ''.
+    monkeypatch.setenv('CODEX_THREAD_ID', '')
+    assert is_agentic_caller() is False
 
 
 def test_basic_user_agent_string():


### PR DESCRIPTION
The Kiro IDE and Kiro CLI are separate products with separate app bundles. Only the CLI exports KIRO_SESSION_ID, so commands driven by the IDE's agent were reported as ordinary human-run commands and its traffic was unattributed.

Add AGENTIC_CALLER_KIRO_IDE (AX), keyed on KIRO_AGENT. The variable is scoped to agent activity rather than to the editor being open, following CURSOR_AGENT and ANTIGRAVITY_AGENT. 

Something like TERM_PROGRAM=kiro was rejected since the IDE's integrated terminal is also human-driven, so it would attribute a person's typing as agentic and make the metric non-comparable with the other AGENTIC_CALLER_* rows. Kiro service must export KIRO_AGENT for this to report, matching how Cursor behaves today. Setting this up for when it does.

Also expose is_agentic_caller() so callers that adapt behavior for agents (for example, suppressing interactive prompts) use the same signals the User-Agent already reports instead of reimplementing the table.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
