### PR TITLE
Fix s3 transfer stats corruption when two transfers share (type, src, dest)

### DIFF
--- a/.changes/next-release/bugfix-s3-10589.json
+++ b/.changes/next-release/bugfix-s3-10589.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Fixed a bug where `s3 cp`/`sync`/`mv`/`rm` transfer progress and size accounting could be corrupted if two concurrent transfers shared the same transfer type, source, and destination, by disambiguating in-flight transfer bookkeeping with the transfer's unique `transfer_id`."
+}

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -46,6 +46,17 @@ def _create_new_result_cls(name, extra_fields=None, base_cls=BaseResult):
     fields = list(base_cls._fields)
     if extra_fields:
         fields += extra_fields
+    # transfer_id disambiguates concurrent transfers that share the same
+    # (transfer_type, src, dest), e.g. the same file uploaded to the same
+    # destination more than once in a single invocation. It defaults to
+    # None so existing callers that don't provide one are unaffected.
+    if base_cls is BaseResult and 'transfer_id' not in fields:
+        fields += ['transfer_id']
+        return type(
+            name,
+            (namedtuple(name, fields, defaults=(None,)), base_cls),
+            {}
+        )
     return type(name, (namedtuple(name, fields), base_cls), {})
 
 
@@ -124,7 +135,8 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
             'transfer_type': self._transfer_type,
             'src': src,
             'dest': dest,
-            'total_transfer_size': future.meta.size
+            'total_transfer_size': future.meta.size,
+            'transfer_id': future.meta.transfer_id,
         }
         self._result_kwargs_cache[future.meta.transfer_id] = result_kwargs
 
@@ -250,6 +262,12 @@ class ResultRecorder(BaseResultHandler):
         for result_property in [result.transfer_type, result.src, result.dest]:
             if result_property is not None:
                 key_parts.append(ensure_text_type(result_property))
+        # transfer_id disambiguates two otherwise-identical concurrent
+        # transfers (same transfer_type/src/dest) so their progress and
+        # size accounting don't collide in the ongoing-transfer dicts.
+        transfer_id = getattr(result, 'transfer_id', None)
+        if transfer_id is not None:
+            key_parts.append(ensure_text_type(str(transfer_id)))
         return u':'.join(key_parts)
 
     def _pop_result_from_ongoing_dicts(self, result):

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -653,6 +653,49 @@ class ResultRecorderTest(unittest.TestCase):
         self.assertEqual(
             self.result_recorder.bytes_transferred, bytes_transferred)
 
+    def test_concurrent_transfers_with_same_key_do_not_clobber_each_other(self):
+        # Two distinct, concurrently in-flight transfers can share the same
+        # (transfer_type, src, dest), e.g. the same file uploaded to the
+        # same destination more than once within a single invocation. Their
+        # accounting must stay independent (via transfer_id) instead of
+        # colliding in the ongoing-transfer dicts.
+        self.result_recorder(
+            QueuedResult(
+                transfer_type=self.transfer_type, src=self.src,
+                dest=self.dest, total_transfer_size=1000, transfer_id=1
+            )
+        )
+        self.result_recorder(
+            QueuedResult(
+                transfer_type=self.transfer_type, src=self.src,
+                dest=self.dest, total_transfer_size=2000, transfer_id=2
+            )
+        )
+        self.assertEqual(
+            self.result_recorder.expected_bytes_transferred, 3000)
+
+        # transfer_id=1 completes successfully.
+        self.result_recorder(
+            SuccessResult(
+                transfer_type=self.transfer_type, src=self.src,
+                dest=self.dest, transfer_id=1
+            )
+        )
+        self.assertEqual(self.result_recorder.files_transferred, 1)
+
+        # transfer_id=2 (still fully outstanding) then fails. Its
+        # bookkeeping must not have been wiped out by transfer_id=1's
+        # completion.
+        self.result_recorder(
+            FailureResult(
+                transfer_type=self.transfer_type, src=self.src,
+                dest=self.dest, exception=self.exception, transfer_id=2
+            )
+        )
+        self.assertEqual(self.result_recorder.files_failed, 1)
+        self.assertEqual(
+            self.result_recorder.bytes_failed_to_transfer, 2000)
+
     def test_failure_result_still_did_not_know_transfer_size(self):
         self.result_recorder(
             QueuedResult(


### PR DESCRIPTION
## Summary

Fixes #10589.

`ResultRecorder`'s in-flight transfer bookkeeping (`_ongoing_progress`, `_ongoing_total_sizes`) is keyed only by `(transfer_type, src, dest)`. Every s3transfer `Future` already carries a unique `future.meta.transfer_id`, but it's dropped before reaching `ResultRecorder`. If two transfers are ever queued concurrently with the identical `(transfer_type, src, dest)` tuple, their bookkeeping collides in the same dict slot: whichever completes first pops the shared entry, corrupting the other's still-in-flight accounting (e.g. `bytes_failed_to_transfer` can read `0` for a transfer that genuinely failed with bytes outstanding).

I was not able to construct a confirmed realistic end-to-end CLI scenario that triggers this (normal `cp`/`sync` produce unique `(src, dest)` per file), so I'm not claiming a proven high-severity data-loss path — see the honesty note in the linked issue. This is a real defect in the stats/progress accounting layer worth fixing defensively, since the disambiguating identifier is already available and simply unused.

## Fix

- Add an optional `transfer_id` field (default `None`) to the `BaseResult`-derived result types — fully backward compatible with all existing construction call sites.
- Populate it from `future.meta.transfer_id` in `BaseResultSubscriber._add_to_result_kwargs_cache`.
- Use it in `_get_ongoing_dict_key` (when present) to disambiguate otherwise-identical concurrent transfers.

## Test plan

- Added `test_concurrent_transfers_with_same_key_do_not_clobber_each_other` to `tests/unit/customizations/s3/test_results.py`, reproducing the exact collision/clobbering scenario.
  - Verified it fails against the pre-fix code and passes after the fix.
- Ran `tests/unit/customizations/s3/` + `tests/functional/s3/`: 764 passed, 14 skipped, no regressions (up from 763 passed pre-change, reflecting the one new test).
- Added a changelog entry under `.changes/next-release/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)