### PR TITLE
Speed up autocomplete index generation with a single SQLite transaction

### DIFF
--- a/.changes/next-release/enhancement-Source-2201.json
+++ b/.changes/next-release/enhancement-Source-2201.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Source",
+  "description": "Speed up autocomplete index generation with a single SQLite transaction"
+}

--- a/awscli/autocomplete/generator.py
+++ b/awscli/autocomplete/generator.py
@@ -51,7 +51,9 @@ def _do_generate_index(filename):
     driver = clidriver.create_clidriver()
     index_gen = IndexGenerator(indexers=indexers)
     try:
+        db_connection.execute('BEGIN')
         index_gen.generate_index(driver)
+        db_connection.execute('COMMIT')
     finally:
         db_connection.close()
 
@@ -70,5 +72,5 @@ class IndexGenerator:
         self._indexers = indexers
 
     def generate_index(self, clidriver):
-        for indexer in self._indexers:
-            indexer.generate_index(clidriver)
+        for index_builder in self._indexers:
+            index_builder.generate_index(clidriver)

--- a/tests/unit/autocomplete/test_generator.py
+++ b/tests/unit/autocomplete/test_generator.py
@@ -23,3 +23,15 @@ class TestGenerateCompletionIndex(unittest.TestCase):
         index = generator.IndexGenerator([model_index])
         index.generate_index(clidriver)
         model_index.generate_index.assert_called_with(clidriver)
+
+    @mock.patch('awscli.autocomplete.generator.IndexGenerator')
+    @mock.patch('awscli.autocomplete.generator.clidriver.create_clidriver')
+    @mock.patch('awscli.autocomplete.generator.db.DatabaseConnection')
+    def test_generates_index_in_transaction(
+        self, database_connection, _create_clidriver, _index_generator
+    ):
+        generator._do_generate_index('index.db')
+
+        database_connection.return_value.execute.assert_has_calls(
+            [mock.call('BEGIN'), mock.call('COMMIT')]
+        )


### PR DESCRIPTION
*Issue #, if available:* #8889

*Description of changes:* Speeds up the autocomplete index generation by wrapping it in a single transaction.

I was looking at our CI timing, and this seems especially slow on Windows - spot-checking another PR, `install-dependencies` is 3-4 minutes on Linux/MacOS, but ~15 minutes on Windows. It should also benefit source installation users and package maintainers as suggested in the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
