### PR TITLE
Fix UnboundLocalError in ConfigFileWriter._update_subattributes for empty nested sections

### DIFF
--- a/.changes/next-release/bugfix-configure-10587.json
+++ b/.changes/next-release/bugfix-configure-10587.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "configure",
+  "description": "Fixed an `UnboundLocalError` raised by `aws configure set` when updating a nested config section (e.g. `s3`, `s3api`) that currently has no sub-keys under it."
+}

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -215,6 +215,8 @@ class ConfigFileWriter(object):
 
     def _update_subattributes(self, index, contents, values, starting_indent):
         index += 1
+        current_indent = None
+        i = index - 1
         for i in range(index, len(contents)):
             line = contents[i]
             match = self.OPTION_REGEX.search(line)

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -326,6 +326,34 @@ class TestConfigFileWriter(unittest.TestCase):
             '[profile foo]\n'
             'foo = bar\n')
 
+    def test_add_to_empty_nested_stanza_followed_by_section(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+            '[profile foo]\n'
+            'foo = bar\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '    signature_version = newval\n'
+            '[profile foo]\n'
+            'foo = bar\n')
+
+    def test_add_to_empty_nested_stanza_at_eof(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '    signature_version = newval\n')
+
     def test_update_nested_attr_no_prior_nesting(self):
         original = (
             '[default]\n'


### PR DESCRIPTION
## Summary

Fixes #10587.

`ConfigFileWriter._update_subattributes` (used by `aws configure set` to write into nested config sections like `s3`/`s3api`) only assigned `current_indent` inside the branch where a sub-option line matched `OPTION_REGEX`. When the target nested section is currently **empty** (no sub-keys yet — a valid config state, e.g. `s3 =` immediately followed by another `[section]`, or `s3 =` as the last line of the file), `current_indent` (and, in the end-of-file case, the loop variable `i`) is never assigned, and the subsequent reference raises `UnboundLocalError` instead of writing the value.

## Fix

Initialize `current_indent = None` and `i = index - 1` before the loop. `None` never equals `starting_indent` (always an int), so behavior for every previously-passing case (sections with existing sub-keys) is unchanged — this only fixes the two previously-crashing empty-section paths.

## Test plan

- Added `test_add_to_empty_nested_stanza_followed_by_section` and `test_add_to_empty_nested_stanza_at_eof` to `tests/unit/customizations/configure/test_writer.py`.
  - Verified both fail with `UnboundLocalError` against the pre-fix code, and pass after the fix (including correctly writing the value, not just avoiding the crash).
- Ran `tests/unit/customizations/configure/` (109 passed) and `tests/functional/configure/` (33 passed) — no regressions.
- Added a changelog entry under `.changes/next-release/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)