### PR TITLE
Fix UnboundLocalError in nested config updates

### DIFF
--- a/.changes/next-release/bugfix-configure-10348.json
+++ b/.changes/next-release/bugfix-configure-10348.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "configure",
+  "description": "Fixed an ``UnboundLocalError`` crash in ``aws configure set`` when a nested config block such as ``s3 =`` is empty, or is immediately followed by a comment, a blank line, or a new section header. Fixes `#10348 <https://github.com/aws/aws-cli/issues/10348>`__."
+}

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -215,6 +215,8 @@ class ConfigFileWriter(object):
 
     def _update_subattributes(self, index, contents, values, starting_indent):
         index += 1
+        # Seeded in case there are no lines after the nested option at all.
+        i = index - 1
         for i in range(index, len(contents)):
             line = contents[i]
             match = self.OPTION_REGEX.search(line)
@@ -228,16 +230,21 @@ class ConfigFileWriter(object):
                                                 key_name, option_value)
                     contents[i] = new_line
                     del values[key_name]
-            if starting_indent == current_indent or \
-                    self.SECTION_REGEX.search(line) is not None:
-                # We've arrived at the starting indent level so we can just
-                # write out all the values now.
-                self._insert_new_values(i - 1, contents, values, '    ')
-                break
+                if current_indent != starting_indent:
+                    # We're still inside the nested block.
+                    continue
+            elif self.SECTION_REGEX.search(line) is None:
+                # Comments, blank lines and the like don't end the block.
+                continue
+            # We've arrived at the starting indent level so we can just
+            # write out all the values now.
+            self._insert_new_values(i - 1, contents, values, '    ')
+            break
         else:
-            if starting_indent != current_indent:
-                # The option is the last option in the file
-                self._insert_new_values(i, contents, values, '    ')
+            # The option is the last option in the file
+            if values and not contents[-1].endswith('\n'):
+                contents[-1] += '\n'
+            self._insert_new_values(i, contents, values, '    ')
         return i
 
     def _insert_new_values(self, line_number, contents, new_values, indent=''):

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -326,6 +326,78 @@ class TestConfigFileWriter(unittest.TestCase):
             '[profile foo]\n'
             'foo = bar\n')
 
+    def test_add_to_empty_nested_at_end_of_file(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '    signature_version = newval\n')
+
+    def test_add_to_nested_with_comment_after_nested_key(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+            '# a comment\n'
+            '    other = foo\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '# a comment\n'
+            '    other = foo\n'
+            '    signature_version = newval\n')
+
+    def test_add_to_nested_with_new_section_after_nested_key(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+            '[profile foo]\n'
+            'foo = bar\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '    signature_version = newval\n'
+            '[profile foo]\n'
+            'foo = bar\n')
+
+    def test_add_to_nested_with_blank_line_after_nested_key(self):
+        original = (
+            '[default]\n'
+            's3 =\n'
+            '\n'
+            '    other = foo\n'
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '\n'
+            '    other = foo\n'
+            '    signature_version = newval\n')
+
+    def test_add_to_empty_nested_without_trailing_newline(self):
+        original = (
+            '[default]\n'
+            's3 ='
+        )
+        self.assert_update_config(
+            original, {'__section__': 'default',
+                       's3': {'signature_version': 'newval'}},
+            '[default]\n'
+            's3 =\n'
+            '    signature_version = newval\n')
+
     def test_update_nested_attr_no_prior_nesting(self):
         original = (
             '[default]\n'


### PR DESCRIPTION
Fixes #10348

`ConfigFileWriter._update_subattributes()` reads `current_indent` on every line
but only assigns it when `OPTION_REGEX` matches, so any non-option line directly
after a nested key is read before assignment. `i` has the same problem when the
nested key is the last line in the file and the loop body never runs.

All three of these shapes crash on `aws configure set s3.signature_version s3v4`:

```ini
[default]        [default]        [default]
s3 =             s3 =             s3 =
# comment        [profile foo]    (end of file)
```

```
UnboundLocalError: cannot access local variable 'current_indent'
where it is not associated with a value
```

The fix classifies each line explicitly instead of carrying the previous match's
indent forward, and seeds `i` before the loop. It also adds a missing trailing
newline before appending, without which the above would turn the crash into a
corrupted config file.

Tests cover all three shapes plus an empty nested block with no trailing
newline; each fails before the change.


