### PR TITLE
[v2] Move Content-Length validation from urllib3 to botocore

### DIFF
--- a/.changes/next-release/bugfix-HTTP-36336.json
+++ b/.changes/next-release/bugfix-HTTP-36336.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "HTTP",
+  "description": "Fixes regression where ``Content-Length`` validation is moved back to ``botocore`` from ``urllib3``. This re-enables functionality that depends on ``botocore``'s validation, such as resilient streaming from S3 to ``stdout`` in the case of an ``IncompleteRead``."
+}

--- a/awscli/botocore/httpsession.py
+++ b/awscli/botocore/httpsession.py
@@ -477,6 +477,7 @@ class URLLib3Session:
                 preload_content=False,
                 decode_content=False,
                 chunked=self._chunked(request.headers),
+                enforce_content_length=False,
             )
 
             http_response = botocore.awsrequest.AWSResponse(

--- a/tests/unit/botocore/test_http_session.py
+++ b/tests/unit/botocore/test_http_session.py
@@ -146,6 +146,7 @@ class TestURLLib3Session(unittest.TestCase):
             preload_content=False,
             decode_content=False,
             chunked=chunked,
+            enforce_content_length=False,
         )
 
     def _assert_manager_call(self, manager, *assert_args, **assert_kwargs):


### PR DESCRIPTION
*Notes:*

* In https://github.com/aws/aws-cli/pull/9971, we upgraded our `urllib3` bundled dependency to the next major version. This introduced a regression where `urllib3` performs `Content-Length` validation instead of `botocore`, causing a different error to be raised instead of botocore's `IncompleteRead`. As of `urllib3` v2, `Content-Length` validation is enforced by default, and there is a config option to opt-out (https://github.com/urllib3/urllib3/pull/2514). botocore's `Content-Length` validation was implemented in 2013 when `urllib3` had no support for `Content-Length` validation, so botocore built its own `Content-Length` validation. This PR opts out of `urllib3`'s `Content-Length` validation so this check is handled by botocore (as it was pre-urllib3-v2). This fixes a bug in S3 streaming to `stdout` when an `IncompleteRead` is encountered.

*Description of changes:*

* Pass `enforce_content_length=False` to urllib3, to opt-out of content-length validation. This brings `Content-Length` validation back to `urllib3`. This fixes a bug with encountering an `IncompleteRead` while streaming an S3 object to `stdout`.

*Description of tests:*

* Added a blackbox test locally to test the S3 streaming download scenario. Verified that the expected retry request is made by the AWS CLI. Without this change, the retry is not made, and the streaming download terminates and surfaces an incomplete read error. **Note:** this blackbox test is not included in this PR, but it will be added in a future PR as part of the same stack as https://github.com/aws/aws-cli/pull/10591.
* Successfully ran all test suites and CI (see GitHub Actions).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
