### PR TITLE
[v2] Add AvailabilityZoneId to the EC2 CreateVolume examples

### DIFF
--- a/.changes/next-release/enhancement-ec2-92203.json
+++ b/.changes/next-release/enhancement-ec2-92203.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``ec2``",
+  "description": "Updated AWS CLI v2 API reference for EC2 create-volume command so that the examples include ``AvailabilityZoneId`` in the output."
+}

--- a/awscli/examples/ec2/create-volume.rst
+++ b/awscli/examples/ec2/create-volume.rst
@@ -1,4 +1,4 @@
-**To create an empty General Purpose SSD (gp2) volume**
+**Example 1: To create an empty General Purpose SSD (gp2) volume**
 
 The following ``create-volume`` example creates an 80 GiB General Purpose SSD (gp2) volume in the specified Availability Zone. Note that the current Region must be ``us-east-1``, or you can add the ``--region`` parameter to specify the Region for the command. ::
 
@@ -10,6 +10,7 @@ The following ``create-volume`` example creates an 80 GiB General Purpose SSD (g
 Output::
 
     {
+        "AvailabilityZoneId": "use1-az1",
         "AvailabilityZone": "us-east-1a",
         "Tags": [],
         "Encrypted": false,
@@ -36,11 +37,12 @@ The following ``create-volume`` example creates a Provisioned IOPS SSD (io1) vol
         --volume-type io1 \
         --iops 1000 \
         --snapshot-id snap-066877671789bd71b \
-        --availability-zone us-east-1a  
+        --availability-zone us-east-1a
 
 Output::
 
     {
+        "AvailabilityZoneId": "use1-az1",
         "AvailabilityZone": "us-east-1a",
         "Tags": [],
         "Encrypted": false,
@@ -60,11 +62,12 @@ The following ``create-volume`` example creates an encrypted volume using the de
     aws ec2 create-volume \
         --size 80 \
         --encrypted \
-        --availability-zone us-east-1a 
+        --availability-zone us-east-1a
 
 Output::
 
     {
+        "AvailabilityZoneId": "use1-az1",
         "AvailabilityZone": "us-east-1a",
         "Tags": [],
         "Encrypted": true,


### PR DESCRIPTION
*Issue #, if available:*

* P389032780 (internal)

*Description of changes:*

* Update help docs for `aws ec2 create-volume` command to add `AvailabilityZoneId` to the examples output.

*Description of tests:*

* Ran and passed all tests and CI (see GitHub Actions).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
