### PR TITLE
Add sso_use_device_code sso-session config setting

### DIFF
--- a/.changes/next-release/feature-sso-3180.json
+++ b/.changes/next-release/feature-sso-3180.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``sso``",
+  "description": "Add the ``sso_use_device_code`` setting for ``sso-session`` sections so ``aws sso login`` and ``aws configure sso`` use the Device Code flow without passing ``--use-device-code``. Fixes `#9098 <https://github.com/aws/aws-cli/issues/9098>`__"
+}

--- a/awscli/customizations/configure/sso_commands.py
+++ b/awscli/customizations/configure/sso_commands.py
@@ -325,12 +325,16 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
         sso_registration_args = self._prompt_for_sso_registration_args(
             verify=verify,
         )
+        use_device_code = (
+            sso_registration_args.pop('use_device_code', False)
+            or parsed_args.use_device_code
+        )
         sso_token = self._sso_login(
             self._session,
             parsed_globals=parsed_globals,
             token_cache=self._sso_token_cache,
             on_pending_authorization=on_pending_authorization,
-            use_device_code=parsed_args.use_device_code,
+            use_device_code=use_device_code,
             **sso_registration_args,
         )
 
@@ -393,6 +397,7 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
             'start_url': sso_config['sso_start_url'],
             'sso_region': sso_config['sso_region'],
             'registration_scopes': sso_config.get('registration_scopes'),
+            'use_device_code': sso_config.get('use_device_code', False),
         }
 
     def _prompt_for_registration_args_for_new_sso_session(

--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -70,6 +70,9 @@ class LoginCommand(BaseSSOCommand):
         on_pending_authorization = None
         if parsed_args.no_browser:
             on_pending_authorization = PrintOnlyHandler()
+        use_device_code = parsed_args.use_device_code or sso_config.get(
+            'use_device_code', False
+        )
         do_sso_login(
             session=self._session,
             parsed_globals=parsed_globals,
@@ -80,7 +83,7 @@ class LoginCommand(BaseSSOCommand):
             force_refresh=True,
             session_name=sso_config.get('session_name'),
             registration_scopes=sso_config.get('registration_scopes'),
-            use_device_code=parsed_args.use_device_code,
+            use_device_code=use_device_code,
         )
 
         # Only rewrite sso_region after successful login.

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -29,6 +29,7 @@ from botocore.exceptions import (
 from botocore.utils import (
     SSOTokenFetcher,
     SSOTokenFetcherAuth,
+    ensure_boolean,
     original_ld_library_path,
 )
 
@@ -57,8 +58,11 @@ LOGIN_ARGS = [
         'action': 'store_true',
         'default': False,
         'help_text': (
-            'Uses the Device Code authorization grant and login flow '
-            'instead of the Authorization Code flow.'
+            'Uses the Device Code authorization grant and login flow instead '
+            'of the Authorization Code flow. To use the Device Code flow for '
+            'every login, this can be set in the AWS CLI config file for the '
+            'profile\'s sso-session using the ``aws configure set '
+            'sso_use_device_code true --sso-session <name>`` command.'
         ),
     },
 ]
@@ -351,6 +355,12 @@ class BaseSSOCommand(BasicCommand):
             raw_scopes = session_config[scopes_var]
             parsed_scopes = parse_sso_registration_scopes(raw_scopes)
             sso_config['registration_scopes'] = parsed_scopes
+
+        device_code_var = 'sso_use_device_code'
+        if device_code_var in session_config:
+            sso_config['use_device_code'] = ensure_boolean(
+                session_config[device_code_var]
+            )
 
         if missing:
             error_msg = f'Missing the following required SSO configuration values: {", ".join(missing)}. '

--- a/tests/functional/sso/__init__.py
+++ b/tests/functional/sso/__init__.py
@@ -197,7 +197,9 @@ class BaseSSOTest(BaseAWSCommandParamsTest):
         )
         return content
 
-    def get_sso_session_config(self, session_name, include_profile=True):
+    def get_sso_session_config(
+        self, session_name, include_profile=True, use_device_code=None
+    ):
         content = ''
         if include_profile:
             content += (
@@ -213,7 +215,9 @@ class BaseSSOTest(BaseAWSCommandParamsTest):
         )
         if self.registration_scopes:
             scopes = ', '.join(self.registration_scopes)
-            content += f'sso_registration_scopes={scopes}'
+            content += f'sso_registration_scopes={scopes}\n'
+        if use_device_code is not None:
+            content += f'sso_use_device_code={use_device_code}\n'
         return content
 
     def set_config_file_content(self, content=None):

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -355,6 +355,149 @@ class TestLoginCommand(BaseSSOTest):
             expected_token=self.access_token,
         )
 
+    def test_login_device_sso_session_from_config(self):
+        content = self.get_sso_session_config(
+            'test-session', use_device_code='true'
+        )
+        self.set_config_file_content(content=content)
+        self.add_oidc_device_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.assert_used_expected_sso_region(expected_region=self.sso_region)
+        self.assert_device_browser_handler_called_with(
+            'foo',
+            'https://sso.fake/device',
+            'https://sso.verify',
+        )
+        self.assert_cache_contains_registration(
+            start_url=self.start_url,
+            session_name='test-session',
+            scopes=self.registration_scopes,
+            expected_client_id='device-client-id',
+        )
+        self.assert_cache_contains_token(
+            start_url=self.start_url,
+            session_name='test-session',
+            expected_token=self.access_token,
+        )
+
+    def test_login_device_no_browser_from_config(self):
+        content = self.get_sso_session_config(
+            'test-session', use_device_code='true'
+        )
+        self.set_config_file_content(content=content)
+        self.add_oidc_device_responses(self.access_token)
+        stdout, _, _ = self.run_cmd('sso login --no-browser')
+        self.assertIn('Browser will not be automatically opened.', stdout)
+        self.open_browser_mock.assert_not_called()
+        self.assert_used_expected_sso_region(expected_region=self.sso_region)
+        self.assert_cache_contains_token(
+            start_url=self.start_url,
+            session_name='test-session',
+            expected_token=self.access_token,
+        )
+
+    def test_login_auth_sso_session_config_setting_false(self):
+        content = self.get_sso_session_config(
+            'test-session', use_device_code='false'
+        )
+        self.set_config_file_content(content=content)
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.assert_auth_browser_handler_called_with('sso%3Aaccount%3Aaccess')
+        self.assert_cache_contains_registration(
+            start_url=self.start_url,
+            session_name='test-session',
+            scopes=self.registration_scopes,
+            expected_client_id='auth-client-id',
+        )
+
+    def test_login_auth_sso_session_config_setting_invalid(self):
+        content = self.get_sso_session_config(
+            'test-session', use_device_code='maybe'
+        )
+        self.set_config_file_content(content=content)
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.assert_auth_browser_handler_called_with('sso%3Aaccount%3Aaccess')
+        self.assert_cache_contains_registration(
+            start_url=self.start_url,
+            session_name='test-session',
+            scopes=self.registration_scopes,
+            expected_client_id='auth-client-id',
+        )
+
+    def test_login_auth_sso_session_config_setting_in_profile_ignored(self):
+        content = (
+            f'[default]\n'
+            f'sso_session=test-session\n'
+            f'sso_use_device_code=true\n'
+            f'[sso-session test-session]\n'
+            f'sso_start_url={self.start_url}\n'
+            f'sso_region={self.sso_region}\n'
+        )
+        self.set_config_file_content(content=content)
+        self.add_oidc_auth_code_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.assert_auth_browser_handler_called_with('sso%3Aaccount%3Aaccess')
+        self.assert_cache_contains_registration(
+            start_url=self.start_url,
+            session_name='test-session',
+            scopes=self.registration_scopes,
+            expected_client_id='auth-client-id',
+        )
+
+    def test_login_device_sso_session_config_setting_from_session(self):
+        content = (
+            f'[default]\n'
+            f'sso_session=test-session\n'
+            f'sso_use_device_code=false\n'
+            f'[sso-session test-session]\n'
+            f'sso_start_url={self.start_url}\n'
+            f'sso_region={self.sso_region}\n'
+            f'sso_use_device_code=true\n'
+        )
+        self.set_config_file_content(content=content)
+        self.add_oidc_device_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.assert_device_browser_handler_called_with(
+            'foo',
+            'https://sso.fake/device',
+            'https://sso.verify',
+        )
+        self.assert_cache_contains_registration(
+            start_url=self.start_url,
+            session_name='test-session',
+            scopes=self.registration_scopes,
+            expected_client_id='device-client-id',
+        )
+
+    def test_login_device_sso_with_explicit_sso_session_arg_from_config(self):
+        content = self.get_sso_session_config(
+            'default-session', use_device_code='false'
+        )
+        content += self.get_sso_session_config(
+            'named-session', include_profile=False, use_device_code='true'
+        )
+        self.set_config_file_content(content=content)
+        self.add_oidc_device_responses(self.access_token)
+        self.run_cmd('sso login --sso-session named-session')
+        self.assert_device_browser_handler_called_with(
+            'foo',
+            'https://sso.fake/device',
+            'https://sso.verify',
+        )
+        self.assert_cache_contains_registration(
+            start_url=self.start_url,
+            session_name='named-session',
+            scopes=self.registration_scopes,
+            expected_client_id='device-client-id',
+        )
+        self.assert_cache_contains_token(
+            start_url=self.start_url,
+            session_name='named-session',
+            expected_token=self.access_token,
+        )
+
     def test_login_device_sso_session_with_scopes(self):
         self.registration_scopes = ['sso:foo', 'sso:bar']
         content = self.get_sso_session_config('test-session')

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -1349,6 +1349,121 @@ class TestConfigureSSOCommand:
             ],
         )
 
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [],
+            ["--use-device-code"],
+        ],
+    )
+    def test_configure_sso_with_existing_sso_session_use_device_code(
+        self,
+        sso_cmd_factory,
+        ptk_stubber,
+        aws_config,
+        sso_stubber_factory,
+        stub_simple_single_item_sso_responses,
+        mock_do_sso_login,
+        args,
+        parsed_globals,
+        configure_sso_using_existing_session_inputs,
+        aws_config_lines_for_existing_sso_session,
+        account_id,
+        role_name,
+        existing_start_url,
+        existing_sso_region,
+        existing_scopes,
+    ):
+        existing_lines = aws_config_lines_for_existing_sso_session + [
+            "sso_use_device_code = true"
+        ]
+        write_aws_config(aws_config, lines=existing_lines)
+        session = StubbedSession()
+
+        inputs = configure_sso_using_existing_session_inputs
+        inputs.skip_account_and_role_selection()
+        ptk_stubber.user_inputs = inputs
+
+        sso_stubber = sso_stubber_factory(session)
+        stub_simple_single_item_sso_responses(
+            account_id, role_name, sso_stubber
+        )
+        sso_cmd = sso_cmd_factory(session=session)
+        sso_cmd(args, parsed_globals)
+
+        self.assert_do_sso_login_call(
+            mock_do_sso_login,
+            session,
+            expected_session_name=inputs.session_prompt.answer,
+            expected_sso_region=existing_sso_region,
+            expected_start_url=existing_start_url,
+            expected_scopes=parse_sso_registration_scopes(existing_scopes),
+            expected_use_device_code=True,
+        )
+        assert_aws_config(
+            aws_config,
+            expected_lines=existing_lines
+            + [
+                f"[profile {inputs.profile_prompt.answer}]",
+                f"sso_session = {inputs.session_prompt.answer}",
+                f"sso_account_id = {account_id}",
+                f"sso_role_name = {role_name}",
+                f"region = {inputs.region_prompt.answer}",
+                f"output = {inputs.output_prompt.answer}",
+            ],
+        )
+
+    def test_configure_sso_with_new_sso_session_use_device_code_flag(
+        self,
+        sso_cmd,
+        ptk_stubber,
+        aws_config,
+        stub_sso_list_roles,
+        stub_sso_list_accounts,
+        mock_do_sso_login,
+        botocore_session,
+        parsed_globals,
+        configure_sso_using_new_session_inputs,
+    ):
+        inputs = configure_sso_using_new_session_inputs
+        selected_account_id = inputs.account_id_select.answer["accountId"]
+        ptk_stubber.user_inputs = inputs
+
+        stub_sso_list_accounts(inputs.account_id_select.expected_choices)
+        stub_sso_list_roles(
+            inputs.role_name_select.expected_choices,
+            expected_account_id=selected_account_id,
+        )
+
+        sso_cmd(["--use-device-code"], parsed_globals)
+        self.assert_do_sso_login_call(
+            mock_do_sso_login,
+            botocore_session,
+            expected_session_name=inputs.session_prompt.answer,
+            expected_sso_region=inputs.sso_region_prompt.answer,
+            expected_start_url=inputs.start_url_prompt.answer,
+            expected_scopes=parse_sso_registration_scopes(
+                inputs.scopes_prompt.answer
+            ),
+            expected_force_refresh=True,
+            expected_use_device_code=True,
+        )
+        assert_aws_config(
+            aws_config,
+            expected_lines=[
+                f"[profile {inputs.profile_prompt.answer}]",
+                f"sso_session = {inputs.session_prompt.answer}",
+                f"sso_account_id = {selected_account_id}",
+                f"sso_role_name = {inputs.role_name_select.answer}",
+                f"region = {inputs.region_prompt.answer}",
+                f"output = {inputs.output_prompt.answer}",
+                f"[sso-session {inputs.session_prompt.answer}]",
+                f"sso_start_url = {inputs.start_url_prompt.answer}",
+                f"sso_region = {inputs.sso_region_prompt.answer}",
+                f"sso_registration_scopes = {inputs.scopes_prompt.answer}",
+            ],
+        )
+
     def test_configure_sso_reusing_existing_configuration(
         self,
         sso_cmd_factory,

--- a/tests/unit/customizations/sso/test_utils.py
+++ b/tests/unit/customizations/sso/test_utils.py
@@ -21,6 +21,7 @@ from botocore.session import Session
 
 from awscli.compat import BytesIO, StringIO
 from awscli.customizations.sso.utils import (
+    LOGIN_ARGS,
     AuthCodeFetcher,
     OAuthCallbackHandler,
     OpenBrowserHandler,
@@ -47,6 +48,14 @@ from awscli.testutils import mock, unittest
 )
 def test_parse_registration_scopes(raw_scopes, parsed_scopes):
     assert parse_sso_registration_scopes(raw_scopes) == parsed_scopes
+
+
+def test_use_device_code_help_text_names_config_setting():
+    use_device_code_arg = next(
+        arg for arg in LOGIN_ARGS if arg['name'] == 'use-device-code'
+    )
+    assert 'sso_use_device_code' in use_device_code_arg['help_text']
+    assert 'aws configure set' in use_device_code_arg['help_text']
 
 
 class TestDoSSOLogin(unittest.TestCase):


### PR DESCRIPTION
Fixes #9098.

Users on remote hosts, in containers, and under WSL cannot complete the Authorization Code flow and have to pass
`--use-device-code` on every `aws sso login`. This adds an `sso_use_device_code` setting to the `sso-session` section
of the config file so the Device Code flow can be chosen once per session instead of once per invocation:

```ini
[sso-session my-sso]
sso_start_url = https://my-sso-portal.awsapps.com/start
sso_region = us-east-1
sso_registration_scopes = sso:account:access
sso_use_device_code = true
```

or, without opening an editor:

```
aws configure set sso_use_device_code true --sso-session my-sso
```

**Behavior**

- `aws sso login` (and `aws configure sso` when it is pointed at an existing session) runs the Device Code flow when
  the setting is `true` in the profile's `sso-session` section, exactly as if `--use-device-code` had been passed.
  Passing the flag still works and still wins.
- The Authorization Code flow stays the default. The setting is read only from the `sso-session` section; a key of
  the same name in a profile section has no effect on the login commands. Values other than `true` (case-insensitive)
  leave the default in place, matching how the CLI reads its other boolean config values.
- Nothing in the CLI writes the setting on the user's behalf: `aws configure sso` reads it for an existing session
  but does not prompt for it or write it for a new one. The on-screen messages are unchanged; the `--use-device-code`
  help text now names the setting and the `aws configure set` command that writes it.
- Legacy profiles (no `sso-session` section) already use the Device Code flow and are unaffected.

I know the flag was made explicit-only on purpose (the comment on #9098). This is intended to honour that position
while answering the request there: the default is untouched, the opt-in is scoped to one session rather than the
machine, it has to be written deliberately, and the browser-flow hint keeps teaching the per-run flag. The device
grant is the weaker one, so the per-run override and any on-screen notice are deliberately left out of this change
and easy to add if you want them.

**Tests**

- `tests/functional/sso/test_login.py`: setting on with no flag (device flow, registration and token cached);
  setting on with `--no-browser`; `false` and an invalid value fall back to the Authorization Code flow; the key in a
  profile section is ignored; the session's value wins over a profile's; `--sso-session <name>` reads the named
  session's value.
- `tests/unit/customizations/configure/test_sso.py`: existing session with the setting, with and without the flag
  (the latter guards the kwargs merge); new session with the flag writes no `sso_use_device_code` line.
- `tests/unit/customizations/sso/test_utils.py`: the help text names the setting and `aws configure set`.

**Docs**

The AWS CLI User Guide's IAM Identity Center configuration page (`cli-configure-sso.html`, the `sso-session`
settings list) and the SDKs and Tools Reference Guide's IAM Identity Center credential provider page list the
`sso-session` keys; both need an `sso_use_device_code` entry with the literal value `true`. Happy to open that
change if you point me at the right repository.

Generated by AI tools, and reviewed by Nathan Feger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYUB1iy6AeXeeW8ZMorP1p
