### PR TITLE
Add --redirect-port to sso login, configure sso, and login

### DIFF
--- a/.changes/next-release/feature-login-34536.json
+++ b/.changes/next-release/feature-login-34536.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``login``",
+  "description": "Add a ``--redirect-port`` option to set the localhost port that the callback server listens on, instead of choosing an available port at random."
+}

--- a/.changes/next-release/feature-sso-34535.json
+++ b/.changes/next-release/feature-sso-34535.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``sso``",
+  "description": "Add a ``--redirect-port`` option to ``aws sso login`` and ``aws configure sso`` to set the localhost port that the Authorization Code callback server listens on, instead of choosing an available port at random."
+}

--- a/awscli/customizations/configure/sso_commands.py
+++ b/awscli/customizations/configure/sso_commands.py
@@ -49,6 +49,7 @@ from awscli.customizations.sso.utils import (
     BaseSSOCommand,
     PrintOnlyHandler,
     do_sso_login,
+    validate_redirect_port,
 )
 from awscli.customizations.utils import uni_print
 from awscli.formatter import CLI_OUTPUT_FORMATS
@@ -315,6 +316,7 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         super()._run_main(parsed_args, parsed_globals)
+        validate_redirect_port(parsed_args.redirect_port)
         self._unset_session_profile()
         on_pending_authorization = None
         if parsed_args.no_browser:
@@ -331,6 +333,7 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
             token_cache=self._sso_token_cache,
             on_pending_authorization=on_pending_authorization,
             use_device_code=parsed_args.use_device_code,
+            redirect_port=parsed_args.redirect_port,
             **sso_registration_args,
         )
 

--- a/awscli/customizations/login/login.py
+++ b/awscli/customizations/login/login.py
@@ -24,10 +24,12 @@ from awscli.customizations.login.utils import (
 )
 from awscli.customizations.prompts import yes_no_choice
 from awscli.customizations.sso.utils import (
+    REDIRECT_PORT_ARG,
     AuthCodeFetcher,
     OpenBrowserHandler,
     PrintOnlyHandler,
     open_browser_with_original_ld_path,
+    validate_redirect_port,
 )
 from awscli.customizations.utils import uni_print
 
@@ -60,7 +62,8 @@ class LoginCommand(BasicCommand):
                 'intended when running the CLI on remote hosts via SSH '
                 'where a local browser is not available.'
             ),
-        }
+        },
+        REDIRECT_PORT_ARG,
     ]
 
     def __init__(
@@ -85,6 +88,7 @@ class LoginCommand(BasicCommand):
         self._config_file_writer = config_file_writer
 
     def _run_main(self, parsed_args, parsed_globals):
+        validate_redirect_port(parsed_args.redirect_port)
         region = self._resolve_region(parsed_globals)
         profile_name = self.resolve_profile_name()
         sign_in_type = self.resolve_sign_in_type(parsed_args)
@@ -115,7 +119,9 @@ class LoginCommand(BasicCommand):
         if sign_in_type is LoginType.SAME_DEVICE:
             token_fetcher = SameDeviceLoginTokenFetcher(
                 client=client,
-                auth_code_fetcher=AuthCodeFetcher(),
+                auth_code_fetcher=AuthCodeFetcher(
+                    redirect_port=parsed_args.redirect_port
+                ),
                 on_pending_authorization=OpenBrowserHandler(
                     open_browser=open_browser_with_original_ld_path
                 ),

--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -21,6 +21,7 @@ from awscli.customizations.sso.utils import (
     BaseSSOCommand,
     PrintOnlyHandler,
     do_sso_login,
+    validate_redirect_port,
 )
 from awscli.customizations.utils import uni_print
 
@@ -49,6 +50,7 @@ class LoginCommand(BaseSSOCommand):
     ]
 
     def _run_main(self, parsed_args, parsed_globals):
+        validate_redirect_port(parsed_args.redirect_port)
         sso_config = self._get_sso_config(sso_session=parsed_args.sso_session)
         start_url = sso_config['sso_start_url']
         configured_region = sso_config.get('sso_region')
@@ -81,6 +83,7 @@ class LoginCommand(BaseSSOCommand):
             session_name=sso_config.get('session_name'),
             registration_scopes=sso_config.get('registration_scopes'),
             use_device_code=parsed_args.use_device_code,
+            redirect_port=parsed_args.redirect_port,
         )
 
         # Only rewrite sso_region after successful login.

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -35,12 +35,28 @@ from botocore.utils import (
 from awscli import __version__ as awscli_version
 from awscli.customizations.assumerole import CACHE_DIR as AWS_CREDS_CACHE_DIR
 from awscli.customizations.commands import BasicCommand
-from awscli.customizations.exceptions import ConfigurationError
+from awscli.customizations.exceptions import (
+    ConfigurationError,
+    ParamValidationError,
+)
 from awscli.customizations.utils import uni_print
 
 LOG = logging.getLogger(__name__)
 
 SSO_TOKEN_DIR = os.path.expanduser(os.path.join('~', '.aws', 'sso', 'cache'))
+
+REDIRECT_PORT_ARG = {
+    'name': 'redirect-port',
+    'cli_type_name': 'integer',
+    'help_text': (
+        'The port on localhost that the local callback server listens on, '
+        'which is used to build the ``redirect_uri`` for the authorization '
+        'request. By default an available port is chosen at random. Set this '
+        'when the port must be known in advance, such as when forwarding it '
+        'from a remote host over SSH. Has no effect when a flow that does not '
+        'start a callback server is used.'
+    ),
+}
 
 LOGIN_ARGS = [
     {
@@ -61,7 +77,19 @@ LOGIN_ARGS = [
             'instead of the Authorization Code flow.'
         ),
     },
+    REDIRECT_PORT_ARG,
 ]
+
+
+def validate_redirect_port(redirect_port):
+    """Validates a ``--redirect-port`` value before starting a login flow."""
+    if redirect_port is None:
+        return
+    if not 1 <= redirect_port <= 65535:
+        raise ParamValidationError(
+            f'Invalid value for --redirect-port: {redirect_port}. '
+            'Value must be between 1 and 65535.'
+        )
 
 
 def _serialize_utc_timestamp(obj):
@@ -86,6 +114,7 @@ def do_sso_login(
     session_name=None,
     use_device_code=False,
     resolved_start_url=None,
+    redirect_port=None,
 ):
     if token_cache is None:
         token_cache = JSONFileCache(SSO_TOKEN_DIR, dumps_func=_sso_json_dumps)
@@ -101,7 +130,7 @@ def do_sso_login(
             sso_region=sso_region,
             client_creator=session.create_client,
             parsed_globals=parsed_globals,
-            auth_code_fetcher=AuthCodeFetcher(),
+            auth_code_fetcher=AuthCodeFetcher(redirect_port=redirect_port),
             cache=token_cache,
             on_pending_authorization=on_pending_authorization,
         )
@@ -230,16 +259,20 @@ class AuthCodeFetcher:
     # How long we wait overall for the callback
     _OVERALL_TIMEOUT = 60 * 10
 
-    def __init__(self):
+    def __init__(self, redirect_port=None):
         self._auth_code = None
         self._state = None
         self._is_done = False
+
+        # Binding to port 0 lets the OS pick any available port, which is what
+        # we want unless the caller needs the port to be known in advance.
+        port = 0 if redirect_port is None else redirect_port
 
         # We do this so that the request handler can have a reference to this
         # AuthCodeFetcher so that it can pass back the state and auth code
         try:
             handler = partial(OAuthCallbackHandler, self)
-            self.http_server = HTTPServer(('', 0), handler)
+            self.http_server = HTTPServer(('', port), handler)
             self.http_server.timeout = self._REQUEST_TIMEOUT
         except OSError as e:
             raise AuthCodeFetcherError(error_msg=e)

--- a/tests/functional/login/test_login.py
+++ b/tests/functional/login/test_login.py
@@ -6,10 +6,13 @@ from unittest import mock
 
 import pytest
 
-from awscli.customizations.exceptions import ConfigurationError
+from awscli.customizations.exceptions import (
+    ConfigurationError,
+    ParamValidationError,
+)
 from awscli.customizations.login.login import LoginCommand
 
-DEFAULT_ARGS = Namespace(remote=False)
+DEFAULT_ARGS = Namespace(remote=False, redirect_port=None)
 DEFAULT_GLOBAL_ARGS = Namespace(
     region='us-east-1', endpoint_url=None, verify_ssl=None
 )
@@ -102,6 +105,50 @@ def test_run_main_same_device_flow(
         },
         'configfile',
     )
+
+
+@mock.patch('awscli.customizations.login.utils.get_base_sign_in_uri')
+@mock.patch('awscli.customizations.login.login.AuthCodeFetcher')
+@mock.patch(
+    'awscli.customizations.login.utils.SameDeviceLoginTokenFetcher.fetch_token'
+)
+@pytest.mark.parametrize('redirect_port', [None, 34535])
+def test_run_main_passes_redirect_port_to_auth_code_fetcher(
+    mock_token_fetcher,
+    mock_auth_code_fetcher,
+    mock_base_sign_in_uri,
+    mock_login_command,
+    redirect_port,
+):
+    mock_base_sign_in_uri.return_value = 'https://foo'
+    mock_token_fetcher.return_value = (
+        {
+            'accessToken': 'access_token',
+            'idToken': SAMPLE_ID_TOKEN,
+            'expiresIn': 3600,
+        },
+        'arn:aws:iam::0123456789012:user/Admin',
+    )
+    args = Namespace(**vars(DEFAULT_ARGS))
+    args.redirect_port = redirect_port
+
+    mock_login_command._run_main(args, DEFAULT_GLOBAL_ARGS)
+
+    mock_auth_code_fetcher.assert_called_once_with(redirect_port=redirect_port)
+
+
+@mock.patch('awscli.customizations.login.login.AuthCodeFetcher')
+def test_run_main_rejects_out_of_range_redirect_port(
+    mock_auth_code_fetcher, mock_login_command
+):
+    args = Namespace(**vars(DEFAULT_ARGS))
+    args.redirect_port = 65536
+
+    with pytest.raises(ParamValidationError) as excinfo:
+        mock_login_command._run_main(args, DEFAULT_GLOBAL_ARGS)
+
+    assert 'must be between 1 and 65535' in str(excinfo.value)
+    mock_auth_code_fetcher.assert_not_called()
 
 
 @mock.patch('awscli.customizations.login.utils.get_base_sign_in_uri')

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -443,6 +443,29 @@ class TestLoginCommand(BaseSSOTest):
         _, stderr, _ = self.run_cmd('sso login', expected_rc=255)
         self.assertIn('State parameter does not match expected value.', stderr)
 
+    def test_login_auth_default_redirect_port(self):
+        content = self.get_sso_session_config('test-session')
+        self.set_config_file_content(content=content)
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.fetcher_mock.assert_called_once_with(redirect_port=None)
+
+    def test_login_auth_explicit_redirect_port(self):
+        content = self.get_sso_session_config('test-session')
+        self.set_config_file_content(content=content)
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login --redirect-port 34535')
+        self.fetcher_mock.assert_called_once_with(redirect_port=34535)
+
+    def test_login_rejects_out_of_range_redirect_port(self):
+        content = self.get_sso_session_config('test-session')
+        self.set_config_file_content(content=content)
+        _, stderr, _ = self.run_cmd(
+            'sso login --redirect-port 65536', expected_rc=252
+        )
+        self.assertIn('must be between 1 and 65535', stderr)
+        self.fetcher_mock.assert_not_called()
+
     def test_login_device_no_extra_user_agent(self):
         self.add_oidc_device_responses(self.access_token)
         self.run_cmd('sso login --use-device-code')

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -41,6 +41,7 @@ from awscli.customizations.configure.sso_commands import (
     display_account,
     get_account_sorting_key,
 )
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.sso.utils import (
     PrintOnlyHandler,
     do_sso_login,
@@ -881,6 +882,7 @@ class TestConfigureSSOCommand:
         expected_scopes=None,
         expected_auth_handler_cls=None,
         expected_force_refresh=None,
+        expected_redirect_port=None,
     ):
         expected_kwargs = {
             "sso_region": expected_sso_region,
@@ -889,6 +891,7 @@ class TestConfigureSSOCommand:
             "on_pending_authorization": None,
             "token_cache": None,
             "use_device_code": expected_use_device_code,
+            "redirect_port": expected_redirect_port,
         }
         if expected_session_name is not None:
             expected_kwargs["session_name"] = expected_session_name
@@ -956,6 +959,44 @@ class TestConfigureSSOCommand:
             f"aws sts get-caller-identity --profile {inputs.profile_prompt.answer}"
             in stdout
         )
+
+    def test_configure_sso_passes_redirect_port(
+        self,
+        sso_cmd,
+        ptk_stubber,
+        aws_config,
+        stub_simple_single_item_sso_responses,
+        mock_do_sso_login,
+        botocore_session,
+        parsed_globals,
+        configure_sso_legacy_inputs,
+        account_id,
+        role_name,
+    ):
+        inputs = configure_sso_legacy_inputs
+        inputs.skip_account_and_role_selection()
+        ptk_stubber.user_inputs = inputs
+        stub_simple_single_item_sso_responses(account_id, role_name)
+
+        sso_cmd(["--redirect-port", "34535"], parsed_globals)
+        self.assert_do_sso_login_call(
+            mock_do_sso_login,
+            botocore_session,
+            expected_sso_region=inputs.sso_region_prompt.answer,
+            expected_start_url=inputs.start_url_prompt.answer,
+            expected_redirect_port=34535,
+        )
+
+    def test_configure_sso_rejects_out_of_range_redirect_port(
+        self,
+        sso_cmd,
+        parsed_globals,
+        mock_do_sso_login,
+    ):
+        with pytest.raises(ParamValidationError) as excinfo:
+            sso_cmd(["--redirect-port", "65536"], parsed_globals)
+        assert "must be between 1 and 65535" in str(excinfo.value)
+        mock_do_sso_login.assert_not_called()
 
     def test_single_account_single_role_flow_no_browser(
         self,

--- a/tests/unit/customizations/sso/test_utils.py
+++ b/tests/unit/customizations/sso/test_utils.py
@@ -11,15 +11,20 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
+import socket
 import threading
 import webbrowser
 
 import pytest
 import urllib3
-from botocore.exceptions import PendingAuthorizationExpiredError
+from botocore.exceptions import (
+    AuthCodeFetcherError,
+    PendingAuthorizationExpiredError,
+)
 from botocore.session import Session
 
 from awscli.compat import BytesIO, StringIO
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.sso.utils import (
     AuthCodeFetcher,
     OAuthCallbackHandler,
@@ -28,6 +33,7 @@ from awscli.customizations.sso.utils import (
     do_sso_login,
     open_browser_with_original_ld_path,
     parse_sso_registration_scopes,
+    validate_redirect_port,
 )
 from awscli.testutils import mock, unittest
 
@@ -330,3 +336,50 @@ def test_get_auth_code_and_state_timeout():
     """
     with pytest.raises(PendingAuthorizationExpiredError):
         AuthCodeFetcher().get_auth_code_and_state()
+
+
+def _get_available_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('', 0))
+        return sock.getsockname()[1]
+
+
+def test_auth_code_fetcher_binds_random_port_by_default():
+    fetcher = AuthCodeFetcher()
+    try:
+        assert fetcher.http_server.server_port != 0
+    finally:
+        fetcher.http_server.server_close()
+
+
+def test_auth_code_fetcher_binds_requested_redirect_port():
+    redirect_port = _get_available_port()
+    fetcher = AuthCodeFetcher(redirect_port=redirect_port)
+    try:
+        assert fetcher.http_server.server_port == redirect_port
+        assert fetcher.redirect_uri_with_port() == (
+            f'http://127.0.0.1:{redirect_port}/oauth/callback'
+        )
+    finally:
+        fetcher.http_server.server_close()
+
+
+@pytest.mark.parametrize('redirect_port', [None, 1, 8080, 65535])
+def test_validate_redirect_port_allows_valid_ports(redirect_port):
+    validate_redirect_port(redirect_port)
+
+
+@pytest.mark.parametrize('redirect_port', [-1, 0, 65536])
+def test_validate_redirect_port_rejects_out_of_range_ports(redirect_port):
+    with pytest.raises(ParamValidationError) as excinfo:
+        validate_redirect_port(redirect_port)
+    assert 'must be between 1 and 65535' in str(excinfo.value)
+
+
+def test_auth_code_fetcher_errors_when_redirect_port_in_use():
+    occupied = AuthCodeFetcher()
+    try:
+        with pytest.raises(AuthCodeFetcherError):
+            AuthCodeFetcher(redirect_port=occupied.http_server.server_port)
+    finally:
+        occupied.http_server.server_close()


### PR DESCRIPTION
*Issue #, if available:* Fixes #10433, relates to #9148

*Description of changes:*

The Authorization Code callback server binds to port 0, so the OS picks an arbitrary free port on each login and the port can't be known ahead of time. That breaks logging in from a remote host over SSH, where the callback port has to be forwarded before the flow starts — today the only workaround is falling back to the device code flow with `--use-device-code`.

This adds `--redirect-port` to set the port explicitly:

```
aws sso login --redirect-port 34535
```

Omitting it preserves the current random-port behavior.

**Scope**

The option is wired into all three commands that start a callback server, since they all share `AuthCodeFetcher`:

| Command | Before | After |
|---|---|---|
| `aws sso login` | random port | `--redirect-port` |
| `aws configure sso` | random port | `--redirect-port` |
| `aws login` | random port | `--redirect-port` |

`aws sso login` and `aws configure sso` pick it up from the shared `LOGIN_ARGS`; `aws login` has its own `ARG_TABLE`, so the arg is defined once as `REDIRECT_PORT_ARG` and referenced from both. Without that, adding the flag to `LOGIN_ARGS` alone would make `aws configure sso` accept an option it silently ignores, and would leave `aws login` — which builds its own `AuthCodeFetcher()` — on a random port.

Deliberately out of scope: no `sso_redirect_port` config setting and no `--redirect-host`. Both are easier to add later than to take back, and the host half would change the bind from loopback-ish to all interfaces, which deserves its own discussion (see the review on #10134).

**Validation**

Values outside 1-65535 are rejected before the flow starts, so a user doesn't answer all the `configure sso` prompts and then fail. A port that's already bound still surfaces the existing `AuthCodeFetcherError`, which already suggests the device code fallback.

**Relationship to existing PRs**

This overlaps #10462, #10456, and #10134, all of which cover only `aws sso login`. Happy to close this in favor of one of those if a maintainer would rather land the narrower change first — this one exists mainly to cover all three commands and to keep `aws configure sso` from accepting an inert flag.

**Testing**

Unit and functional coverage for: the default random port, binding the requested port, the resulting `redirect_uri`, plumbing through `do_sso_login`, port-already-in-use, out-of-range rejection for each of the three commands, and the port reaching `AuthCodeFetcher` from `aws login`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.