### PR TITLE
[v2] Map classic S3 config options to CRT client

### DIFF
--- a/.changes/next-release/enhancement-crt-31704.json
+++ b/.changes/next-release/enhancement-crt-31704.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "crt",
+  "description": "Support ``multipart_threshold`` (upload only) and ``max_concurrent_requests`` config options for CRT client."
+}

--- a/awscli/customizations/s3/factory.py
+++ b/awscli/customizations/s3/factory.py
@@ -120,7 +120,6 @@ class TransferManagerFactory:
         )
 
     def _create_crt_client(self, params, runtime_config):
-        config_file_params = self._session.get_scoped_config().get('s3', {})
         create_crt_client_kwargs = {
             'region': self._resolve_region(params),
             'verify': self._resolve_verify(params),
@@ -131,11 +130,11 @@ class TransferManagerFactory:
         target_throughput = runtime_config.get('target_bandwidth', None)
         if target_throughput:
             create_crt_client_kwargs['target_throughput'] = target_throughput
-        multipart_chunksize = runtime_config.get('multipart_chunksize', None)
-        # User didn't explicitly configure `multipart_chunksize`. Set it to
-        # `None` and let CRT dynamically calculate the part size.
-        if 'multipart_chunksize' not in config_file_params:
-            multipart_chunksize = None
+        # Leaving this unset lets the CRT client dynamically calculate the
+        # part size if user didn't explicitly configure it.
+        multipart_chunksize = None
+        if runtime_config.is_explicitly_set('multipart_chunksize'):
+            multipart_chunksize = runtime_config['multipart_chunksize']
         create_crt_client_kwargs['part_size'] = multipart_chunksize
         if params.get('sign_request', True):
             crt_credentials_provider = self._get_crt_credentials_provider()

--- a/awscli/customizations/s3/factory.py
+++ b/awscli/customizations/s3/factory.py
@@ -32,6 +32,12 @@ from awscli.customizations.s3.transferconfig import (
 
 LOGGER = logging.getLogger(__name__)
 
+CRT_CLIENT_KWARG_MAP = {
+    'multipart_chunksize': 'part_size',
+    'multipart_threshold': 'multipart_upload_threshold',
+    'max_concurrent_requests': 'max_active_connections_override',
+}
+
 
 class ClientFactory:
     def __init__(self, session):
@@ -130,12 +136,9 @@ class TransferManagerFactory:
         target_throughput = runtime_config.get('target_bandwidth', None)
         if target_throughput:
             create_crt_client_kwargs['target_throughput'] = target_throughput
-        # Leaving this unset lets the CRT client dynamically calculate the
-        # part size if user didn't explicitly configure it.
-        multipart_chunksize = None
-        if runtime_config.is_explicitly_set('multipart_chunksize'):
-            multipart_chunksize = runtime_config['multipart_chunksize']
-        create_crt_client_kwargs['part_size'] = multipart_chunksize
+        create_crt_client_kwargs.update(
+            self._resolve_crt_client_config_kwargs(runtime_config)
+        )
         if params.get('sign_request', True):
             crt_credentials_provider = self._get_crt_credentials_provider()
             create_crt_client_kwargs['crt_credentials_provider'] = (
@@ -152,6 +155,17 @@ class TransferManagerFactory:
         create_crt_client_kwargs['fio_options'] = fio_options
 
         return create_s3_crt_client(**create_crt_client_kwargs)
+
+    def _resolve_crt_client_config_kwargs(self, runtime_config):
+        kwargs = {}
+        for config_name, crt_name in CRT_CLIENT_KWARG_MAP.items():
+            if runtime_config.is_explicitly_set(config_name):
+                kwargs[crt_name] = runtime_config[config_name]
+        if 'part_size' not in kwargs:
+            # `create_s3_crt_client` defaults this to 8MB, so `None` has to be
+            # passed to opt into the CRT's dynamic part size calculation.
+            kwargs['part_size'] = None
+        return kwargs
 
     def _create_crt_request_serializer(self, params):
         return BotocoreCRTRequestSerializer(

--- a/awscli/customizations/s3/transferconfig.py
+++ b/awscli/customizations/s3/transferconfig.py
@@ -42,6 +42,29 @@ class InvalidConfigError(Exception):
     pass
 
 
+class ResolvedRuntimeConfig(dict):
+    """A runtime config that tracks which values the user supplied.
+
+    A value matching its default says nothing about whether the user
+    configured it, so callers needing that distinction cannot infer it from
+    the resolved value alone.
+    """
+
+    def __init__(self, values, explicit_keys):
+        super().__init__(values)
+        self._explicit_keys = frozenset(explicit_keys)
+
+    @property
+    def explicit_keys(self):
+        return self._explicit_keys
+
+    def is_explicitly_set(self, name):
+        return name in self._explicit_keys
+
+    def copy(self):
+        return ResolvedRuntimeConfig(dict(self), self._explicit_keys)
+
+
 class RuntimeConfig:
     POSITIVE_INTEGERS = [
         'multipart_chunksize',
@@ -89,9 +112,11 @@ class RuntimeConfig:
         that use this runtime config.
 
         :param kwargs:  Any key in the ``DEFAULTS`` dict.
-        :return: A dictionary of the merged and converted values.
+        :return: A ``ResolvedRuntimeConfig`` of the merged and converted
+            values, which also tracks which keys were explicitly provided.
 
         """
+        explicit_keys = set(kwargs)
         runtime_config = DEFAULTS.copy()
         if kwargs:
             runtime_config.update(kwargs)
@@ -100,7 +125,7 @@ class RuntimeConfig:
         self._convert_booleans(runtime_config)
         self._resolve_choice_aliases(runtime_config)
         self._validate_config(runtime_config)
-        return runtime_config
+        return ResolvedRuntimeConfig(runtime_config, explicit_keys)
 
     def _convert_human_readable_sizes(self, runtime_config):
         for attr in self.HUMAN_READABLE_SIZES:

--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -89,6 +89,8 @@ def create_s3_crt_client(
     use_ssl=True,
     verify=None,
     fio_options=None,
+    multipart_upload_threshold=None,
+    max_active_connections_override=None,
 ):
     """
     :type region: str
@@ -135,6 +137,16 @@ def create_s3_crt_client(
 
     :type fio_options: Optional[dict]
     :param fio_options: Kwargs to use to build an `awscrt.s3.S3FileIoOptions`.
+
+    :type multipart_upload_threshold: Optional[int]
+    :param multipart_upload_threshold: Size, in bytes, above which uploads use
+        a multipart upload rather than a single request. Only affects uploads.
+        If not set, the maximum of ``part_size`` and 5 MiB is used.
+
+    :type max_active_connections_override: Optional[int]
+    :param max_active_connections_override: Caps the number of active
+        connections. Only applies when lower than the connection count derived
+        from ``target_throughput``. If not set, the derived value is used.
     """
 
     event_loop_group = EventLoopGroup(num_threads)
@@ -180,6 +192,8 @@ def create_s3_crt_client(
         throughput_target_gbps=target_gbps,
         enable_s3express=True,
         fio_options=crt_fio_options,
+        multipart_upload_threshold=multipart_upload_threshold,
+        max_active_connections_override=max_active_connections_override,
     )
 
 

--- a/tests/unit/customizations/s3/test_factory.py
+++ b/tests/unit/customizations/s3/test_factory.py
@@ -572,6 +572,54 @@ class TestTransferManagerFactory(unittest.TestCase):
         self.assertEqual(mock_crt_client.call_args[1]['part_size'], None)
 
     @mock.patch('s3transfer.crt.S3Client')
+    def test_multipart_threshold_configure_for_crt_manager(
+        self, mock_crt_client
+    ):
+        threshold = 64 * (1024**2)
+        self.runtime_config = self.get_runtime_config(
+            preferred_transfer_client='crt', multipart_threshold=threshold
+        )
+        transfer_manager = self.factory.create_transfer_manager(
+            self.params, self.runtime_config
+        )
+        self.assert_is_crt_manager(transfer_manager)
+        self.assertEqual(
+            mock_crt_client.call_args[1]['multipart_upload_threshold'],
+            threshold,
+        )
+
+    @mock.patch('s3transfer.crt.S3Client')
+    def test_max_concurrent_requests_configure_for_crt_manager(
+        self, mock_crt_client
+    ):
+        self.runtime_config = self.get_runtime_config(
+            preferred_transfer_client='crt', max_concurrent_requests=3
+        )
+        transfer_manager = self.factory.create_transfer_manager(
+            self.params, self.runtime_config
+        )
+        self.assert_is_crt_manager(transfer_manager)
+        self.assertEqual(
+            mock_crt_client.call_args[1]['max_active_connections_override'], 3
+        )
+
+    @mock.patch('s3transfer.crt.S3Client')
+    def test_unconfigured_options_not_passed_to_crt_manager(
+        self, mock_crt_client
+    ):
+        self.runtime_config = self.get_runtime_config(
+            preferred_transfer_client='crt'
+        )
+        transfer_manager = self.factory.create_transfer_manager(
+            self.params, self.runtime_config
+        )
+        self.assert_is_crt_manager(transfer_manager)
+        call_kwargs = mock_crt_client.call_args[1]
+        self.assertIsNone(call_kwargs['part_size'])
+        self.assertIsNone(call_kwargs['multipart_upload_threshold'])
+        self.assertIsNone(call_kwargs['max_active_connections_override'])
+
+    @mock.patch('s3transfer.crt.S3Client')
     def test_part_size_configured_when_matching_default(self, mock_crt_client):
         # Explicitly configuring the same value as the default still counts
         # as explicitly configured.

--- a/tests/unit/customizations/s3/test_factory.py
+++ b/tests/unit/customizations/s3/test_factory.py
@@ -547,11 +547,6 @@ class TestTransferManagerFactory(unittest.TestCase):
         self, mock_crt_client
     ):
         part_size = 16 * (1024**2)
-        self.session.get_scoped_config.return_value = {
-            's3': {
-                'multipart_chunksize': part_size,
-            }
-        }
         self.runtime_config = self.get_runtime_config(
             preferred_transfer_client='crt', multipart_chunksize=part_size
         )
@@ -563,12 +558,10 @@ class TestTransferManagerFactory(unittest.TestCase):
 
     @mock.patch('s3transfer.crt.S3Client')
     def test_default_part_size_for_crt_manager(self, mock_crt_client):
-        part_size = 16 * (1024**2)
-        # Explicitly showing that the user has not configured
-        # `multipart_chunksize`.
-        self.session.get_scoped_config.return_value = {'s3': {}}
+        # `multipart_chunksize` is not provided, so it is not explicitly
+        # configured even though the runtime config still resolves a default.
         self.runtime_config = self.get_runtime_config(
-            preferred_transfer_client='crt', multipart_chunksize=part_size
+            preferred_transfer_client='crt'
         )
         transfer_manager = self.factory.create_transfer_manager(
             self.params, self.runtime_config
@@ -577,6 +570,23 @@ class TestTransferManagerFactory(unittest.TestCase):
         # When `multipart_chunksize` isn't explicitly provided, configure
         # `part_size` to `None`.
         self.assertEqual(mock_crt_client.call_args[1]['part_size'], None)
+
+    @mock.patch('s3transfer.crt.S3Client')
+    def test_part_size_configured_when_matching_default(self, mock_crt_client):
+        # Explicitly configuring the same value as the default still counts
+        # as explicitly configured.
+        default_chunksize = RuntimeConfig.defaults()['multipart_chunksize']
+        self.runtime_config = self.get_runtime_config(
+            preferred_transfer_client='crt',
+            multipart_chunksize=default_chunksize,
+        )
+        transfer_manager = self.factory.create_transfer_manager(
+            self.params, self.runtime_config
+        )
+        self.assert_is_crt_manager(transfer_manager)
+        self.assertEqual(
+            mock_crt_client.call_args[1]['part_size'], default_chunksize
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/customizations/s3/test_transferconfig.py
+++ b/tests/unit/customizations/s3/test_transferconfig.py
@@ -193,3 +193,56 @@ class TestConvertToS3TransferConfig:
         assert result.max_bandwidth == 1024 * 1024
         assert result.io_chunksize == 1024 * 1024
         assert result.max_in_memory_upload_chunks != 1000
+
+
+class TestResolvedRuntimeConfig:
+    def build(self, **kwargs):
+        return transferconfig.RuntimeConfig().build_config(**kwargs)
+
+    def test_tracks_explicitly_provided_keys(self):
+        config = self.build(max_concurrent_requests=5, io_chunksize='1MB')
+        assert config.explicit_keys == {
+            'max_concurrent_requests',
+            'io_chunksize',
+        }
+
+    def test_nothing_is_explicit_when_no_values_provided(self):
+        config = self.build()
+        assert config.explicit_keys == set()
+        assert not config.is_explicitly_set('max_concurrent_requests')
+
+    def test_value_matching_default_is_still_explicit(self):
+        default = transferconfig.DEFAULTS['max_concurrent_requests']
+        config = self.build(max_concurrent_requests=default)
+        assert config.is_explicitly_set('max_concurrent_requests')
+
+    def test_defaults_are_not_explicit(self):
+        config = self.build(max_concurrent_requests=5)
+        assert not config.is_explicitly_set('multipart_threshold')
+        # The default value is still resolved and available.
+        assert (
+            config['multipart_threshold']
+            == transferconfig.DEFAULTS['multipart_threshold']
+        )
+
+    def test_unknown_keys_are_tracked_as_explicit(self):
+        config = self.build(not_a_real_option='foo')
+        assert config.is_explicitly_set('not_a_real_option')
+        assert 'not_a_real_option' not in transferconfig.DEFAULTS
+
+    def test_copy_preserves_provenance(self):
+        config = self.build(io_chunksize='1MB').copy()
+        assert config.is_explicitly_set('io_chunksize')
+        assert not config.is_explicitly_set('multipart_threshold')
+
+    def test_provenance_records_keys_not_converted_values(self):
+        # Values are converted after provenance is captured.
+        config = self.build(multipart_chunksize='16MB')
+        assert config.is_explicitly_set('multipart_chunksize')
+        assert config['multipart_chunksize'] == 16 * 1024 * 1024
+
+    def test_behaves_like_a_dict(self):
+        config = self.build(max_queue_size=10)
+        assert config['max_queue_size'] == 10
+        assert config.get('max_queue_size') == 10
+        assert 'multipart_threshold' in dict(config)


### PR DESCRIPTION
* Map `multipart_threshold` to `mutlipart_upload_threshold`.
  * Downloads will be supported in a later commit via a different mechanism.
* Map `max_concurrent_requests` to `max_active_connections_override`
* Implement `ResolvedRuntimeConfig`, a dict-like object that tracks whether a config option was explicitly provided by the user or if it's just an implicit default value. We need it in cases like `multipart_chunksize` where CLI gives it a default value but CRT expects a `None` value so it can dynamically set it.