### PR TITLE
Catch urllib3 ProtocolError on streamed responses

### DIFF
--- a/.changes/next-release/bugfix-s3-27431.json
+++ b/.changes/next-release/bugfix-s3-27431.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Wrap ``urllib3.exceptions.ProtocolError`` raised while streaming a response body in ``ResponseStreamingError`` so that part-level download retries apply when a connection is reset mid-transfer."
+}

--- a/awscli/botocore/exceptions.py
+++ b/awscli/botocore/exceptions.py
@@ -146,6 +146,10 @@ class ProxyConnectionError(ConnectionError):
     fmt = 'Failed to connect to proxy URL: "{proxy_url}"'
 
 
+class ResponseStreamingError(HTTPClientError):
+    fmt = 'An error occurred while reading from response stream: {error}'
+
+
 class NoCredentialsError(BotoCoreError):
     """
     No credentials could be found.

--- a/awscli/botocore/response.py
+++ b/awscli/botocore/response.py
@@ -24,8 +24,13 @@ from botocore.compat import (
     json,  # noqa
     set_socket_timeout,
 )
-from botocore.exceptions import IncompleteReadError, ReadTimeoutError
+from botocore.exceptions import (
+    IncompleteReadError,
+    ReadTimeoutError,
+    ResponseStreamingError,
+)
 from botocore.hooks import first_non_none_response  # noqa
+from urllib3.exceptions import ProtocolError as URLLib3ProtocolError
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
 
 logger = logging.getLogger(__name__)
@@ -87,6 +92,8 @@ class StreamingBody:
         except URLLib3ReadTimeoutError as e:
             # TODO: the url will be None as urllib3 isn't setting it yet
             raise ReadTimeoutError(endpoint_url=e.url, error=e)
+        except URLLib3ProtocolError as e:
+            raise ResponseStreamingError(error=e)
         self._amount_read += len(chunk)
         if amt is None or (not chunk and amt > 0):
             # If the server sends empty contents or

--- a/awscli/s3transfer/utils.py
+++ b/awscli/s3transfer/utils.py
@@ -21,7 +21,11 @@ import string
 import threading
 from collections import defaultdict
 
-from botocore.exceptions import IncompleteReadError, ReadTimeoutError
+from botocore.exceptions import (
+    IncompleteReadError,
+    ReadTimeoutError,
+    ResponseStreamingError,
+)
 from botocore.httpchecksum import DEFAULT_CHECKSUM_ALGORITHM, AwsChunkedWrapper
 from botocore.utils import is_s3express_bucket
 from s3transfer.compat import SOCKET_ERROR, fallocate, rename_file
@@ -41,6 +45,7 @@ S3_RETRYABLE_DOWNLOAD_ERRORS = (
     SOCKET_ERROR,
     ReadTimeoutError,
     IncompleteReadError,
+    ResponseStreamingError,
 )
 
 

--- a/tests/unit/botocore/test_response.py
+++ b/tests/unit/botocore/test_response.py
@@ -16,8 +16,13 @@ import io
 import botocore
 from botocore import response
 from botocore.awsrequest import AWSRequest, AWSResponse
-from botocore.exceptions import IncompleteReadError, ReadTimeoutError
+from botocore.exceptions import (
+    IncompleteReadError,
+    ReadTimeoutError,
+    ResponseStreamingError,
+)
 from dateutil.tz import tzutc
+from urllib3.exceptions import ProtocolError as URLLib3ProtocolError
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
 
 from tests import unittest
@@ -167,6 +172,20 @@ class TestStreamWrapper(unittest.TestCase):
 
         stream = response.StreamingBody(TimeoutBody(), content_length=None)
         with self.assertRaises(ReadTimeoutError):
+            stream.read()
+
+    def test_catches_urllib3_protocol_error(self):
+        class ProtocolErrorBody:
+            def read(*args, **kwargs):
+                raise URLLib3ProtocolError(None, None, None)
+
+            def geturl(*args, **kwargs):
+                return 'http://example.com'
+
+        stream = response.StreamingBody(
+            ProtocolErrorBody(), content_length=None
+        )
+        with self.assertRaises(ResponseStreamingError):
             stream.read()
 
     def test_streaming_line_abstruse_newline_standard(self):

--- a/tests/unit/s3transfer/test_download.py
+++ b/tests/unit/s3transfer/test_download.py
@@ -19,6 +19,7 @@ from io import BytesIO
 
 from awscrt import checksums as crt_checksums
 from botocore.config import Config
+from botocore.response import StreamingBody
 from s3transfer.bandwidth import BandwidthLimiter
 from s3transfer.checksums import (
     FullObjectChecksum,
@@ -45,6 +46,7 @@ from s3transfer.download import (
 from s3transfer.exceptions import RetriesExceededError
 from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG, BoundedExecutor
 from s3transfer.utils import CallArgs, OSUtils
+from urllib3.exceptions import ProtocolError as URLLib3ProtocolError
 
 from tests import (
     BaseSubmissionTaskTest,
@@ -764,6 +766,31 @@ class TestGetObjectTask(BaseTaskTest):
 
         # Retryable error should have not affected the bytes placed into
         # the io queue.
+        self.stubber.assert_no_pending_responses()
+        self.assert_io_writes([(0, self.content)])
+
+    def test_retries_urllib3_protocol_error(self):
+        # A ProtocolError raised while streaming the response body (e.g. the
+        # connection is reset mid-download) is wrapped by StreamingBody into a
+        # ResponseStreamingError, which is retryable.
+        self.stubber.add_response(
+            'get_object',
+            service_response={
+                'Body': StreamingBody(
+                    StreamWithError(self.stream, URLLib3ProtocolError),
+                    content_length=None,
+                )
+            },
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
+        )
+        self.stubber.add_response(
+            'get_object',
+            service_response={'Body': BytesIO(self.content)},
+            expected_params={'Bucket': self.bucket, 'Key': self.key},
+        )
+        task = self.get_download_task()
+        task()
+
         self.stubber.assert_no_pending_responses()
         self.assert_io_writes([(0, self.content)])
 


### PR DESCRIPTION
## Problem

When `aws s3 cp --recursive` downloads large objects, a single mid-transfer TCP
reset fails the entire file. s3transfer's part-level retry
(`num_download_attempts`, default 5) never engages.

Production traceback (`aws-cli/2.36.5 Python/3.14.6 Linux`, ~114 GB across 51
objects, `max_concurrent_requests = 32`):

```
File "awscli/s3transfer/tasks.py", line 137, in __call__
File "awscli/s3transfer/tasks.py", line 160, in _execute_main
File "awscli/s3transfer/download.py", line 672, in _main
File "awscli/s3transfer/download.py", line 855, in __next__
File "awscli/s3transfer/utils.py", line 608, in read
File "awscli/botocore/response.py", line 86, in read
File "urllib3/response.py", line 1112, in read
File "urllib3/response.py", line 930, in _error_catcher
urllib3.exceptions.ProtocolError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
```

In that run, 4 `ProtocolError`s mapped 1:1 onto 4 `download failed` lines — no
retry was attempted for any of them. From the same `--debug` log:

```
grep -c 'Retrying exception caught' -> 0
grep -c 'RetriesExceededError'      -> 0
grep -c 'ResponseStreamingError'    -> 0
```

Note the request-level retry in botocore cannot help here: the reset happens
while streaming the body, long after a `200` response head was received, so the
log shows `botocore.retries.standard - Not retrying request.` before each
failure.

## Root cause

`urllib3.exceptions.ProtocolError` inherits `ProtocolError -> HTTPError ->
Exception`. It is neither a `ConnectionError` nor a `ResponseStreamingError`, so
`except S3_RETRYABLE_DOWNLOAD_ERRORS` in `GetObjectTask._main` does not match and
the exception escapes the retry loop entirely.

The `v2` branch is missing two upstream fixes:

| upstream | what it does | in v1 since | in v2 |
|---|---|---|---|
| [boto/botocore#2573](https://github.com/boto/botocore/pull/2573) (`a5e5119b6`, 2021-12-10) | wraps `URLLib3ProtocolError` into a new `ResponseStreamingError` | botocore `1.23.24` | ❌ |
| [boto/s3transfer#301](https://github.com/boto/s3transfer/pull/301) (`5fc308a11`, 2024-03-06) | adds `ResponseStreamingError` to `S3_RETRYABLE_DOWNLOAD_ERRORS` | s3transfer `0.10.1` | ❌ |

`awscli` v1 has had both for a while (it currently resolves botocore 1.43.62 /
s3transfer 0.19.2), so v2 is strictly behind v1 on download resilience here.

Both halves are needed — wrapping alone still would not match the retryable
tuple.

## Change

* `awscli/botocore/exceptions.py`: add `ResponseStreamingError` (verbatim from #2573).
* `awscli/botocore/response.py`: `StreamingBody.read()` wraps `URLLib3ProtocolError` (verbatim from #2573).
* `awscli/s3transfer/utils.py`: add `ResponseStreamingError` to `S3_RETRYABLE_DOWNLOAD_ERRORS` (from boto/s3transfer#301).
* Tests: the unit test from #2573, plus a `GetObjectTask` test asserting the
  part-level retry now actually engages and the download completes.

`StreamingBody` on `v2` has no `readinto()`, so unlike current botocore
`develop` there is no second call site to guard.

## Scope

This does not address *why* the resets happen — that is a separate network-side
issue. It fixes the amplifier: a transient reset becomes a retryable, recoverable
part failure instead of a whole-file failure.

## Testing

* `tests/unit` — 9392 passed (one pre-existing unrelated failure in
  `tests/unit/customizations/history/test_history.py`, present on a clean `v2`).
* `tests/functional/s3`, `tests/functional/s3transfer` — 509 passed.
* `ruff` / `ruff-format` (pinned 0.4.8, per `.pre-commit-config.yaml`) clean.
* Both new tests verified to fail without the source change.

---

Generated by AI tools, and reviewed by Sheng Cao.