### PR TITLE
Update documentation for maintenance mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,18 @@
 # Contributing
 
-We work hard to provide a high-quality and useful command line interface, and we greatly value feedback and contributions from our community. Whether it's a new feature, correction, or additional documentation, we welcome your pull requests. Please submit any [issues](https://github.com/aws/aws-cli/issues) or [pull requests](https://github.com/aws/aws-cli/pulls) through GitHub.
+AWS CLI v1 is in maintenance mode. During maintenance mode, releases are
+limited to critical bug fixes and security issues. AWS CLI v1 does not receive
+new features, service API updates, or support for new regions. For more
+information, see the [maintenance mode section of the README](README.rst#aws-cli-v1-is-in-maintenance-mode).
+For new features and other work outside this support level, we recommend
+contributing to AWS CLI v2. See the
+[AWS CLI v2 contributing guide](https://github.com/aws/aws-cli/blob/v2/CONTRIBUTING.rst).
 
-This document contains guidelines for reporting issues or pull requests and contributing code.
 
 ## Reporting Issues
 
 - Check to see if there\'s an existing issue/pull request for the bug/feature. All issues are at <https://github.com/aws/aws-cli/issues> and pull reqs are at <https://github.com/aws/aws-cli/pulls>.
-- If there isn\'t an existing issue there, please file an issue. If possible, used one of the suggested issue types when creating a new issue (like a bug report of feature request). These issue types have their own template and required information. In general, the ideal report includes:
+- If there isn\'t an existing issue there, please file an issue. If possible, use one of the suggested issue types when creating a new issue (like a bug report or feature request). These issue types have their own template and required information. In general, the ideal report includes:
   - A description of the problem/suggestion.
   - The specific AWS CLI commands you are running. Please include debug logs for these commands by appending the `--debug` option to each command. Be sure to remove any sensitive information from the debug logs.
   - The AWS CLI version you are using `aws --version`.
@@ -21,9 +26,13 @@ The list below are guidelines to use when submitting pull requests. These are th
 - The SDK is released under the [Apache license](http://aws.amazon.com/apache2.0/). Any code you submit will be released under that license.
 - We maintain a high percentage of code coverage in our unit tests. As a general rule of thumb, code changes should not lower the overall code coverage percentage for the project. In practice, this means that **every bug fix and feature addition should include tests.**
 - Code should follow [pep8](https://www.python.org/dev/peps/pep-0008/), although if you are modifying an existing module, it is more important for the code to be consistent if there are any discrepancies. Using [`flake8`](https://flake8.pycqa.org/en/latest/) can assist in identifying `pep8` compliance issues.
-- Code must work on `python3.9` and higher.
+- Code must work on Python 3.10 and higher.
 - The AWS CLI is cross platform and code must work on at least Linux, Windows, and Mac OS X. Avoid platform specific behavior.
-- If you would like to implement support for a significant feature that is not yet available in the AWS CLI, please talk to us beforehand to avoid any duplication of effort. You can file an [issue](https://github.com/aws/aws-cli/issues) to discuss the feature request further.
+- AWS CLI v1 does not accept new feature work. To propose or implement a new
+  feature, follow the
+  [AWS CLI v2 contributing guide](https://github.com/aws/aws-cli/blob/v2/CONTRIBUTING.rst)
+  and file an [issue](https://github.com/aws/aws-cli/issues) to discuss the
+  request before beginning implementation.
 
 ## Git Commits and Workflow
 

--- a/README.rst
+++ b/README.rst
@@ -15,15 +15,19 @@ Jump to:
 -  `More Resources <#more-resources>`__
 
 
-Entering Maintenance Mode on July 15, 2026
-------------------------------------------
+AWS CLI v1 is in Maintenance Mode
+---------------------------------
 
-We `announced <https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/>`__
-the upcoming **end-of-support for the AWS CLI v1**. We recommend
-that you migrate to
+The AWS CLI v1 entered maintenance mode on August 5, 2026 and will reach
+end-of-support on July 15, 2027. During maintenance mode, AWS limits releases
+to critical bug fixes and security issues only. The AWS CLI v1 will not receive
+API updates for new or existing services, or be updated to support new regions.
+
+We recommend that you migrate to
 `AWS CLI v2 <https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html>`__.
-For dates, additional details, and information on how to migrate,
-please refer to the linked announcement.
+For more information, see the
+`maintenance mode announcement <https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/>`__,
+and the `update regarding dependency versions <https://aws.amazon.com/blogs/developer/aws-cli-v1-maintenance-mode-announcing-changes-to-dependency-updates/>`__.
 
 Getting Started
 ---------------
@@ -61,7 +65,8 @@ any important security bulletins related to aws-cli.*
 Maintenance and Support for CLI Major Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The AWS CLI version 1 was made generally available on 09/02/2013 and is currently in the full support phase of the availability life cycle.
+The AWS CLI version 1 entered maintenance mode on August 5, 2026 and will reach
+end-of-support on July 15, 2027.
 
 For information about maintenance and support for SDK major versions and their underlying dependencies, see the `Maintenance Policy <https://docs.aws.amazon.com/credref/latest/refdocs/maint-policy.html>`__ section in the *AWS SDKs and Tools Shared Configuration and Credentials Reference Guide*.
 

--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
@@ -107,9 +107,14 @@
                         {% endif %}
                     </p>
                     <p>
-                        We <a href="https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/">announced</a> the upcoming end-of-support for the AWS CLI v1.
-                        For dates, additional details, and information on how to migrate, please refer to the linked announcement.
-                        For more information see the AWS CLI version 2
+                        AWS CLI v1 entered maintenance mode on August 5, 2026 and will reach end-of-support on July 15, 2027.
+                        During maintenance mode, releases are limited to critical bug fixes and security issues.
+                        AWS CLI v1 will not receive API updates for new or existing services, or be updated to support new regions.
+                        For more information, see the
+                        <a href="https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/">maintenance mode announcement</a>.
+                    </p>
+                    <p>
+                        We recommend that you migrate to AWS CLI version 2. See the
                         <a href="https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html">installation instructions</a>
                         and
                         <a href="https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html">migration guide</a>.

--- a/scripts/install
+++ b/scripts/install
@@ -237,14 +237,20 @@ def main():
             print("You can now run: %s --version" % opts.bin_location)
         else:
             print("You can now run: %s --version" % real_location)
-        print('\nNote: We announced the end-of-support for the AWS CLI v1: '
-              'https://aws.amazon.com/blogs/developer/'
-              'cli-v1-maintenance-mode-announcement/',
-              '\nFor dates, additional details, and information on how to '
-              'migrate, please refer to the linked announcement.',
-              '\nWe recommend that you migrate to AWS CLI v2, see the',
-              'installation instructions at: https://docs.aws.amazon.com/cli/'
-              'latest/userguide/install-cliv2.html')
+        print(
+            '\nNote: AWS CLI v1 entered maintenance mode on August 5, 2026 '
+            'and will reach end-of-support on July 15, 2027.'
+            '\nDuring maintenance mode, releases are limited to critical bug '
+            'fixes and security issues. AWS CLI v1 will not receive API '
+            'updates for new or existing services, or be updated to support '
+            'new regions.'
+            '\nFor more information, see the maintenance mode announcement: '
+            'https://aws.amazon.com/blogs/developer/'
+            'cli-v1-maintenance-mode-announcement/'
+            '\nWe recommend that you migrate to AWS CLI v2. See the migration '
+            'guide: https://docs.aws.amazon.com/cli/latest/userguide/'
+            'cliv2-migration.html'
+        )
     finally:
         shutil.rmtree(working_dir)
 


### PR DESCRIPTION
*Issue #, if available:* Supersedes https://github.com/aws/aws-cli/pull/10537

*Description of changes:* 

Adds information about CLIv1's maintenance mode to
1. Readme
2. Install script when using bundled installers
3. Command reference
4. Contribution guide


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
