### PR TITLE
Emit warnings for unsupported TM config options

### DIFF
--- a/awscli/customizations/s3/factory.py
+++ b/awscli/customizations/s3/factory.py
@@ -97,7 +97,7 @@ class TransferManagerFactory:
         client_type = self._compute_transfer_client_type(
             params, runtime_config
         )
-        self._warn_unsupported_settings(client_type, runtime_config)
+        self.warn_unsupported_settings(client_type, runtime_config)
         if client_type == constants.CRT_TRANSFER_CLIENT:
             return self._create_crt_transfer_manager(params, runtime_config)
         else:
@@ -207,7 +207,7 @@ class TransferManagerFactory:
             sys.stderr,
         )
 
-    def _warn_unsupported_settings(self, client_type, runtime_config):
+    def warn_unsupported_settings(self, client_type, runtime_config):
         unsupported = self._get_unsupported_options(
             client_type, runtime_config
         )

--- a/awscli/customizations/s3/factory.py
+++ b/awscli/customizations/s3/factory.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import logging
 import os
+import sys
 
 import awscrt.s3
 from botocore.client import Config
@@ -31,10 +32,29 @@ from awscli.customizations.s3.transferconfig import (
     DEFAULTS,
     create_transfer_config_from_runtime_config,
 )
+from awscli.customizations.utils import uni_print
 
 LOGGER = logging.getLogger(__name__)
 
 ADAPTIVE_RETRY_MODE = 'adaptive'
+
+WARN_IGNORED = 'warn_ignored'
+
+EXCLUDE_FROM_AUTO = 'exclude_from_auto'
+
+UNSUPPORTED_OPTIONS = {
+    constants.CRT_TRANSFER_CLIENT: {
+        'max_bandwidth': EXCLUDE_FROM_AUTO,
+        'max_queue_size': WARN_IGNORED,
+        'io_chunksize': WARN_IGNORED,
+    },
+    constants.CLASSIC_TRANSFER_CLIENT: {
+        'target_bandwidth': WARN_IGNORED,
+        'should_stream': WARN_IGNORED,
+        'disk_throughput': WARN_IGNORED,
+        'direct_io': WARN_IGNORED,
+    },
+}
 
 CRT_CLIENT_KWARG_MAP = {
     'multipart_chunksize': 'part_size',
@@ -77,6 +97,7 @@ class TransferManagerFactory:
         client_type = self._compute_transfer_client_type(
             params, runtime_config
         )
+        self._warn_unsupported_settings(client_type, runtime_config)
         if client_type == constants.CRT_TRANSFER_CLIENT:
             return self._create_crt_transfer_manager(params, runtime_config)
         else:
@@ -126,6 +147,7 @@ class TransferManagerFactory:
                 f'Not auto resolving to the crt s3 transfer client because '
                 f'it does not support: {", ".join(unsupported)}'
             )
+            self._warn_classic_only_settings(runtime_config)
             return False
         return True
 
@@ -136,17 +158,72 @@ class TransferManagerFactory:
         )
 
     def _get_unsupported_settings(self, params, runtime_config):
-        unsupported = []
-        if runtime_config.is_explicitly_set('max_bandwidth'):
-            unsupported.append('max_bandwidth')
-        if (
-            self._session.get_config_variable('retry_mode')
-            == ADAPTIVE_RETRY_MODE
-        ):
+        unsupported = self._get_classic_only_settings(runtime_config)
+        if self._is_adaptive_retry_mode():
             unsupported.append(f'retry_mode = {ADAPTIVE_RETRY_MODE}')
         if self._is_non_seekable_stream_upload(params):
             unsupported.append('uploads from a non-seekable stream')
         return unsupported
+
+    def _get_classic_only_settings(self, runtime_config):
+        return self._get_unsupported_options(
+            constants.CRT_TRANSFER_CLIENT,
+            runtime_config,
+            action=EXCLUDE_FROM_AUTO,
+        )
+
+    def _get_unsupported_options(
+        self, client_type, runtime_config, action=None
+    ):
+        return [
+            name
+            for name, option_action in UNSUPPORTED_OPTIONS.get(
+                client_type, {}
+            ).items()
+            if (action is None or option_action == action)
+            and runtime_config.is_explicitly_set(name)
+        ]
+
+    def _is_adaptive_retry_mode(self):
+        return (
+            self._session.get_config_variable('retry_mode')
+            == ADAPTIVE_RETRY_MODE
+        )
+
+    def _warn_classic_only_settings(self, runtime_config):
+        classic_only = self._get_classic_only_settings(runtime_config)
+        if not classic_only:
+            return
+        uni_print(
+            f"warning: Using the '{constants.CLASSIC_TRANSFER_CLIENT}' s3 "
+            f"transfer client because the "
+            f"'{constants.CRT_TRANSFER_CLIENT}' s3 transfer client does not "
+            f"support: {', '.join(classic_only)}. A future version of the AWS "
+            f"CLI will use the '{constants.CRT_TRANSFER_CLIENT}' s3 transfer "
+            f"client by default, at which point these values will be "
+            f"ignored. Set the preferred_transfer_client configuration value "
+            f"to '{constants.CLASSIC_TRANSFER_CLIENT}' to continue using the "
+            f"'{constants.CLASSIC_TRANSFER_CLIENT}' s3 transfer client.\n",
+            sys.stderr,
+        )
+
+    def _warn_unsupported_settings(self, client_type, runtime_config):
+        unsupported = self._get_unsupported_options(
+            client_type, runtime_config
+        )
+        if (
+            client_type == constants.CRT_TRANSFER_CLIENT
+            and self._is_adaptive_retry_mode()
+        ):
+            unsupported.append(f'retry_mode = {ADAPTIVE_RETRY_MODE}')
+        if not unsupported:
+            return
+        uni_print(
+            f"warning: The following configuration values are not supported "
+            f"by the '{client_type}' s3 transfer client and will be ignored: "
+            f"{', '.join(unsupported)}.\n",
+            sys.stderr,
+        )
 
     def _is_non_seekable_stream_upload(self, params):
         return bool(

--- a/tests/unit/customizations/s3/test_factory.py
+++ b/tests/unit/customizations/s3/test_factory.py
@@ -901,7 +901,7 @@ class TestClassicOnlySettingsWarning:
 def warn_unsupported_settings(auto_resolve_factory, capsys):
     def _warn(client_type, **kwargs):
         runtime_config = RuntimeConfig().build_config(**kwargs)
-        auto_resolve_factory._warn_unsupported_settings(
+        auto_resolve_factory.warn_unsupported_settings(
             client_type, runtime_config
         )
         return capsys.readouterr().err

--- a/tests/unit/customizations/s3/test_factory.py
+++ b/tests/unit/customizations/s3/test_factory.py
@@ -23,6 +23,7 @@ from s3transfer.manager import TransferManager
 
 from awscli.customizations.s3 import constants
 from awscli.customizations.s3.factory import (
+    ADAPTIVE_RETRY_MODE,
     ClientFactory,
     TransferManagerFactory,
 )
@@ -835,6 +836,167 @@ class TestAutoResolveCrtClient:
     ):
         s3_params['paths_type'] = 's3s3'
         assert resolve_client_type() == constants.CLASSIC_TRANSFER_CLIENT
+
+
+class TestClassicOnlySettingsWarning:
+    def test_warns_when_routed_away_for_max_bandwidth(
+        self, resolve_client_type, capsys
+    ):
+        resolve_client_type(max_bandwidth=1024)
+        warning = capsys.readouterr().err
+        assert 'max_bandwidth' in warning
+        assert 'A future version of the AWS CLI' in warning
+        assert 'preferred_transfer_client' in warning
+
+    def test_does_not_warn_for_adaptive_retry_mode(
+        self, resolve_client_type, auto_resolve_session, capsys
+    ):
+        # The crt transfer client will eventually support adaptive retries, so
+        # there is nothing for the user to act on.
+        auto_resolve_session.get_config_variable.return_value = 'adaptive'
+        resolve_client_type()
+        assert capsys.readouterr().err == ''
+
+    def test_does_not_warn_for_stream_upload_fallback(
+        self, resolve_client_type, s3_params, capsys
+    ):
+        s3_params['is_stream'] = True
+        s3_params['paths_type'] = 'locals3'
+        resolve_client_type()
+        assert capsys.readouterr().err == ''
+
+    def test_does_not_warn_when_crt_is_resolved(
+        self, resolve_client_type, capsys
+    ):
+        resolve_client_type()
+        assert capsys.readouterr().err == ''
+
+    def test_does_not_warn_when_auto_resolve_disabled(
+        self, resolve_client_type, monkeypatch, capsys
+    ):
+        monkeypatch.delenv('AWS_CLI_AUTO_RESOLVE_CLIENT')
+        resolve_client_type(max_bandwidth=1024)
+        assert capsys.readouterr().err == ''
+
+    def test_does_not_warn_on_optimized_system(
+        self,
+        resolve_client_type,
+        mock_crt_is_optimized_for_system,
+        capsys,
+    ):
+        mock_crt_is_optimized_for_system.return_value = True
+        resolve_client_type(max_bandwidth=1024)
+        assert capsys.readouterr().err == ''
+
+    def test_does_not_warn_when_classic_explicitly_preferred(
+        self, resolve_client_type, capsys
+    ):
+        resolve_client_type(
+            preferred_transfer_client='classic', max_bandwidth=1024
+        )
+        assert capsys.readouterr().err == ''
+
+
+@pytest.fixture
+def warn_unsupported_settings(auto_resolve_factory, capsys):
+    def _warn(client_type, **kwargs):
+        runtime_config = RuntimeConfig().build_config(**kwargs)
+        auto_resolve_factory._warn_unsupported_settings(
+            client_type, runtime_config
+        )
+        return capsys.readouterr().err
+
+    return _warn
+
+
+class TestWarnUnsupportedSettings:
+    def test_warns_for_options_crt_ignores(self, warn_unsupported_settings):
+        warning = warn_unsupported_settings(
+            constants.CRT_TRANSFER_CLIENT,
+            max_queue_size=500,
+            io_chunksize=1024,
+        )
+        assert 'max_queue_size' in warning
+        assert 'io_chunksize' in warning
+        assert constants.CRT_TRANSFER_CLIENT in warning
+
+    def test_warns_for_options_classic_ignores(
+        self, warn_unsupported_settings
+    ):
+        warning = warn_unsupported_settings(
+            constants.CLASSIC_TRANSFER_CLIENT,
+            target_bandwidth=1024,
+            direct_io=True,
+        )
+        assert 'target_bandwidth' in warning
+        assert 'direct_io' in warning
+        assert constants.CLASSIC_TRANSFER_CLIENT in warning
+
+    def test_warns_for_max_bandwidth_when_crt_resolved(
+        self, warn_unsupported_settings
+    ):
+        warning = warn_unsupported_settings(
+            constants.CRT_TRANSFER_CLIENT, max_bandwidth=1024
+        )
+        assert 'max_bandwidth' in warning
+
+    def test_does_not_warn_for_max_bandwidth_when_classic_resolved(
+        self, warn_unsupported_settings
+    ):
+        assert (
+            warn_unsupported_settings(
+                constants.CLASSIC_TRANSFER_CLIENT, max_bandwidth=1024
+            )
+            == ''
+        )
+
+    def test_warns_for_adaptive_retry_mode_under_crt(
+        self, warn_unsupported_settings, auto_resolve_session
+    ):
+        auto_resolve_session.get_config_variable.return_value = 'adaptive'
+        warning = warn_unsupported_settings(constants.CRT_TRANSFER_CLIENT)
+        assert f'retry_mode = {ADAPTIVE_RETRY_MODE}' in warning
+
+    def test_does_not_warn_for_supported_retry_mode(
+        self, warn_unsupported_settings, auto_resolve_session
+    ):
+        auto_resolve_session.get_config_variable.return_value = 'standard'
+        assert warn_unsupported_settings(constants.CRT_TRANSFER_CLIENT) == ''
+
+    def test_does_not_warn_for_adaptive_retry_mode_under_classic(
+        self, warn_unsupported_settings, auto_resolve_session
+    ):
+        auto_resolve_session.get_config_variable.return_value = 'adaptive'
+        assert (
+            warn_unsupported_settings(constants.CLASSIC_TRANSFER_CLIENT) == ''
+        )
+
+    def test_does_not_warn_when_nothing_configured(
+        self, warn_unsupported_settings
+    ):
+        assert warn_unsupported_settings(constants.CRT_TRANSFER_CLIENT) == ''
+
+    def test_does_not_warn_for_supported_options(
+        self, warn_unsupported_settings
+    ):
+        assert (
+            warn_unsupported_settings(
+                constants.CRT_TRANSFER_CLIENT,
+                multipart_chunksize=8 * (1024**2),
+                max_concurrent_requests=5,
+            )
+            == ''
+        )
+
+    def test_does_not_warn_across_clients(self, warn_unsupported_settings):
+        assert (
+            warn_unsupported_settings(
+                constants.CLASSIC_TRANSFER_CLIENT,
+                max_queue_size=500,
+                io_chunksize=1024,
+            )
+            == ''
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There are 2 types of warnings we want to emit:
1. Cases where the resolved transfer client type doesn't support a configured option and ignores it.
2. Cases where CRT doesn't support a configured option and falls back to the classic TM. These are for options that CRT will never support, but we want to avoid changing the default TM client to minimize disruptions. Instead, we'll begin emitting warnings before completely switching to CRT by default and ignoring the configured option (same as 1).