### PR TITLE
Fix auth token leakage in CodeArtifact login error messages

### DIFF
--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -42,10 +42,10 @@ class CommandFailedError(Exception):
     def __init__(self, called_process_error, auth_token):
         msg = str(called_process_error).replace(auth_token, '******')
         if called_process_error.stderr is not None:
-            msg +=(
-                f' Stderr from command:\n'
-                f'{called_process_error.stderr.decode(get_stderr_encoding())}'
-            )
+            stderr = called_process_error.stderr.decode(
+                get_stderr_encoding()
+            ).replace(auth_token, '******')
+            msg += f' Stderr from command:\n{stderr}'
         Exception.__init__(self, msg)
 
 

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -83,6 +83,21 @@ class TestBaseLogin(unittest.TestCase):
         ):
             self.test_subject._run_commands('tool', ['cmd'])
 
+    def test_run_commands_command_failed_redact_auth_token_in_stderr(self):
+        error_to_be_caught = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=['cmd'],
+            output=None,
+            stderr=b'Command error message containing auth-token here.'
+        )
+        self.subprocess_utils.run.side_effect = error_to_be_caught
+        with self.assertRaisesRegex(
+            CommandFailedError,
+            rf"(?=.*cmd)(?!.*auth-token)"
+            rf"(?=.*Stderr from command:\nCommand error message containing \*\*\*\*\*\* here.)"
+        ):
+            self.test_subject._run_commands('tool', ['cmd'])
+
     def test_run_commands_nonexistent_command(self):
         self.subprocess_utils.run.side_effect = OSError(
             errno.ENOENT, 'not found error'


### PR DESCRIPTION
The CommandFailedError class redacted the auth token from the main error message but not from stderr output of failed commands. This could expose the auth token in error messages when subprocess commands fail. Add token redaction to stderr and add a test to verify the token is masked in all error output.

*Issue #10575

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
